### PR TITLE
Redux dev tools support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules/
 coverage/
 yarn-error.log
 *.swp
+
+.idea/
+.vscode/

--- a/src/index.js
+++ b/src/index.js
@@ -16,9 +16,8 @@ import RoverList from './containers/RoverList';
 import Accounts from './containers/Accounts/Base';
 import MissionControl from './containers/MissionControl';
 
-/* eslint-disable no-underscore-dangle */
+/* eslint-disable-next-line no-underscore-dangle */
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
-/* eslint-enable */
 const reduxMiddleware = composeEnhancers(
   applyMiddleware(
     thunk,

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { render } from 'react-dom';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import { CookiesProvider } from 'react-cookie';
-import { createStore, applyMiddleware } from 'redux';
+import { createStore, compose, applyMiddleware } from 'redux';
 import { Provider as ReduxProvider } from 'react-redux';
 import thunk from 'redux-thunk';
 import { createLogger } from 'redux-logger';
@@ -16,10 +16,15 @@ import RoverList from './containers/RoverList';
 import Accounts from './containers/Accounts/Base';
 import MissionControl from './containers/MissionControl';
 
-const reduxMiddleware = applyMiddleware(
-  thunk,
-  createLogger(),
-  promiseMiddleware(),
+/* eslint-disable no-underscore-dangle */
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+/* eslint-enable */
+const reduxMiddleware = composeEnhancers(
+  applyMiddleware(
+    thunk,
+    createLogger(),
+    promiseMiddleware(),
+  ),
 );
 
 const store = createStore(rootReducer, reduxMiddleware);


### PR DESCRIPTION
This adds support for the Redeux Developer Tool Chrome extension. ([Chrome store](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en), [github](https://github.com/zalmoxisus/redux-devtools-extension)).

This allows time-travel debugging.

![image](https://user-images.githubusercontent.com/976857/46907120-e7633b80-cedb-11e8-9141-cf489d18fb41.png)
