### PR TITLE
Validate JWT token

### DIFF
--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -1,12 +1,61 @@
-import React from 'react';
-import { Header, Segment } from 'semantic-ui-react';
+import React, { Component, Fragment } from 'react';
+import { Header, Loader } from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+import { withCookies, Cookies } from 'react-cookie';
 
-const App = () => (
-  <Segment>
-    <Header>
-      Welcome to rovercode!
-    </Header>
-  </Segment>
-);
+import axios from 'axios';
 
-export default App;
+
+class App extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      rovers: null,
+    };
+  }
+
+  componentDidMount() {
+    const { cookies } = this.props;
+
+    return axios.get('/api/v1/rovers/', {
+      headers: {
+        Authorization: `JWT ${cookies.get('auth_jwt')}`,
+      },
+    })
+      .then((response) => {
+        this.setState({
+          rovers: response.data,
+        });
+      })
+      .catch(() => {
+        this.setState({
+          rovers: [],
+        });
+      });
+  }
+
+  render() {
+    const { rovers } = this.state;
+
+    return (
+      <Fragment>
+        {
+           rovers !== null ? (
+             <Header>
+               {`Welcome to rovercode, you have ${rovers.length} rover(s)!`}
+             </Header>
+           ) : (
+             <Loader active />
+           )
+        }
+      </Fragment>
+    );
+  }
+}
+
+App.propTypes = {
+  cookies: PropTypes.instanceOf(Cookies).isRequired,
+};
+
+export default withCookies(App);

--- a/src/containers/__tests__/App.test.js
+++ b/src/containers/__tests__/App.test.js
@@ -1,10 +1,65 @@
 import React from 'react';
+import { Header, Loader } from 'semantic-ui-react';
 import { shallow } from 'enzyme';
+import { Cookies } from 'react-cookie';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
 
 import App from '../App';
 
+const mock = new MockAdapter(axios);
+const cookiesValues = { auth_jwt: '1234' };
+const cookies = new Cookies(cookiesValues);
+
 test('App renders on the page with no errors', () => {
-  const wrapper = shallow(<App />);
+  const wrapper = shallow(<App />, {
+    context: { cookies },
+  });
 
   expect(wrapper).toMatchSnapshot();
+});
+
+test('App shows the correct number of rovers for the user', async () => {
+  mock.reset();
+  mock.onGet('/api/v1/rovers/').reply(200, [
+    {
+      id: 1,
+      name: 'Sparky',
+      owner: 1,
+    },
+    {
+      id: 2,
+      name: 'Marvin',
+      owner: 1,
+    },
+  ]);
+
+  const cookieWrapper = shallow(<App />, {
+    context: { cookies },
+  });
+
+  const wrapper = cookieWrapper.dive();
+
+  await wrapper.instance().componentDidMount();
+  wrapper.update();
+
+  expect(wrapper.find(Header).exists()).toBe(true);
+  expect(wrapper.find(Loader).exists()).toBe(false);
+});
+
+test('App shows no rovers on error', async () => {
+  mock.reset();
+  mock.onGet('/api/v1/rovers/').timeout();
+
+  const cookieWrapper = shallow(<App />, {
+    context: { cookies },
+  });
+
+  const wrapper = cookieWrapper.dive();
+
+  await wrapper.instance().componentDidMount();
+  wrapper.update();
+
+  expect(wrapper.find(Header).exists()).toBe(true);
+  expect(wrapper.find(Loader).exists()).toBe(false);
 });

--- a/src/containers/__tests__/__snapshots__/App.test.js.snap
+++ b/src/containers/__tests__/__snapshots__/App.test.js.snap
@@ -4,7 +4,7 @@ exports[`App renders on the page with no errors 1`] = `
 ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <App />,
+  Symbol(enzyme.__unrendered__): <withCookies(Component) />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
     "getNode": [Function],
@@ -15,48 +15,40 @@ ShallowWrapper {
   Symbol(enzyme.__node__): Object {
     "instance": null,
     "key": undefined,
-    "nodeType": "function",
+    "nodeType": "class",
     "props": Object {
-      "children": <Header>
-        Welcome to rovercode!
-      </Header>,
+      "allCookies": Object {},
+      "cookies": Cookies {
+        "HAS_DOCUMENT_COOKIE": true,
+        "changeListeners": Array [
+          [Function],
+        ],
+        "cookies": Object {},
+        "hooks": undefined,
+      },
     },
     "ref": null,
-    "rendered": Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "function",
-      "props": Object {
-        "children": "Welcome to rovercode!",
-      },
-      "ref": null,
-      "rendered": "Welcome to rovercode!",
-      "type": [Function],
-    },
+    "rendered": null,
     "type": [Function],
   },
   Symbol(enzyme.__nodes__): Array [
     Object {
       "instance": null,
       "key": undefined,
-      "nodeType": "function",
+      "nodeType": "class",
       "props": Object {
-        "children": <Header>
-          Welcome to rovercode!
-        </Header>,
+        "allCookies": Object {},
+        "cookies": Cookies {
+          "HAS_DOCUMENT_COOKIE": true,
+          "changeListeners": Array [
+            [Function],
+          ],
+          "cookies": Object {},
+          "hooks": undefined,
+        },
       },
       "ref": null,
-      "rendered": Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "children": "Welcome to rovercode!",
-        },
-        "ref": null,
-        "rendered": "Welcome to rovercode!",
-        "type": [Function],
-      },
+      "rendered": null,
       "type": [Function],
     },
   ],
@@ -64,6 +56,16 @@ ShallowWrapper {
     "adapter": ReactSixteenAdapter {
       "options": Object {
         "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+    "context": Object {
+      "cookies": Cookies {
+        "HAS_DOCUMENT_COOKIE": true,
+        "changeListeners": Array [
+          [Function],
+        ],
+        "cookies": Object {},
+        "hooks": undefined,
       },
     },
   },


### PR DESCRIPTION
Call API on main page to validate JWT token from login and have an example for how to make an API call. This will be removed once there are actual API calls happening in the application, but this proves that the token works properly.

![image](https://user-images.githubusercontent.com/1184314/42296149-331d2a06-7fc0-11e8-9e74-2bf97d99246e.png)

**NOTE**: The backend is setting the session cookies which causes this to work even without a JWT token. To test this properly, remove `csrftoken`, `messages`, and `sessionid` after login and refresh the page:
![image](https://user-images.githubusercontent.com/1184314/42296156-45063852-7fc0-11e8-879e-6323af692527.png)
