### PR TITLE
Indicator component

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     },
     "moduleNameMapper": {
       ".+\\.(png|jpg)$": "<rootDir>/src/assets/images/__mocks__/imageMock.js",
+      ".+\\.(css|less)$": "<rootDir>/src/css/__mocks__/styleMock.js",
       "@/(.*)$": "<rootDir>/src/$1"
     }
   },

--- a/src/actions/__test__/sensor.test.js
+++ b/src/actions/__test__/sensor.test.js
@@ -1,0 +1,25 @@
+import {
+  changeLeftSensorState,
+  changeRightSensorState,
+  COVERED,
+  NOT_COVERED,
+} from '../sensor';
+
+
+describe('Sensor actions', () => {
+  test('changeLeftSensor', () => {
+    const action = changeLeftSensorState(COVERED);
+    const { type, payload } = action;
+
+    expect(type).toEqual('CHANGE_LEFT_SENSOR_STATE');
+    expect(payload).toEqual(COVERED);
+  });
+
+  test('changeRightSensor', () => {
+    const action = changeRightSensorState(NOT_COVERED);
+    const { type, payload } = action;
+
+    expect(type).toEqual('CHANGE_RIGHT_SENSOR_STATE');
+    expect(payload).toEqual(NOT_COVERED);
+  });
+});

--- a/src/actions/sensor.js
+++ b/src/actions/sensor.js
@@ -1,0 +1,20 @@
+// actions https://redux.js.org/basics/actions
+// async actions https://redux.js.org/advanced/asyncactions
+
+export const CHANGE_LEFT_SENSOR_STATE = 'CHANGE_LEFT_SENSOR_STATE';
+export const CHANGE_RIGHT_SENSOR_STATE = 'CHANGE_RIGHT_SENSOR_STATE';
+
+// Sensor States
+export const COVERED = 1;
+export const NOT_COVERED = 2;
+
+// action creators
+export const changeLeftSensorState = state => ({
+  type: CHANGE_LEFT_SENSOR_STATE,
+  payload: state,
+});
+
+export const changeRightSensorState = state => ({
+  type: CHANGE_RIGHT_SENSOR_STATE,
+  payload: state,
+});

--- a/src/components/Indicator.js
+++ b/src/components/Indicator.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Grid } from 'semantic-ui-react';
+import { connect } from 'react-redux';
+import { hot } from 'react-hot-loader';
+import PropTypes from 'prop-types';
+
+import { COVERED } from '@/actions/sensor';
+import '@/css/indicator.css';
+
+const mapStateToProps = ({ sensor }) => ({ sensor });
+
+const Indicator = ({ sensor }) => (
+  <Grid columns={12} centered>
+    <Grid.Row>
+      <Grid.Column width={6}>
+        {
+          sensor.left === COVERED ? (
+            <div id="leftIndicator" className="indicator covered" />
+          ) : (
+            <div id="leftIndicator" className="indicator not-covered" />
+          )
+        }
+      </Grid.Column>
+      <Grid.Column width={6}>
+        {
+          sensor.right === COVERED ? (
+            <div id="rightIndicator" className="indicator covered" />
+          ) : (
+            <div id="rightIndicator" className="indicator not-covered" />
+          )
+        }
+      </Grid.Column>
+    </Grid.Row>
+  </Grid>
+);
+
+Indicator.propTypes = {
+  sensor: PropTypes.shape({
+    left: PropTypes.number.isRequired,
+    right: PropTypes.number.isRequired,
+  }).isRequired,
+};
+
+export default hot(module)(connect(mapStateToProps)(Indicator));

--- a/src/components/__tests__/Indicator.test.js
+++ b/src/components/__tests__/Indicator.test.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import configureStore from 'redux-mock-store';
+
+import { COVERED, NOT_COVERED } from '@/actions/sensor';
+import Indicator from '../Indicator';
+
+describe('The Indicator component', () => {
+  const mockStore = configureStore();
+  let store;
+
+  beforeEach(() => {
+    store = mockStore({
+      sensor: {
+        left: NOT_COVERED,
+        right: NOT_COVERED,
+      },
+    });
+    store.dispatch = jest.fn();
+  });
+
+  test('renders on the page with no errors', () => {
+    const wrapper = mount(<Indicator store={store} />);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  test('displays left covered', () => {
+    store = mockStore({
+      sensor: {
+        left: COVERED,
+        right: NOT_COVERED,
+      },
+    });
+    const wrapper = shallow(<Indicator store={store} />).dive();
+
+    expect(wrapper.find('#leftIndicator').hasClass('covered')).toBe(true);
+    expect(wrapper.find('#leftIndicator').hasClass('not-covered')).toBe(false);
+    expect(wrapper.find('#rightIndicator').hasClass('covered')).toBe(false);
+    expect(wrapper.find('#rightIndicator').hasClass('not-covered')).toBe(true);
+  });
+
+  test('displays right covered', () => {
+    store = mockStore({
+      sensor: {
+        left: NOT_COVERED,
+        right: COVERED,
+      },
+    });
+    const wrapper = shallow(<Indicator store={store} />).dive();
+
+    expect(wrapper.find('#leftIndicator').hasClass('covered')).toBe(false);
+    expect(wrapper.find('#leftIndicator').hasClass('not-covered')).toBe(true);
+    expect(wrapper.find('#rightIndicator').hasClass('covered')).toBe(true);
+    expect(wrapper.find('#rightIndicator').hasClass('not-covered')).toBe(false);
+  });
+
+  test('displays both covered', () => {
+    store = mockStore({
+      sensor: {
+        left: COVERED,
+        right: COVERED,
+      },
+    });
+    const wrapper = shallow(<Indicator store={store} />).dive();
+
+    expect(wrapper.find('#leftIndicator').hasClass('covered')).toBe(true);
+    expect(wrapper.find('#leftIndicator').hasClass('not-covered')).toBe(false);
+    expect(wrapper.find('#rightIndicator').hasClass('covered')).toBe(true);
+    expect(wrapper.find('#rightIndicator').hasClass('not-covered')).toBe(false);
+  });
+
+  test('displays neither covered', () => {
+    store = mockStore({
+      sensor: {
+        left: NOT_COVERED,
+        right: NOT_COVERED,
+      },
+    });
+    const wrapper = shallow(<Indicator store={store} />).dive();
+
+    expect(wrapper.find('#leftIndicator').hasClass('covered')).toBe(false);
+    expect(wrapper.find('#leftIndicator').hasClass('not-covered')).toBe(true);
+    expect(wrapper.find('#rightIndicator').hasClass('covered')).toBe(false);
+    expect(wrapper.find('#rightIndicator').hasClass('not-covered')).toBe(true);
+  });
+});

--- a/src/components/__tests__/__snapshots__/Indicator.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Indicator.test.js.snap
@@ -1,0 +1,97 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The Indicator component renders on the page with no errors 1`] = `
+<Connect(Indicator)
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [MockFunction],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <Indicator
+    dispatch={[MockFunction]}
+    sensor={
+      Object {
+        "left": 2,
+        "right": 2,
+      }
+    }
+    store={
+      Object {
+        "clearActions": [Function],
+        "dispatch": [MockFunction],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      }
+    }
+    storeSubscription={
+      Subscription {
+        "listeners": Object {
+          "clear": [Function],
+          "get": [Function],
+          "notify": [Function],
+          "subscribe": [Function],
+        },
+        "onStateChange": [Function],
+        "parentSub": undefined,
+        "store": Object {
+          "clearActions": [Function],
+          "dispatch": [MockFunction],
+          "getActions": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+        },
+        "unsubscribe": [Function],
+      }
+    }
+  >
+    <Grid
+      centered={true}
+      columns={12}
+    >
+      <div
+        className="ui centered twelve column grid"
+      >
+        <GridRow>
+          <div
+            className="row"
+          >
+            <GridColumn
+              width={6}
+            >
+              <div
+                className="six wide column"
+              >
+                <div
+                  className="indicator not-covered"
+                  id="leftIndicator"
+                />
+              </div>
+            </GridColumn>
+            <GridColumn
+              width={6}
+            >
+              <div
+                className="six wide column"
+              >
+                <div
+                  className="indicator not-covered"
+                  id="rightIndicator"
+                />
+              </div>
+            </GridColumn>
+          </div>
+        </GridRow>
+      </div>
+    </Grid>
+  </Indicator>
+</Connect(Indicator)>
+`;

--- a/src/containers/MissionControl.js
+++ b/src/containers/MissionControl.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 
 import Console from '@/components/Console';
 import Control from '@/components/Control';
+import Indicator from '@/components/Indicator';
 import Workspace from '@/components/Workspace';
 
 const mapStateToProps = ({ code }) => ({ code });
@@ -32,7 +33,12 @@ const MissionControl = ({ code }) => (
         </Grid.Row>
       </Grid.Column>
       <Grid.Column width={4}>
-        <Console />
+        <Grid.Row>
+          <Console />
+        </Grid.Row>
+        <Grid.Row>
+          <Indicator />
+        </Grid.Row>
       </Grid.Column>
     </Grid.Row>
   </Grid>

--- a/src/containers/__tests__/MissionControl.test.js
+++ b/src/containers/__tests__/MissionControl.test.js
@@ -9,6 +9,7 @@ import MissionControl from '../MissionControl';
 
 jest.mock('@/components/Console', () => () => <div />);
 jest.mock('@/components/Control', () => () => <div />);
+jest.mock('@/components/Indicator', () => () => <div />);
 jest.mock('@/components/Workspace', () => () => <div />);
 
 const cookiesValues = { auth_jwt: '1234' };

--- a/src/containers/__tests__/__snapshots__/MissionControl.test.js.snap
+++ b/src/containers/__tests__/__snapshots__/MissionControl.test.js.snap
@@ -119,9 +119,24 @@ exports[`The MissionControl container renders on the page with no errors 1`] = `
               <div
                 className="four wide column"
               >
-                <Component>
-                  <div />
-                </Component>
+                <GridRow>
+                  <div
+                    className="row"
+                  >
+                    <Component>
+                      <div />
+                    </Component>
+                  </div>
+                </GridRow>
+                <GridRow>
+                  <div
+                    className="row"
+                  >
+                    <Component>
+                      <div />
+                    </Component>
+                  </div>
+                </GridRow>
               </div>
             </GridColumn>
           </div>

--- a/src/css/__mocks__/styleMock.js
+++ b/src/css/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/src/css/indicator.css
+++ b/src/css/indicator.css
@@ -1,0 +1,15 @@
+.indicator {
+  margin: 0 auto;
+  border-radius: 25px;
+  width: 50px;
+  height: 50px;
+  box-shadow: inset 0 0 5px #555;
+}
+
+.covered {  
+  background-color: #43AC6A;
+}
+
+.not-covered {  
+  background-color: #BBBBBB;
+}

--- a/src/reducers/__tests__/sensor.test.js
+++ b/src/reducers/__tests__/sensor.test.js
@@ -1,0 +1,36 @@
+import reducer from '../sensor';
+import {
+  CHANGE_LEFT_SENSOR_STATE,
+  CHANGE_RIGHT_SENSOR_STATE,
+  COVERED,
+  NOT_COVERED,
+} from '../../actions/sensor';
+
+describe('The sensor reducer', () => {
+  test('should handle CHANGE_LEFT_SENSOR_STATE', () => {
+    expect(
+      reducer({}, {
+        type: CHANGE_LEFT_SENSOR_STATE,
+        payload: COVERED,
+      }),
+    ).toEqual({
+      left: COVERED,
+    });
+  });
+
+  test('should handle CHANGE_RIGHT_SENSOR_STATE', () => {
+    expect(
+      reducer({}, {
+        type: CHANGE_RIGHT_SENSOR_STATE,
+        payload: NOT_COVERED,
+      }),
+    ).toEqual({
+      right: NOT_COVERED,
+    });
+  });
+
+  test('should return unmodified state for an unhandled action type', () => {
+    const state = { hello: 'world' };
+    expect(reducer(state, { type: 'FAKE_ACTION' })).toEqual(state);
+  });
+});

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,9 +2,11 @@ import { combineReducers } from 'redux';
 import code from './code';
 import console from './console';
 import rover from './rover';
+import sensor from './sensor';
 
 export default combineReducers({
   code,
   console,
   rover,
+  sensor,
 });

--- a/src/reducers/sensor.js
+++ b/src/reducers/sensor.js
@@ -1,0 +1,28 @@
+import {
+  CHANGE_LEFT_SENSOR_STATE,
+  CHANGE_RIGHT_SENSOR_STATE,
+  NOT_COVERED,
+} from '../actions/sensor';
+
+export default function sensor(
+  state = {
+    left: NOT_COVERED,
+    right: NOT_COVERED,
+  },
+  action,
+) {
+  switch (action.type) {
+    case CHANGE_LEFT_SENSOR_STATE:
+      return {
+        ...state,
+        left: action.payload,
+      };
+    case CHANGE_RIGHT_SENSOR_STATE:
+      return {
+        ...state,
+        right: action.payload,
+      };
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
Next step of #20
Create an indicator component to show when the left or right sensor is covered or uncovered. The indicator changes based on the state which, for now, can be changed using the console if the [React Developer Tools](https://github.com/facebook/react-devtools) are installed.
* Open the developer console.
* Click `React` to connect.
* Go to `Console`.
* State can be changed by using `$r.store.dispatch({type: 'CHANGE_RIGHT_SENSOR_STATE', payload: 1});` to change the right sensor to `COVERED` or `$r.store.dispatch({type: 'CHANGE_LEFT_SENSOR_STATE', payload: 2});` to change the left sensor to `NOT_COVERED`
![image](https://user-images.githubusercontent.com/1184314/46184635-7a796000-c2a4-11e8-9d5d-141f9625ecb9.png)
