### PR TITLE
Fetch, Save, and Create Programs

### DIFF
--- a/src/actions/__test__/code.test.js
+++ b/src/actions/__test__/code.test.js
@@ -3,6 +3,7 @@ import {
   updateXmlCode,
   changeExecutionState,
   changeName,
+  changeId,
   EXECUTION_RUN,
 } from '../code';
 
@@ -38,5 +39,13 @@ describe('Code actions', () => {
 
     expect(type).toEqual('CHANGE_NAME');
     expect(payload).toEqual('test name');
+  });
+
+  test('changeId', () => {
+    const action = changeId(123);
+    const { type, payload } = action;
+
+    expect(type).toEqual('CHANGE_ID');
+    expect(payload).toEqual(123);
   });
 });

--- a/src/actions/__test__/code.test.js
+++ b/src/actions/__test__/code.test.js
@@ -7,6 +7,7 @@ import {
   changeName,
   changeId,
   fetchProgram,
+  saveProgram,
   EXECUTION_RUN,
 } from '../code';
 
@@ -68,6 +69,29 @@ describe('Code actions', () => {
     const payload = await action.payload;
 
     expect(type).toEqual('FETCH_PROGRAM');
+    expect(payload).toEqual(program);
+    mock.restore();
+  });
+
+  test('save program', async () => {
+    const mock = new MockAdapter(axios);
+    const program = {
+      id: 1,
+      name: 'mybd',
+      content: '<xml></xml>',
+      user: 1,
+    };
+
+    mock.onPut('/api/v1/block-diagrams/1/', {
+      name: program.name,
+      content: program.content,
+    }).reply(200, program);
+
+    const action = saveProgram(1, program.content, program.name);
+    const { type } = action;
+    const payload = await action.payload;
+
+    expect(type).toEqual('SAVE_PROGRAM');
     expect(payload).toEqual(program);
     mock.restore();
   });

--- a/src/actions/__test__/code.test.js
+++ b/src/actions/__test__/code.test.js
@@ -1,0 +1,42 @@
+import {
+  updateJsCode,
+  updateXmlCode,
+  changeExecutionState,
+  changeName,
+  EXECUTION_RUN,
+} from '../code';
+
+
+describe('Code actions', () => {
+  test('updateJsCode', () => {
+    const action = updateJsCode('test code');
+    const { type, payload } = action;
+
+    expect(type).toEqual('UPDATE_JSCODE');
+    expect(payload).toEqual('test code');
+  });
+
+  test('updateXmlCode', () => {
+    const action = updateXmlCode('test code');
+    const { type, payload } = action;
+
+    expect(type).toEqual('UPDATE_XMLCODE');
+    expect(payload).toEqual('test code');
+  });
+
+  test('changeExecutionState', () => {
+    const action = changeExecutionState(EXECUTION_RUN);
+    const { type, payload } = action;
+
+    expect(type).toEqual('CHANGE_EXECUTION_STATE');
+    expect(payload).toEqual(EXECUTION_RUN);
+  });
+
+  test('changeName', () => {
+    const action = changeName('test name');
+    const { type, payload } = action;
+
+    expect(type).toEqual('CHANGE_NAME');
+    expect(payload).toEqual('test name');
+  });
+});

--- a/src/actions/__test__/code.test.js
+++ b/src/actions/__test__/code.test.js
@@ -8,6 +8,7 @@ import {
   changeId,
   fetchProgram,
   saveProgram,
+  createProgram,
   EXECUTION_RUN,
 } from '../code';
 
@@ -92,6 +93,26 @@ describe('Code actions', () => {
     const payload = await action.payload;
 
     expect(type).toEqual('SAVE_PROGRAM');
+    expect(payload).toEqual(program);
+    mock.restore();
+  });
+
+  test('create program', async () => {
+    const mock = new MockAdapter(axios);
+    const program = {
+      name: 'mybd',
+    };
+
+    mock.onPost('/api/v1/block-diagrams/', {
+      name: program.name,
+      content: '<xml></xml>',
+    }).reply(200, program);
+
+    const action = createProgram(program.name);
+    const { type } = action;
+    const payload = await action.payload;
+
+    expect(type).toEqual('CREATE_PROGRAM');
     expect(payload).toEqual(program);
     mock.restore();
   });

--- a/src/actions/__test__/code.test.js
+++ b/src/actions/__test__/code.test.js
@@ -1,9 +1,12 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
 import {
   updateJsCode,
   updateXmlCode,
   changeExecutionState,
   changeName,
   changeId,
+  fetchProgram,
   EXECUTION_RUN,
 } from '../code';
 
@@ -47,5 +50,25 @@ describe('Code actions', () => {
 
     expect(type).toEqual('CHANGE_ID');
     expect(payload).toEqual(123);
+  });
+
+  test('fetch program', async () => {
+    const mock = new MockAdapter(axios);
+    const program = {
+      id: 1,
+      name: 'mybd',
+      content: '<xml></xml>',
+      user: 1,
+    };
+
+    mock.onGet('/api/v1/block-diagrams/1/').reply(200, program);
+
+    const action = fetchProgram(1);
+    const { type } = action;
+    const payload = await action.payload;
+
+    expect(type).toEqual('FETCH_PROGRAM');
+    expect(payload).toEqual(program);
+    mock.restore();
   });
 });

--- a/src/actions/code.js
+++ b/src/actions/code.js
@@ -5,6 +5,7 @@ export const UPDATE_JSCODE = 'UPDATE_JSCODE';
 export const UPDATE_XMLCODE = 'UPDATE_XMLCODE';
 export const CHANGE_EXECUTION_STATE = 'CHANGE_EXECUTION_STATE';
 export const CHANGE_NAME = 'CHANGE_NAME';
+export const CHANGE_ID = 'CHANGE_ID';
 
 // Execution States
 export const EXECUTION_RUN = 1;
@@ -31,4 +32,9 @@ export const changeExecutionState = state => ({
 export const changeName = name => ({
   type: CHANGE_NAME,
   payload: name,
+});
+
+export const changeId = id => ({
+  type: CHANGE_ID,
+  payload: id,
 });

--- a/src/actions/code.js
+++ b/src/actions/code.js
@@ -6,6 +6,9 @@ import axios from 'axios';
 export const FETCH_PROGRAM = 'FETCH_PROGRAM';
 export const FETCH_PROGRAM_FULFILLED = `${FETCH_PROGRAM}_FULFILLED`;
 export const FETCH_PROGRAM_REJECTED = `${FETCH_PROGRAM}_REJECTED`;
+export const SAVE_PROGRAM = 'SAVE_PROGRAM';
+export const SAVE_PROGRAM_FULFILLED = `${SAVE_PROGRAM}_FULFILLED`;
+export const SAVE_PROGRAM_REJECTED = `${SAVE_PROGRAM}_REJECTED`;
 
 export const UPDATE_JSCODE = 'UPDATE_JSCODE';
 export const UPDATE_XMLCODE = 'UPDATE_XMLCODE';
@@ -48,6 +51,17 @@ export const changeId = id => ({
 export const fetchProgram = (id, xhroptions) => ({
   type: FETCH_PROGRAM,
   payload: axios.get(`/api/v1/block-diagrams/${id}/`, xhroptions)
+    .then(({ data }) => (
+      data
+    )),
+});
+
+export const saveProgram = (id, content, name, xhroptions) => ({
+  type: SAVE_PROGRAM,
+  payload: axios.put(`/api/v1/block-diagrams/${id}/`, {
+    content,
+    name,
+  }, xhroptions)
     .then(({ data }) => (
       data
     )),

--- a/src/actions/code.js
+++ b/src/actions/code.js
@@ -2,7 +2,9 @@
 // async actions https://redux.js.org/advanced/asyncactions
 
 export const UPDATE_JSCODE = 'UPDATE_JSCODE';
+export const UPDATE_XMLCODE = 'UPDATE_XMLCODE';
 export const CHANGE_EXECUTION_STATE = 'CHANGE_EXECUTION_STATE';
+export const CHANGE_NAME = 'CHANGE_NAME';
 
 // Execution States
 export const EXECUTION_RUN = 1;
@@ -16,7 +18,17 @@ export const updateJsCode = jsCode => ({
   payload: jsCode,
 });
 
+export const updateXmlCode = xmlCode => ({
+  type: UPDATE_XMLCODE,
+  payload: xmlCode,
+});
+
 export const changeExecutionState = state => ({
   type: CHANGE_EXECUTION_STATE,
   payload: state,
+});
+
+export const changeName = name => ({
+  type: CHANGE_NAME,
+  payload: name,
 });

--- a/src/actions/code.js
+++ b/src/actions/code.js
@@ -1,6 +1,12 @@
 // actions https://redux.js.org/basics/actions
 // async actions https://redux.js.org/advanced/asyncactions
 
+import axios from 'axios';
+
+export const FETCH_PROGRAM = 'FETCH_PROGRAM';
+export const FETCH_PROGRAM_FULFILLED = `${FETCH_PROGRAM}_FULFILLED`;
+export const FETCH_PROGRAM_REJECTED = `${FETCH_PROGRAM}_REJECTED`;
+
 export const UPDATE_JSCODE = 'UPDATE_JSCODE';
 export const UPDATE_XMLCODE = 'UPDATE_XMLCODE';
 export const CHANGE_EXECUTION_STATE = 'CHANGE_EXECUTION_STATE';
@@ -37,4 +43,12 @@ export const changeName = name => ({
 export const changeId = id => ({
   type: CHANGE_ID,
   payload: id,
+});
+
+export const fetchProgram = (id, xhroptions) => ({
+  type: FETCH_PROGRAM,
+  payload: axios.get(`/api/v1/block-diagrams/${id}/`, xhroptions)
+    .then(({ data }) => (
+      data
+    )),
 });

--- a/src/actions/code.js
+++ b/src/actions/code.js
@@ -9,6 +9,9 @@ export const FETCH_PROGRAM_REJECTED = `${FETCH_PROGRAM}_REJECTED`;
 export const SAVE_PROGRAM = 'SAVE_PROGRAM';
 export const SAVE_PROGRAM_FULFILLED = `${SAVE_PROGRAM}_FULFILLED`;
 export const SAVE_PROGRAM_REJECTED = `${SAVE_PROGRAM}_REJECTED`;
+export const CREATE_PROGRAM = 'CREATE_PROGRAM';
+export const CREATE_PROGRAM_FULFILLED = `${CREATE_PROGRAM}_FULFILLED`;
+export const CREATE_PROGRAM_REJECTED = `${CREATE_PROGRAM}_REJECTED`;
 
 export const UPDATE_JSCODE = 'UPDATE_JSCODE';
 export const UPDATE_XMLCODE = 'UPDATE_XMLCODE';
@@ -61,6 +64,17 @@ export const saveProgram = (id, content, name, xhroptions) => ({
   payload: axios.put(`/api/v1/block-diagrams/${id}/`, {
     content,
     name,
+  }, xhroptions)
+    .then(({ data }) => (
+      data
+    )),
+});
+
+export const createProgram = (name, xhroptions) => ({
+  type: CREATE_PROGRAM,
+  payload: axios.post('/api/v1/block-diagrams/', {
+    name,
+    content: '<xml></xml>',
   }, xhroptions)
     .then(({ data }) => (
       data

--- a/src/components/RoverList.js
+++ b/src/components/RoverList.js
@@ -1,5 +1,6 @@
 import React, { Component, Fragment } from 'react';
-import { Header, Loader } from 'semantic-ui-react';
+import { Button, Header, Loader } from 'semantic-ui-react';
+import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 class RoverList extends Component {
@@ -21,6 +22,11 @@ class RoverList extends Component {
               </Header>
             )
         }
+        <Link to="/mission-control">
+          <Button>
+            Mission Control
+          </Button>
+        </Link>
       </Fragment>
     );
   }

--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -14,7 +14,7 @@ import {
   EXECUTION_STOP,
   EXECUTION_RESET,
 } from '@/actions/code';
-import { append } from '@/actions/console';
+import { append, clear } from '@/actions/console';
 import BlocklyApi from '@/utils/blockly-api';
 
 const mapStateToProps = ({ code }) => ({ code });
@@ -22,6 +22,7 @@ const mapDispatchToProps = dispatch => ({
   updateJsCode: jsCode => dispatch(actionUpdateJsCode(jsCode)),
   changeExecutionState: state => dispatch(actionChangeExecutionState(state)),
   writeToConsole: message => dispatch(append(message)),
+  clearConsole: () => dispatch(clear()),
   updateXmlCode: xmlCode => dispatch(actionUpdateXmlCode(xmlCode)),
 });
 
@@ -135,7 +136,7 @@ class Workspace extends Component {
   }
 
   componentDidMount() {
-    const { code, writeToConsole } = this.props;
+    const { code, clearConsole, writeToConsole } = this.props;
 
     Blockly.HSV_SATURATION = 0.85;
     Blockly.HSV_VALUE = 0.9;
@@ -160,6 +161,7 @@ class Workspace extends Component {
       workspace,
     }, () => this.loadDesign(code.xmlCode));
 
+    clearConsole();
     writeToConsole('rovercode console started');
   }
 
@@ -331,6 +333,7 @@ Workspace.propTypes = {
   updateXmlCode: PropTypes.func.isRequired,
   changeExecutionState: PropTypes.func.isRequired,
   writeToConsole: PropTypes.func.isRequired,
+  clearConsole: PropTypes.func.isRequired,
 };
 
 export default hot(module)(connect(mapStateToProps, mapDispatchToProps)(Workspace));

--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -11,6 +11,7 @@ import {
   updateXmlCode as actionUpdateXmlCode,
   changeExecutionState as actionChangeExecutionState,
   saveProgram as actionSaveProgram,
+  createProgram as actionCreateProgram,
   EXECUTION_RUN,
   EXECUTION_STEP,
   EXECUTION_STOP,
@@ -33,6 +34,14 @@ const mapDispatchToProps = (dispatch, { cookies }) => ({
       },
     });
     return dispatch(saveProgramAction);
+  },
+  createProgram: (name) => {
+    const createProgramAction = actionCreateProgram(name, {
+      headers: {
+        Authorization: `JWT ${cookies.get('auth_jwt')}`,
+      },
+    });
+    return dispatch(createProgramAction);
   },
 });
 
@@ -322,7 +331,12 @@ class Workspace extends Component {
   }
 
   loadDesign = (xmlCode) => {
+    const { createProgram } = this.props;
+
     if (!xmlCode) {
+      // No program already loaded, create a new one
+      const number = (Math.floor(Math.random() * 1000));
+      createProgram(`Unnamed_Design_${number}`);
       return;
     }
 
@@ -353,6 +367,7 @@ Workspace.propTypes = {
   writeToConsole: PropTypes.func.isRequired,
   clearConsole: PropTypes.func.isRequired,
   saveProgram: PropTypes.func.isRequired,
+  createProgram: PropTypes.func.isRequired,
 };
 
 export default hot(module)(withCookies(connect(mapStateToProps, mapDispatchToProps)(Workspace)));

--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -7,6 +7,7 @@ import Interpreter from 'js-interpreter';
 
 import {
   updateJsCode as actionUpdateJsCode,
+  updateXmlCode as actionUpdateXmlCode,
   changeExecutionState as actionChangeExecutionState,
   EXECUTION_RUN,
   EXECUTION_STEP,
@@ -21,6 +22,7 @@ const mapDispatchToProps = dispatch => ({
   updateJsCode: jsCode => dispatch(actionUpdateJsCode(jsCode)),
   changeExecutionState: state => dispatch(actionChangeExecutionState(state)),
   writeToConsole: message => dispatch(append(message)),
+  updateXmlCode: xmlCode => dispatch(actionUpdateXmlCode(xmlCode)),
 });
 
 // TODO: rover API
@@ -152,7 +154,7 @@ class Workspace extends Component {
       trashcan: true,
     });
 
-    workspace.addChangeListener(this.updateJsCode);
+    workspace.addChangeListener(this.updateCode);
 
     this.setState({
       workspace,
@@ -188,6 +190,16 @@ class Workspace extends Component {
     }
   }
 
+  updateXmlCode = () => {
+    const { updateXmlCode } = this.props;
+    const { workspace } = this.state;
+
+    const xml = Blockly.Xml.workspaceToDom(workspace);
+    const xmlCode = Blockly.Xml.domToText(xml);
+
+    updateXmlCode(xmlCode);
+  }
+
   updateJsCode = () => {
     const { updateJsCode } = this.props;
     const { workspace } = this.state;
@@ -208,6 +220,7 @@ class Workspace extends Component {
 
   updateCode = () => {
     this.updateJsCode();
+    this.updateXmlCode();
   }
 
   beginSleep = (sleepTimeInMs) => {

--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -135,7 +135,7 @@ class Workspace extends Component {
   }
 
   componentDidMount() {
-    const { writeToConsole } = this.props;
+    const { code, writeToConsole } = this.props;
 
     Blockly.HSV_SATURATION = 0.85;
     Blockly.HSV_VALUE = 0.9;
@@ -158,7 +158,7 @@ class Workspace extends Component {
 
     this.setState({
       workspace,
-    });
+    }, () => this.loadDesign(code.xmlCode));
 
     writeToConsole('rovercode console started');
   }
@@ -301,6 +301,21 @@ class Workspace extends Component {
     }
   }
 
+  loadDesign = (xmlCode) => {
+    if (!xmlCode) {
+      return;
+    }
+
+    const { workspace } = this.state;
+
+    workspace.clear();
+
+    const xmlDom = Blockly.Xml.textToDom(xmlCode);
+    Blockly.Xml.domToWorkspace(workspace, xmlDom);
+
+    this.updateCode();
+  }
+
   render() {
     return (
       <div ref={(editorDiv) => { this.editorDiv = editorDiv; }} style={{ height: '480px', width: '600px' }} />
@@ -313,6 +328,7 @@ Workspace.propTypes = {
     jsCode: PropTypes.string,
   }).isRequired,
   updateJsCode: PropTypes.func.isRequired,
+  updateXmlCode: PropTypes.func.isRequired,
   changeExecutionState: PropTypes.func.isRequired,
   writeToConsole: PropTypes.func.isRequired,
 };

--- a/src/components/__tests__/RoverList.test.js
+++ b/src/components/__tests__/RoverList.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { MemoryRouter } from 'react-router';
 import { Header, Loader } from 'semantic-ui-react';
 import { shallow, mount } from 'enzyme';
 import RoverList from '../RoverList';
@@ -17,7 +18,11 @@ describe('The RoverList component', () => {
 
   test('fetches rovers on mount', async () => {
     fetchRovers = jest.fn();
-    await mount(<RoverList fetchRovers={fetchRovers} />);
+    await mount(
+      <MemoryRouter>
+        <RoverList fetchRovers={fetchRovers} />
+      </MemoryRouter>,
+    );
     expect(fetchRovers.mock.calls.length).toBe(1);
   });
 

--- a/src/components/__tests__/Workspace.test.js
+++ b/src/components/__tests__/Workspace.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
+import { Cookies } from 'react-cookie';
 import configureStore from 'redux-mock-store';
 import {
   changeExecutionState,
@@ -15,8 +16,12 @@ jest.mock('node-blockly/browser');
 import Blockly from 'node-blockly/browser'; // eslint-disable-line import/first
 import Workspace from '../Workspace'; // eslint-disable-line import/first
 
+const cookiesValues = { auth_jwt: '1234' };
+const cookies = new Cookies(cookiesValues);
+
 describe('The Workspace component', () => {
   const mockStore = configureStore();
+  const context = { cookies };
   let store;
   let playground = null;
 
@@ -46,24 +51,24 @@ describe('The Workspace component', () => {
   });
 
   test('renders on the page with no errors', () => {
-    const wrapper = mount(<Workspace store={store} />);
+    const wrapper = mount(<Workspace store={store} />, { context });
 
-    expect(toJson(wrapper)).toMatchSnapshot();
+    expect(toJson(wrapper.find(Workspace))).toMatchSnapshot();
   });
 
   test('adds correct code prefix', () => {
     Blockly.JavaScript.workspaceToCode.mockReturnValue('testText');
 
-    const wrapper = shallow(<Workspace store={store} />);
+    const wrapper = shallow(<Workspace store={store} />, { context });
 
-    wrapper.dive().instance().updateJsCode();
+    wrapper.dive().dive().instance().updateJsCode();
     expect(Blockly.JavaScript.STATEMENT_PREFIX).toEqual('highlightBlock(%1);\n');
   });
 
   test('goes to running state on state change', () => {
-    const wrapper = shallow(<Workspace store={store} />);
+    const wrapper = shallow(<Workspace store={store} />, { context });
 
-    const workspace = wrapper.dive();
+    const workspace = wrapper.dive().dive();
     workspace.instance().goToRunningState = jest.fn();
     workspace.setProps({
       code: {
@@ -76,9 +81,9 @@ describe('The Workspace component', () => {
   });
 
   test('steps on state change', () => {
-    const wrapper = shallow(<Workspace store={store} />);
+    const wrapper = shallow(<Workspace store={store} />, { context });
 
-    const workspace = wrapper.dive();
+    const workspace = wrapper.dive().dive();
     workspace.instance().stepCode = jest.fn();
     workspace.setProps({
       code: {
@@ -91,9 +96,9 @@ describe('The Workspace component', () => {
   });
 
   test('goes to stop state on state change', () => {
-    const wrapper = shallow(<Workspace store={store} />);
+    const wrapper = shallow(<Workspace store={store} />, { context });
 
-    const workspace = wrapper.dive();
+    const workspace = wrapper.dive().dive();
     workspace.instance().goToStopState = jest.fn();
     workspace.setProps({
       code: {
@@ -106,9 +111,9 @@ describe('The Workspace component', () => {
   });
 
   test('resets on state change', () => {
-    const wrapper = shallow(<Workspace store={store} />);
+    const wrapper = shallow(<Workspace store={store} />, { context });
 
-    const workspace = wrapper.dive();
+    const workspace = wrapper.dive().dive();
     workspace.instance().resetCode = jest.fn();
     workspace.setProps({
       code: {
@@ -121,9 +126,9 @@ describe('The Workspace component', () => {
   });
 
   test('does nothing on invalid state change', () => {
-    const wrapper = shallow(<Workspace store={store} />);
+    const wrapper = shallow(<Workspace store={store} />, { context });
 
-    const workspace = wrapper.dive();
+    const workspace = wrapper.dive().dive();
     workspace.instance().goToRunningState = jest.fn();
     workspace.instance().stepCode = jest.fn();
     workspace.instance().goToStopState = jest.fn();
@@ -142,18 +147,18 @@ describe('The Workspace component', () => {
   });
 
   test('exits sleep after specified time', (done) => {
-    const wrapper = shallow(<Workspace store={store} />);
+    const wrapper = shallow(<Workspace store={store} />, { context });
 
-    const workspace = wrapper.dive();
+    const workspace = wrapper.dive().dive();
     workspace.instance().endSleep = jest.fn(() => done());
     workspace.update();
     workspace.instance().beginSleep(0);
   });
 
   test('updates javascript code', () => {
-    const wrapper = shallow(<Workspace store={store} />);
+    const wrapper = shallow(<Workspace store={store} />, { context });
 
-    const workspace = wrapper.dive();
+    const workspace = wrapper.dive().dive();
     workspace.instance().updateJsCode = jest.fn();
     workspace.update();
     workspace.instance().updateCode();
@@ -162,9 +167,9 @@ describe('The Workspace component', () => {
   });
 
   test('runs code after waking if running', () => {
-    const wrapper = shallow(<Workspace store={store} />);
+    const wrapper = shallow(<Workspace store={store} />, { context });
 
-    const workspace = wrapper.dive();
+    const workspace = wrapper.dive().dive();
     workspace.instance().runCode = jest.fn();
     workspace.instance().runningEnabled = true;
     workspace.update();
@@ -174,9 +179,9 @@ describe('The Workspace component', () => {
   });
 
   test('doesn\'t run code after waking if not running', () => {
-    const wrapper = shallow(<Workspace store={store} />);
+    const wrapper = shallow(<Workspace store={store} />, { context });
 
-    const workspace = wrapper.dive();
+    const workspace = wrapper.dive().dive();
     workspace.instance().runCode = jest.fn();
     workspace.instance().runningEnabled = false;
     workspace.update();
@@ -188,9 +193,9 @@ describe('The Workspace component', () => {
   test('runs code when not at end, running, and not sleeping', () => {
     jest.useFakeTimers();
 
-    const wrapper = shallow(<Workspace store={store} />);
+    const wrapper = shallow(<Workspace store={store} />, { context });
 
-    const workspace = wrapper.dive();
+    const workspace = wrapper.dive().dive();
     workspace.instance().stepCode = jest.fn(() => true);
     workspace.instance().runningEnabled = true;
     workspace.instance().sleeping = false;
@@ -203,9 +208,9 @@ describe('The Workspace component', () => {
   test('doesn\'t run code when at the end', () => {
     jest.useFakeTimers();
 
-    const wrapper = shallow(<Workspace store={store} />);
+    const wrapper = shallow(<Workspace store={store} />, { context });
 
-    const workspace = wrapper.dive();
+    const workspace = wrapper.dive().dive();
     workspace.instance().stepCode = jest.fn(() => false);
     workspace.update();
     workspace.instance().runCode();
@@ -216,9 +221,9 @@ describe('The Workspace component', () => {
   test('doesn\'t run code when not running', () => {
     jest.useFakeTimers();
 
-    const wrapper = shallow(<Workspace store={store} />);
+    const wrapper = shallow(<Workspace store={store} />, { context });
 
-    const workspace = wrapper.dive();
+    const workspace = wrapper.dive().dive();
     workspace.instance().stepCode = jest.fn(() => true);
     workspace.instance().runningEnabled = false;
     workspace.update();
@@ -230,9 +235,9 @@ describe('The Workspace component', () => {
   test('doesn\'t run code when sleeping', () => {
     jest.useFakeTimers();
 
-    const wrapper = shallow(<Workspace store={store} />);
+    const wrapper = shallow(<Workspace store={store} />, { context });
 
-    const workspace = wrapper.dive();
+    const workspace = wrapper.dive().dive();
     workspace.instance().stepCode = jest.fn(() => true);
     workspace.instance().runningEnabled = true;
     workspace.instance().sleeping = true;
@@ -243,9 +248,9 @@ describe('The Workspace component', () => {
   });
 
   test('stops stepping when at the end', () => {
-    const wrapper = shallow(<Workspace store={store} />);
+    const wrapper = shallow(<Workspace store={store} />, { context });
 
-    const workspace = wrapper.dive();
+    const workspace = wrapper.dive().dive();
     workspace.setState({
       interpreter: {
         step: jest.fn(() => false),
@@ -258,9 +263,9 @@ describe('The Workspace component', () => {
   });
 
   test('stops stepping when highlighted', () => {
-    const wrapper = shallow(<Workspace store={store} />);
+    const wrapper = shallow(<Workspace store={store} />, { context });
 
-    const workspace = wrapper.dive();
+    const workspace = wrapper.dive().dive();
     workspace.setState({
       interpreter: {
         step: jest.fn(() => true),
@@ -278,9 +283,9 @@ describe('The Workspace component', () => {
   test('continues stepping when not at the end', () => {
     const mockStep = jest.fn();
     mockStep.mockReturnValueOnce(true).mockReturnValueOnce(false);
-    const wrapper = shallow(<Workspace store={store} />);
+    const wrapper = shallow(<Workspace store={store} />, { context });
 
-    const workspace = wrapper.dive();
+    const workspace = wrapper.dive().dive();
     workspace.setState({
       interpreter: {
         step: mockStep,
@@ -294,9 +299,9 @@ describe('The Workspace component', () => {
   });
 
   test('stops and updates code on reset', () => {
-    const wrapper = shallow(<Workspace store={store} />);
+    const wrapper = shallow(<Workspace store={store} />, { context });
 
-    const workspace = wrapper.dive();
+    const workspace = wrapper.dive().dive();
     workspace.instance().updateCode = jest.fn();
     workspace.update();
     workspace.instance().resetCode();
@@ -306,9 +311,9 @@ describe('The Workspace component', () => {
   });
 
   test('updates and runs code when going to running state', () => {
-    const wrapper = shallow(<Workspace store={store} />);
+    const wrapper = shallow(<Workspace store={store} />, { context });
 
-    const workspace = wrapper.dive();
+    const workspace = wrapper.dive().dive();
     workspace.instance().updateCode = jest.fn();
     workspace.instance().runCode = jest.fn();
     workspace.update();
@@ -320,9 +325,9 @@ describe('The Workspace component', () => {
   });
 
   test('halts execution when going to stop state', () => {
-    const wrapper = shallow(<Workspace store={store} />);
+    const wrapper = shallow(<Workspace store={store} />, { context });
 
-    const workspace = wrapper.dive();
+    const workspace = wrapper.dive().dive();
     workspace.instance().goToStopState();
 
     expect(workspace.instance().runningEnabled).toBe(false);
@@ -332,9 +337,9 @@ describe('The Workspace component', () => {
     playground.getBlockById = jest.fn(() => ({
       getCommentText: () => 'highlightBlock(\'LkcrRd=UT=:*2QSbfwlK\');',
     }));
-    const wrapper = shallow(<Workspace store={store} />);
+    const wrapper = shallow(<Workspace store={store} />, { context });
 
-    const workspace = wrapper.dive();
+    const workspace = wrapper.dive().dive();
     workspace.instance().highlightBlock(1);
 
     expect(workspace.instance().highlightPause).toBe(true);
@@ -346,9 +351,9 @@ describe('The Workspace component', () => {
     playground.getBlockById = jest.fn(() => ({
       getCommentText: () => 'PASS',
     }));
-    const wrapper = shallow(<Workspace store={store} />);
+    const wrapper = shallow(<Workspace store={store} />, { context });
 
-    const workspace = wrapper.dive();
+    const workspace = wrapper.dive().dive();
     workspace.instance().highlightBlock(1);
 
     expect(workspace.instance().highlightPause).toBe(false);
@@ -361,9 +366,9 @@ describe('The Workspace component', () => {
         xmlCode: '<xml></xml>',
       },
     });
-    const wrapper = shallow(<Workspace store={localStore} />);
+    const wrapper = shallow(<Workspace store={localStore} />, { context });
 
-    wrapper.dive();
+    wrapper.dive().dive();
 
     expect(playground.clear).toHaveBeenCalled();
     expect(Blockly.Xml.domToWorkspace).toHaveBeenCalled();

--- a/src/components/__tests__/Workspace.test.js
+++ b/src/components/__tests__/Workspace.test.js
@@ -31,6 +31,7 @@ describe('The Workspace component', () => {
     playground = {
       addChangeListener: jest.fn((cb) => { cb(); }),
       highlightBlock: jest.fn(),
+      clear: jest.fn(),
     };
     Blockly.svgResize.mockReset();
     Blockly.inject.mockReset();
@@ -352,5 +353,20 @@ describe('The Workspace component', () => {
 
     expect(workspace.instance().highlightPause).toBe(false);
     expect(playground.highlightBlock).not.toHaveBeenCalled();
+  });
+
+  test('initializes workspace when program already loaded', () => {
+    const localStore = mockStore({
+      code: {
+        xmlCode: '<xml></xml>',
+      },
+    });
+    const wrapper = shallow(<Workspace store={localStore} />);
+
+    wrapper.dive();
+
+    expect(playground.clear).toHaveBeenCalled();
+    expect(Blockly.Xml.domToWorkspace).toHaveBeenCalled();
+    expect(Blockly.Xml.domToWorkspace).toHaveBeenCalledWith(playground, 'test-dom');
   });
 });

--- a/src/components/__tests__/__snapshots__/RoverList.test.js.snap
+++ b/src/components/__tests__/__snapshots__/RoverList.test.js.snap
@@ -20,36 +20,26 @@ ShallowWrapper {
     "key": undefined,
     "nodeType": "function",
     "props": Object {
-      "children": <Loader
-        active={true}
-      />,
-    },
-    "ref": null,
-    "rendered": Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "function",
-      "props": Object {
-        "active": true,
-      },
-      "ref": null,
-      "rendered": null,
-      "type": [Function],
-    },
-    "type": Symbol(react.fragment),
-  },
-  Symbol(enzyme.__nodes__): Array [
-    Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "function",
-      "props": Object {
-        "children": <Loader
+      "children": Array [
+        <Loader
           active={true}
         />,
-      },
-      "ref": null,
-      "rendered": Object {
+        <Link
+          replace={false}
+          to="/mission-control"
+        >
+          <Button
+            as="button"
+            role="button"
+          >
+            Mission Control
+          </Button>
+        </Link>,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
         "instance": null,
         "key": undefined,
         "nodeType": "function",
@@ -60,6 +50,106 @@ ShallowWrapper {
         "rendered": null,
         "type": [Function],
       },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "children": <Button
+            as="button"
+            role="button"
+          >
+            Mission Control
+          </Button>,
+          "replace": false,
+          "to": "/mission-control",
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "as": "button",
+            "children": "Mission Control",
+            "role": "button",
+          },
+          "ref": null,
+          "rendered": "Mission Control",
+          "type": [Function],
+        },
+        "type": [Function],
+      },
+    ],
+    "type": Symbol(react.fragment),
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "function",
+      "props": Object {
+        "children": Array [
+          <Loader
+            active={true}
+          />,
+          <Link
+            replace={false}
+            to="/mission-control"
+          >
+            <Button
+              as="button"
+              role="button"
+            >
+              Mission Control
+            </Button>
+          </Link>,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "active": true,
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "children": <Button
+              as="button"
+              role="button"
+            >
+              Mission Control
+            </Button>,
+            "replace": false,
+            "to": "/mission-control",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "as": "button",
+              "children": "Mission Control",
+              "role": "button",
+            },
+            "ref": null,
+            "rendered": "Mission Control",
+            "type": [Function],
+          },
+          "type": [Function],
+        },
+      ],
       "type": Symbol(react.fragment),
     },
   ],

--- a/src/components/__tests__/__snapshots__/Workspace.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Workspace.test.js.snap
@@ -15,12 +15,22 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
           ],
           Array [
             Object {
+              "payload": "test-dom-text",
+              "type": "UPDATE_XMLCODE",
+            },
+          ],
+          Array [
+            Object {
               "payload": "rovercode console started",
               "type": "APPEND",
             },
           ],
         ],
         "results": Array [
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
           Object {
             "isThrow": false,
             "value": undefined,
@@ -59,12 +69,22 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
             ],
             Array [
               Object {
+                "payload": "test-dom-text",
+                "type": "UPDATE_XMLCODE",
+              },
+            ],
+            Array [
+              Object {
                 "payload": "rovercode console started",
                 "type": "APPEND",
               },
             ],
           ],
           "results": Array [
+            Object {
+              "isThrow": false,
+              "value": undefined,
+            },
             Object {
               "isThrow": false,
               "value": undefined,
@@ -103,12 +123,22 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
               ],
               Array [
                 Object {
+                  "payload": "test-dom-text",
+                  "type": "UPDATE_XMLCODE",
+                },
+              ],
+              Array [
+                Object {
                   "payload": "rovercode console started",
                   "type": "APPEND",
                 },
               ],
             ],
             "results": Array [
+              Object {
+                "isThrow": false,
+                "value": undefined,
+              },
               Object {
                 "isThrow": false,
                 "value": undefined,
@@ -128,6 +158,7 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
       }
     }
     updateJsCode={[Function]}
+    updateXmlCode={[Function]}
     writeToConsole={[Function]}
   >
     <div

--- a/src/components/__tests__/__snapshots__/Workspace.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Workspace.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`The Workspace component renders on the page with no errors 1`] = `
-<Connect(Workspace)
+<withCookies(Component)
   store={
     Object {
       "clearActions": [Function],
@@ -17,6 +17,18 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
             Object {
               "payload": "test-dom-text",
               "type": "UPDATE_XMLCODE",
+            },
+          ],
+          Array [
+            Object {
+              "payload": Promise {},
+              "type": "SAVE_PROGRAM",
+            },
+          ],
+          Array [
+            Object {
+              "payload": Promise {},
+              "type": "FETCH_PROGRAM",
             },
           ],
           Array [
@@ -48,6 +60,14 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
             "isThrow": false,
             "value": undefined,
           },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
         ],
       },
       "getActions": [Function],
@@ -57,13 +77,16 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
     }
   }
 >
-  <Workspace
-    changeExecutionState={[Function]}
-    clearConsole={[Function]}
-    code={
-      Object {
-        "execution": null,
-        "jsCode": "",
+  <Connect(Workspace)
+    allCookies={Object {}}
+    cookies={
+      Cookies {
+        "HAS_DOCUMENT_COOKIE": true,
+        "changeListeners": Array [
+          [Function],
+        ],
+        "cookies": Object {},
+        "hooks": undefined,
       }
     }
     store={
@@ -81,6 +104,18 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
               Object {
                 "payload": "test-dom-text",
                 "type": "UPDATE_XMLCODE",
+              },
+            ],
+            Array [
+              Object {
+                "payload": Promise {},
+                "type": "SAVE_PROGRAM",
+              },
+            ],
+            Array [
+              Object {
+                "payload": Promise {},
+                "type": "FETCH_PROGRAM",
               },
             ],
             Array [
@@ -112,6 +147,14 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
               "isThrow": false,
               "value": undefined,
             },
+            Object {
+              "isThrow": false,
+              "value": undefined,
+            },
+            Object {
+              "isThrow": false,
+              "value": undefined,
+            },
           ],
         },
         "getActions": [Function],
@@ -120,17 +163,31 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
         "subscribe": [Function],
       }
     }
-    storeSubscription={
-      Subscription {
-        "listeners": Object {
-          "clear": [Function],
-          "get": [Function],
-          "notify": [Function],
-          "subscribe": [Function],
-        },
-        "onStateChange": [Function],
-        "parentSub": undefined,
-        "store": Object {
+  >
+    <Workspace
+      allCookies={Object {}}
+      changeExecutionState={[Function]}
+      clearConsole={[Function]}
+      code={
+        Object {
+          "execution": null,
+          "jsCode": "",
+        }
+      }
+      cookies={
+        Cookies {
+          "HAS_DOCUMENT_COOKIE": true,
+          "changeListeners": Array [
+            [Function],
+          ],
+          "cookies": Object {},
+          "hooks": undefined,
+        }
+      }
+      fetchProgram={[Function]}
+      saveProgram={[Function]}
+      store={
+        Object {
           "clearActions": [Function],
           "dispatch": [MockFunction] {
             "calls": Array [
@@ -144,6 +201,18 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
                 Object {
                   "payload": "test-dom-text",
                   "type": "UPDATE_XMLCODE",
+                },
+              ],
+              Array [
+                Object {
+                  "payload": Promise {},
+                  "type": "SAVE_PROGRAM",
+                },
+              ],
+              Array [
+                Object {
+                  "payload": Promise {},
+                  "type": "FETCH_PROGRAM",
                 },
               ],
               Array [
@@ -175,28 +244,120 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
                 "isThrow": false,
                 "value": undefined,
               },
+              Object {
+                "isThrow": false,
+                "value": undefined,
+              },
+              Object {
+                "isThrow": false,
+                "value": undefined,
+              },
             ],
           },
           "getActions": [Function],
           "getState": [Function],
           "replaceReducer": [Function],
           "subscribe": [Function],
-        },
-        "unsubscribe": [Function],
-      }
-    }
-    updateJsCode={[Function]}
-    updateXmlCode={[Function]}
-    writeToConsole={[Function]}
-  >
-    <div
-      style={
-        Object {
-          "height": "480px",
-          "width": "600px",
         }
       }
-    />
-  </Workspace>
-</Connect(Workspace)>
+      storeSubscription={
+        Subscription {
+          "listeners": Object {
+            "clear": [Function],
+            "get": [Function],
+            "notify": [Function],
+            "subscribe": [Function],
+          },
+          "onStateChange": [Function],
+          "parentSub": undefined,
+          "store": Object {
+            "clearActions": [Function],
+            "dispatch": [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "payload": "test-code",
+                    "type": "UPDATE_JSCODE",
+                  },
+                ],
+                Array [
+                  Object {
+                    "payload": "test-dom-text",
+                    "type": "UPDATE_XMLCODE",
+                  },
+                ],
+                Array [
+                  Object {
+                    "payload": Promise {},
+                    "type": "SAVE_PROGRAM",
+                  },
+                ],
+                Array [
+                  Object {
+                    "payload": Promise {},
+                    "type": "FETCH_PROGRAM",
+                  },
+                ],
+                Array [
+                  Object {
+                    "type": "CLEAR",
+                  },
+                ],
+                Array [
+                  Object {
+                    "payload": "rovercode console started",
+                    "type": "APPEND",
+                  },
+                ],
+              ],
+              "results": Array [
+                Object {
+                  "isThrow": false,
+                  "value": undefined,
+                },
+                Object {
+                  "isThrow": false,
+                  "value": undefined,
+                },
+                Object {
+                  "isThrow": false,
+                  "value": undefined,
+                },
+                Object {
+                  "isThrow": false,
+                  "value": undefined,
+                },
+                Object {
+                  "isThrow": false,
+                  "value": undefined,
+                },
+                Object {
+                  "isThrow": false,
+                  "value": undefined,
+                },
+              ],
+            },
+            "getActions": [Function],
+            "getState": [Function],
+            "replaceReducer": [Function],
+            "subscribe": [Function],
+          },
+          "unsubscribe": [Function],
+        }
+      }
+      updateJsCode={[Function]}
+      updateXmlCode={[Function]}
+      writeToConsole={[Function]}
+    >
+      <div
+        style={
+          Object {
+            "height": "480px",
+            "width": "600px",
+          }
+        }
+      />
+    </Workspace>
+  </Connect(Workspace)>
+</withCookies(Component)>
 `;

--- a/src/components/__tests__/__snapshots__/Workspace.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Workspace.test.js.snap
@@ -27,12 +27,6 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
           ],
           Array [
             Object {
-              "payload": Promise {},
-              "type": "FETCH_PROGRAM",
-            },
-          ],
-          Array [
-            Object {
               "type": "CLEAR",
             },
           ],
@@ -40,6 +34,12 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
             Object {
               "payload": "rovercode console started",
               "type": "APPEND",
+            },
+          ],
+          Array [
+            Object {
+              "payload": Promise {},
+              "type": "CREATE_PROGRAM",
             },
           ],
         ],
@@ -114,12 +114,6 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
             ],
             Array [
               Object {
-                "payload": Promise {},
-                "type": "FETCH_PROGRAM",
-              },
-            ],
-            Array [
-              Object {
                 "type": "CLEAR",
               },
             ],
@@ -127,6 +121,12 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
               Object {
                 "payload": "rovercode console started",
                 "type": "APPEND",
+              },
+            ],
+            Array [
+              Object {
+                "payload": Promise {},
+                "type": "CREATE_PROGRAM",
               },
             ],
           ],
@@ -184,7 +184,7 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
           "hooks": undefined,
         }
       }
-      fetchProgram={[Function]}
+      createProgram={[Function]}
       saveProgram={[Function]}
       store={
         Object {
@@ -211,12 +211,6 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
               ],
               Array [
                 Object {
-                  "payload": Promise {},
-                  "type": "FETCH_PROGRAM",
-                },
-              ],
-              Array [
-                Object {
                   "type": "CLEAR",
                 },
               ],
@@ -224,6 +218,12 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
                 Object {
                   "payload": "rovercode console started",
                   "type": "APPEND",
+                },
+              ],
+              Array [
+                Object {
+                  "payload": Promise {},
+                  "type": "CREATE_PROGRAM",
                 },
               ],
             ],
@@ -294,12 +294,6 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
                 ],
                 Array [
                   Object {
-                    "payload": Promise {},
-                    "type": "FETCH_PROGRAM",
-                  },
-                ],
-                Array [
-                  Object {
                     "type": "CLEAR",
                   },
                 ],
@@ -307,6 +301,12 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
                   Object {
                     "payload": "rovercode console started",
                     "type": "APPEND",
+                  },
+                ],
+                Array [
+                  Object {
+                    "payload": Promise {},
+                    "type": "CREATE_PROGRAM",
                   },
                 ],
               ],

--- a/src/components/__tests__/__snapshots__/Workspace.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Workspace.test.js.snap
@@ -21,12 +21,21 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
           ],
           Array [
             Object {
+              "type": "CLEAR",
+            },
+          ],
+          Array [
+            Object {
               "payload": "rovercode console started",
               "type": "APPEND",
             },
           ],
         ],
         "results": Array [
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
           Object {
             "isThrow": false,
             "value": undefined,
@@ -50,6 +59,7 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
 >
   <Workspace
     changeExecutionState={[Function]}
+    clearConsole={[Function]}
     code={
       Object {
         "execution": null,
@@ -75,12 +85,21 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
             ],
             Array [
               Object {
+                "type": "CLEAR",
+              },
+            ],
+            Array [
+              Object {
                 "payload": "rovercode console started",
                 "type": "APPEND",
               },
             ],
           ],
           "results": Array [
+            Object {
+              "isThrow": false,
+              "value": undefined,
+            },
             Object {
               "isThrow": false,
               "value": undefined,
@@ -129,12 +148,21 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
               ],
               Array [
                 Object {
+                  "type": "CLEAR",
+                },
+              ],
+              Array [
+                Object {
                   "payload": "rovercode console started",
                   "type": "APPEND",
                 },
               ],
             ],
             "results": Array [
+              Object {
+                "isThrow": false,
+                "value": undefined,
+              },
               Object {
                 "isThrow": false,
                 "value": undefined,

--- a/src/containers/MissionControl.js
+++ b/src/containers/MissionControl.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Grid } from 'semantic-ui-react';
+import { Button, Grid } from 'semantic-ui-react';
 import { hot } from 'react-hot-loader';
+import { Link } from 'react-router-dom';
 
 import CodeViewer from '@/components/CodeViewer';
 import Console from '@/components/Console';
@@ -25,6 +26,14 @@ const MissionControl = () => (
         <hr />
         <Grid.Row>
           <Control />
+        </Grid.Row>
+        <hr />
+        <Grid.Row>
+          <Link to="/">
+            <Button>
+              Home
+            </Button>
+          </Link>
         </Grid.Row>
       </Grid.Column>
       <Grid.Column width={4}>

--- a/src/containers/__tests__/MissionControl.test.js
+++ b/src/containers/__tests__/MissionControl.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { MemoryRouter } from 'react-router';
 import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import { Cookies } from 'react-cookie';
@@ -30,11 +31,16 @@ describe('The MissionControl container', () => {
 
   test('renders on the page with no errors', () => {
     const context = { cookies };
-    wrapper = mount(<MissionControl store={store} />, {
-      context,
-      childContextTypes: { cookies: PropTypes.instanceOf(Cookies) },
-    });
+    wrapper = mount(
+      <MemoryRouter>
+        <MissionControl store={store} />
+      </MemoryRouter>, {
+        context,
+        childContextTypes: { cookies: PropTypes.instanceOf(Cookies) },
+      },
+    );
+    const mcWrapper = wrapper.find(MissionControl);
 
-    expect(toJson(wrapper)).toMatchSnapshot();
+    expect(toJson(mcWrapper)).toMatchSnapshot();
   });
 });

--- a/src/containers/__tests__/__snapshots__/MissionControl.test.js.snap
+++ b/src/containers/__tests__/__snapshots__/MissionControl.test.js.snap
@@ -66,6 +66,35 @@ exports[`The MissionControl container renders on the page with no errors 1`] = `
                   </Component>
                 </div>
               </GridRow>
+              <hr />
+              <GridRow>
+                <div
+                  className="row"
+                >
+                  <Link
+                    replace={false}
+                    to="/"
+                  >
+                    <a
+                      href="/"
+                      onClick={[Function]}
+                    >
+                      <Button
+                        as="button"
+                        role="button"
+                      >
+                        <button
+                          className="ui button"
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          Home
+                        </button>
+                      </Button>
+                    </a>
+                  </Link>
+                </div>
+              </GridRow>
             </div>
           </GridColumn>
           <GridColumn

--- a/src/reducers/__tests__/code.test.js
+++ b/src/reducers/__tests__/code.test.js
@@ -3,6 +3,8 @@ import {
   CHANGE_EXECUTION_STATE,
   EXECUTION_RUN,
   UPDATE_JSCODE,
+  UPDATE_XMLCODE,
+  CHANGE_NAME,
 } from '../../actions/code';
 
 describe('The code reducer', () => {
@@ -17,6 +19,17 @@ describe('The code reducer', () => {
     });
   });
 
+  test('should handle UPDATE_XMLCODE', () => {
+    expect(
+      reducer({}, {
+        type: UPDATE_XMLCODE,
+        payload: 'testcode',
+      }),
+    ).toEqual({
+      xmlCode: 'testcode',
+    });
+  });
+
   test('should handle CHANGE_EXECUTION_STATE', () => {
     expect(
       reducer({}, {
@@ -25,6 +38,17 @@ describe('The code reducer', () => {
       }),
     ).toEqual({
       execution: EXECUTION_RUN,
+    });
+  });
+
+  test('should handle CHANGE_NAME', () => {
+    expect(
+      reducer({}, {
+        type: CHANGE_NAME,
+        payload: 'test name',
+      }),
+    ).toEqual({
+      name: 'test name',
     });
   });
 

--- a/src/reducers/__tests__/code.test.js
+++ b/src/reducers/__tests__/code.test.js
@@ -9,6 +9,9 @@ import {
   FETCH_PROGRAM,
   FETCH_PROGRAM_FULFILLED,
   FETCH_PROGRAM_REJECTED,
+  SAVE_PROGRAM,
+  SAVE_PROGRAM_FULFILLED,
+  SAVE_PROGRAM_REJECTED,
 } from '../../actions/code';
 
 describe('The code reducer', () => {
@@ -111,6 +114,54 @@ describe('The code reducer', () => {
       }),
     ).toEqual({
       isFetching: false,
+      error: { detail },
+    });
+  });
+
+  test('should handle SAVE_PROGRAM', () => {
+    expect(
+      reducer({}, {
+        type: SAVE_PROGRAM,
+      }),
+    ).toEqual({
+      isSaving: true,
+    });
+  });
+
+  test('should handle SAVE_PROGRAM_FULFILLED', () => {
+    const name = 'mybd';
+    const id = 1;
+    const xmlCode = '<xml></xml>';
+
+    expect(
+      reducer({}, {
+        type: SAVE_PROGRAM_FULFILLED,
+        payload: {
+          name,
+          id,
+          content: xmlCode,
+        },
+      }),
+    ).toEqual({
+      isSaving: false,
+      name,
+      id,
+      xmlCode,
+    });
+  });
+
+  test('should handle SAVE_PROGRAM_REJECTED', () => {
+    const detail = 'Authentication credentials were not provided.';
+
+    expect(
+      reducer({}, {
+        type: SAVE_PROGRAM_REJECTED,
+        payload: {
+          detail,
+        },
+      }),
+    ).toEqual({
+      isSaving: false,
       error: { detail },
     });
   });

--- a/src/reducers/__tests__/code.test.js
+++ b/src/reducers/__tests__/code.test.js
@@ -6,6 +6,9 @@ import {
   UPDATE_XMLCODE,
   CHANGE_NAME,
   CHANGE_ID,
+  FETCH_PROGRAM,
+  FETCH_PROGRAM_FULFILLED,
+  FETCH_PROGRAM_REJECTED,
 } from '../../actions/code';
 
 describe('The code reducer', () => {
@@ -61,6 +64,54 @@ describe('The code reducer', () => {
       }),
     ).toEqual({
       id: 123,
+    });
+  });
+
+  test('should handle FETCH_PROGRAM', () => {
+    expect(
+      reducer({}, {
+        type: FETCH_PROGRAM,
+      }),
+    ).toEqual({
+      isFetching: true,
+    });
+  });
+
+  test('should handle FETCH_PROGRAM_FULFILLED', () => {
+    const name = 'mybd';
+    const id = 1;
+    const xmlCode = '<xml></xml>';
+
+    expect(
+      reducer({}, {
+        type: FETCH_PROGRAM_FULFILLED,
+        payload: {
+          name,
+          id,
+          content: xmlCode,
+        },
+      }),
+    ).toEqual({
+      isFetching: false,
+      name,
+      id,
+      xmlCode,
+    });
+  });
+
+  test('should handle FETCH_PROGRAM_REJECTED', () => {
+    const detail = 'Authentication credentials were not provided.';
+
+    expect(
+      reducer({}, {
+        type: FETCH_PROGRAM_REJECTED,
+        payload: {
+          detail,
+        },
+      }),
+    ).toEqual({
+      isFetching: false,
+      error: { detail },
     });
   });
 

--- a/src/reducers/__tests__/code.test.js
+++ b/src/reducers/__tests__/code.test.js
@@ -5,6 +5,7 @@ import {
   UPDATE_JSCODE,
   UPDATE_XMLCODE,
   CHANGE_NAME,
+  CHANGE_ID,
 } from '../../actions/code';
 
 describe('The code reducer', () => {
@@ -49,6 +50,17 @@ describe('The code reducer', () => {
       }),
     ).toEqual({
       name: 'test name',
+    });
+  });
+
+  test('should handle CHANGE_ID', () => {
+    expect(
+      reducer({}, {
+        type: CHANGE_ID,
+        payload: 123,
+      }),
+    ).toEqual({
+      id: 123,
     });
   });
 

--- a/src/reducers/__tests__/code.test.js
+++ b/src/reducers/__tests__/code.test.js
@@ -12,6 +12,9 @@ import {
   SAVE_PROGRAM,
   SAVE_PROGRAM_FULFILLED,
   SAVE_PROGRAM_REJECTED,
+  CREATE_PROGRAM,
+  CREATE_PROGRAM_FULFILLED,
+  CREATE_PROGRAM_REJECTED,
 } from '../../actions/code';
 
 describe('The code reducer', () => {
@@ -162,6 +165,54 @@ describe('The code reducer', () => {
       }),
     ).toEqual({
       isSaving: false,
+      error: { detail },
+    });
+  });
+
+  test('should handle CREATE_PROGRAM', () => {
+    expect(
+      reducer({}, {
+        type: CREATE_PROGRAM,
+      }),
+    ).toEqual({
+      isCreating: true,
+    });
+  });
+
+  test('should handle CREATE_PROGRAM_FULFILLED', () => {
+    const id = 1;
+    const name = 'mybd';
+    const xmlCode = '<xml></xml>';
+
+    expect(
+      reducer({}, {
+        type: CREATE_PROGRAM_FULFILLED,
+        payload: {
+          name,
+          id,
+          content: xmlCode,
+        },
+      }),
+    ).toEqual({
+      isCreating: false,
+      name,
+      id,
+      xmlCode,
+    });
+  });
+
+  test('should handle CREATE_PROGRAM_REJECTED', () => {
+    const detail = 'Authentication credentials were not provided.';
+
+    expect(
+      reducer({}, {
+        type: CREATE_PROGRAM_REJECTED,
+        payload: {
+          detail,
+        },
+      }),
+    ).toEqual({
+      isCreating: false,
       error: { detail },
     });
   });

--- a/src/reducers/code.js
+++ b/src/reducers/code.js
@@ -3,6 +3,7 @@ import {
   UPDATE_JSCODE,
   UPDATE_XMLCODE,
   CHANGE_NAME,
+  CHANGE_ID,
 } from '../actions/code';
 
 export default function code(
@@ -11,6 +12,7 @@ export default function code(
     xmlCode: null,
     execution: null,
     name: null,
+    id: null,
   },
   action,
 ) {
@@ -34,6 +36,11 @@ export default function code(
       return {
         ...state,
         name: action.payload,
+      };
+    case CHANGE_ID:
+      return {
+        ...state,
+        id: action.payload,
       };
     default:
       return state;

--- a/src/reducers/code.js
+++ b/src/reducers/code.js
@@ -10,6 +10,9 @@ import {
   SAVE_PROGRAM,
   SAVE_PROGRAM_FULFILLED,
   SAVE_PROGRAM_REJECTED,
+  CREATE_PROGRAM,
+  CREATE_PROGRAM_FULFILLED,
+  CREATE_PROGRAM_REJECTED,
 } from '../actions/code';
 
 export default function code(
@@ -21,6 +24,7 @@ export default function code(
     id: null,
     isFetching: false,
     isSaving: false,
+    isCreating: false,
     error: null,
   },
   action,
@@ -87,6 +91,25 @@ export default function code(
       return {
         ...state,
         isSaving: false,
+        error: action.payload,
+      };
+    case CREATE_PROGRAM:
+      return {
+        ...state,
+        isCreating: true,
+      };
+    case CREATE_PROGRAM_FULFILLED:
+      return {
+        ...state,
+        isCreating: false,
+        xmlCode: action.payload.content,
+        id: action.payload.id,
+        name: action.payload.name,
+      };
+    case CREATE_PROGRAM_REJECTED:
+      return {
+        ...state,
+        isCreating: false,
         error: action.payload,
       };
     default:

--- a/src/reducers/code.js
+++ b/src/reducers/code.js
@@ -7,6 +7,9 @@ import {
   FETCH_PROGRAM,
   FETCH_PROGRAM_FULFILLED,
   FETCH_PROGRAM_REJECTED,
+  SAVE_PROGRAM,
+  SAVE_PROGRAM_FULFILLED,
+  SAVE_PROGRAM_REJECTED,
 } from '../actions/code';
 
 export default function code(
@@ -17,6 +20,7 @@ export default function code(
     name: null,
     id: null,
     isFetching: false,
+    isSaving: false,
     error: null,
   },
   action,
@@ -64,6 +68,25 @@ export default function code(
       return {
         ...state,
         isFetching: false,
+        error: action.payload,
+      };
+    case SAVE_PROGRAM:
+      return {
+        ...state,
+        isSaving: true,
+      };
+    case SAVE_PROGRAM_FULFILLED:
+      return {
+        ...state,
+        isSaving: false,
+        xmlCode: action.payload.content,
+        id: action.payload.id,
+        name: action.payload.name,
+      };
+    case SAVE_PROGRAM_REJECTED:
+      return {
+        ...state,
+        isSaving: false,
         error: action.payload,
       };
     default:

--- a/src/reducers/code.js
+++ b/src/reducers/code.js
@@ -4,6 +4,9 @@ import {
   UPDATE_XMLCODE,
   CHANGE_NAME,
   CHANGE_ID,
+  FETCH_PROGRAM,
+  FETCH_PROGRAM_FULFILLED,
+  FETCH_PROGRAM_REJECTED,
 } from '../actions/code';
 
 export default function code(
@@ -13,6 +16,8 @@ export default function code(
     execution: null,
     name: null,
     id: null,
+    isFetching: false,
+    error: null,
   },
   action,
 ) {
@@ -41,6 +46,25 @@ export default function code(
       return {
         ...state,
         id: action.payload,
+      };
+    case FETCH_PROGRAM:
+      return {
+        ...state,
+        isFetching: true,
+      };
+    case FETCH_PROGRAM_FULFILLED:
+      return {
+        ...state,
+        isFetching: false,
+        xmlCode: action.payload.content,
+        id: action.payload.id,
+        name: action.payload.name,
+      };
+    case FETCH_PROGRAM_REJECTED:
+      return {
+        ...state,
+        isFetching: false,
+        error: action.payload,
       };
     default:
       return state;

--- a/src/reducers/code.js
+++ b/src/reducers/code.js
@@ -1,9 +1,16 @@
-import { CHANGE_EXECUTION_STATE, UPDATE_JSCODE } from '../actions/code';
+import {
+  CHANGE_EXECUTION_STATE,
+  UPDATE_JSCODE,
+  UPDATE_XMLCODE,
+  CHANGE_NAME,
+} from '../actions/code';
 
 export default function code(
   state = {
     jsCode: null,
+    xmlCode: null,
     execution: null,
+    name: null,
   },
   action,
 ) {
@@ -13,10 +20,20 @@ export default function code(
         ...state,
         jsCode: action.payload,
       };
+    case UPDATE_XMLCODE:
+      return {
+        ...state,
+        xmlCode: action.payload,
+      };
     case CHANGE_EXECUTION_STATE:
       return {
         ...state,
         execution: action.payload,
+      };
+    case CHANGE_NAME:
+      return {
+        ...state,
+        name: action.payload,
       };
     default:
       return state;


### PR DESCRIPTION
Next step of #20 
Adds actions for fetching, creating, and saving a program via the API. If a program is loaded into the state, the workspace will populate with that content. If a program is not loaded, the workspace will create a new program with `Unnamed_Design_#` as the name. In either case, any change to the program will save to the API. Also, added temporary buttons to be able to navigate between `home` and `mission control` in order to test the state preserving and the workspace populating properly.

The idea here is that an `explore` page will load the program into the state and then go to `mission control`. If a user just wants to go right to work, he or she can go right to `mission control` and start working and everything will be saved. In the future, there will be a component to show the name and the user can change it from the auto-generated name, if desired.