### PR TITLE
Login redirect on API auth failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - lts/*
+  - "8"
 script:
   - yarn test
   - yarn lint

--- a/src/actions/__test__/auth.test.js
+++ b/src/actions/__test__/auth.test.js
@@ -1,0 +1,12 @@
+import { updateValidAuth } from '../auth';
+
+
+describe('Auth actions', () => {
+  test('updateValidAuth', () => {
+    const action = updateValidAuth(false);
+    const { type, payload } = action;
+
+    expect(type).toEqual('UPDATE_VALID_AUTH');
+    expect(payload).toEqual(false);
+  });
+});

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -1,0 +1,10 @@
+// actions https://redux.js.org/basics/actions
+// async actions https://redux.js.org/advanced/asyncactions
+
+export const UPDATE_VALID_AUTH = 'UPDATE_VALID_AUTH';
+
+// action creators
+export const updateValidAuth = isValidAuth => ({
+  type: UPDATE_VALID_AUTH,
+  payload: isValidAuth,
+});

--- a/src/components/ProgramName.js
+++ b/src/components/ProgramName.js
@@ -5,6 +5,7 @@ import { hot } from 'react-hot-loader';
 import { withCookies } from 'react-cookie';
 import PropTypes from 'prop-types';
 
+import { updateValidAuth } from '@/actions/auth';
 import { changeName as actionChangeName } from '@/actions/code';
 
 const mapStateToProps = ({ code }) => ({ code });
@@ -15,7 +16,12 @@ const mapDispatchToProps = (dispatch, { cookies }) => ({
         Authorization: `JWT ${cookies.get('auth_jwt')}`,
       },
     });
-    return dispatch(changeNameAction);
+    return dispatch(changeNameAction).catch((error) => {
+      if (error.response.status === 401) {
+        // Authentication is no longer valid
+        dispatch(updateValidAuth(false));
+      }
+    });
   },
 });
 

--- a/src/components/ProtectedRoute.js
+++ b/src/components/ProtectedRoute.js
@@ -4,11 +4,15 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 
-const mapStateToProps = ({ user }) => ({ user });
+const mapStateToProps = ({ auth, user }) => ({ auth, user });
 
 class ProtectedRoute extends Component {
   isAuthenticated = () => {
-    const { user } = this.props;
+    const { auth, user } = this.props;
+
+    if (!auth.isValidAuth) {
+      return false;
+    }
 
     if (user.exp) {
       if (moment().isAfter(moment.unix(user.exp))) {
@@ -39,6 +43,9 @@ class ProtectedRoute extends Component {
 }
 
 ProtectedRoute.propTypes = {
+  auth: PropTypes.shape({
+    isValidAuth: PropTypes.bool,
+  }).isRequired,
   user: PropTypes.shape({
     exp: PropTypes.number,
   }).isRequired,

--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -6,6 +6,7 @@ import { hot } from 'react-hot-loader';
 import { withCookies } from 'react-cookie';
 import Interpreter from 'js-interpreter';
 
+import { updateValidAuth } from '@/actions/auth';
 import {
   updateJsCode as actionUpdateJsCode,
   updateXmlCode as actionUpdateXmlCode,
@@ -33,7 +34,12 @@ const mapDispatchToProps = (dispatch, { cookies }) => ({
         Authorization: `JWT ${cookies.get('auth_jwt')}`,
       },
     });
-    return dispatch(saveProgramAction);
+    return dispatch(saveProgramAction).catch((error) => {
+      if (error.response.status === 401) {
+        // Authentication is no longer valid
+        dispatch(updateValidAuth(false));
+      }
+    });
   },
   createProgram: (name) => {
     const createProgramAction = actionCreateProgram(name, {
@@ -41,7 +47,12 @@ const mapDispatchToProps = (dispatch, { cookies }) => ({
         Authorization: `JWT ${cookies.get('auth_jwt')}`,
       },
     });
-    return dispatch(createProgramAction);
+    return dispatch(createProgramAction).catch((error) => {
+      if (error.response.status === 401) {
+        // Authentication is no longer valid
+        dispatch(updateValidAuth(false));
+      }
+    });
   },
 });
 

--- a/src/components/__tests__/ProtectedRoute.test.js
+++ b/src/components/__tests__/ProtectedRoute.test.js
@@ -20,6 +20,9 @@ describe('The ProtectedRoute component', () => {
         email: 'testuser@example.com',
         exp: 1540341529,
       },
+      auth: {
+        isValidAuth: true,
+      },
     });
   });
 
@@ -64,6 +67,35 @@ describe('The ProtectedRoute component', () => {
   test('renders redirect when not able to determine authentication status', () => {
     store = mockStore({
       user: {},
+      auth: {
+        isValidAuth: true,
+      },
+    });
+    const wrapper = mount(
+      <MemoryRouter initialEntries={['/']} initialIndex={0}>
+        <Switch>
+          <Route exact path="/accounts/login" />
+          <ProtectedRoute exact path="/" component={TestComponent} store={store} />
+        </Switch>
+      </MemoryRouter>,
+    );
+
+    expect(wrapper.find(TestComponent).exists()).toBe(false);
+    expect(wrapper.find(Route).exists()).toBe(true);
+    expect(wrapper.find(Route).prop('path')).toBe('/accounts/login');
+  });
+
+  test('renders redirect when invalid auth', () => {
+    store = mockStore({
+      user: {
+        id: 1,
+        username: 'testuser',
+        email: 'testuser@example.com',
+        exp: 1540341529,
+      },
+      auth: {
+        isValidAuth: false,
+      },
     });
     const wrapper = mount(
       <MemoryRouter initialEntries={['/']} initialIndex={0}>

--- a/src/components/__tests__/__snapshots__/Workspace.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Workspace.test.js.snap
@@ -46,27 +46,27 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
         "results": Array [
           Object {
             "isThrow": false,
-            "value": undefined,
+            "value": Promise {},
           },
           Object {
             "isThrow": false,
-            "value": undefined,
+            "value": Promise {},
           },
           Object {
             "isThrow": false,
-            "value": undefined,
+            "value": Promise {},
           },
           Object {
             "isThrow": false,
-            "value": undefined,
+            "value": Promise {},
           },
           Object {
             "isThrow": false,
-            "value": undefined,
+            "value": Promise {},
           },
           Object {
             "isThrow": false,
-            "value": undefined,
+            "value": Promise {},
           },
         ],
       },
@@ -133,27 +133,27 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
           "results": Array [
             Object {
               "isThrow": false,
-              "value": undefined,
+              "value": Promise {},
             },
             Object {
               "isThrow": false,
-              "value": undefined,
+              "value": Promise {},
             },
             Object {
               "isThrow": false,
-              "value": undefined,
+              "value": Promise {},
             },
             Object {
               "isThrow": false,
-              "value": undefined,
+              "value": Promise {},
             },
             Object {
               "isThrow": false,
-              "value": undefined,
+              "value": Promise {},
             },
             Object {
               "isThrow": false,
-              "value": undefined,
+              "value": Promise {},
             },
           ],
         },
@@ -230,27 +230,27 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
             "results": Array [
               Object {
                 "isThrow": false,
-                "value": undefined,
+                "value": Promise {},
               },
               Object {
                 "isThrow": false,
-                "value": undefined,
+                "value": Promise {},
               },
               Object {
                 "isThrow": false,
-                "value": undefined,
+                "value": Promise {},
               },
               Object {
                 "isThrow": false,
-                "value": undefined,
+                "value": Promise {},
               },
               Object {
                 "isThrow": false,
-                "value": undefined,
+                "value": Promise {},
               },
               Object {
                 "isThrow": false,
-                "value": undefined,
+                "value": Promise {},
               },
             ],
           },
@@ -313,27 +313,27 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
               "results": Array [
                 Object {
                   "isThrow": false,
-                  "value": undefined,
+                  "value": Promise {},
                 },
                 Object {
                   "isThrow": false,
-                  "value": undefined,
+                  "value": Promise {},
                 },
                 Object {
                   "isThrow": false,
-                  "value": undefined,
+                  "value": Promise {},
                 },
                 Object {
                   "isThrow": false,
-                  "value": undefined,
+                  "value": Promise {},
                 },
                 Object {
                   "isThrow": false,
-                  "value": undefined,
+                  "value": Promise {},
                 },
                 Object {
                   "isThrow": false,
-                  "value": undefined,
+                  "value": Promise {},
                 },
               ],
             },

--- a/src/containers/Accounts/Login.js
+++ b/src/containers/Accounts/Login.js
@@ -16,10 +16,12 @@ import PropTypes from 'prop-types';
 import { withCookies, Cookies } from 'react-cookie';
 import jwtDecode from 'jwt-decode';
 
+import { updateValidAuth as actionUpdateValidAuth } from '@/actions/auth';
 import { updateUser as actionUpdateUser } from '@/actions/user';
 
 const mapDispatchToProps = dispatch => ({
   updateUser: data => dispatch(actionUpdateUser(data)),
+  updateValidAuth: isValidAuth => dispatch(actionUpdateValidAuth(isValidAuth)),
 });
 
 class Login extends Component {
@@ -36,7 +38,7 @@ class Login extends Component {
   }
 
   basicLogin = () => {
-    const { cookies, updateUser } = this.props;
+    const { cookies, updateUser, updateValidAuth } = this.props;
     const { username, password } = this.state;
 
     return axios.post('/api/api-token-auth/', {
@@ -46,6 +48,7 @@ class Login extends Component {
       .then((response) => {
         updateUser(jwtDecode(response.data.token));
         cookies.set('auth_jwt', response.data.token, { path: '/' });
+        updateValidAuth(true);
         this.setState({
           basicSuccess: true,
         });
@@ -192,6 +195,7 @@ Sign In
 Login.propTypes = {
   cookies: PropTypes.instanceOf(Cookies).isRequired,
   updateUser: PropTypes.func.isRequired,
+  updateValidAuth: PropTypes.func.isRequired,
 };
 
 export default withCookies(connect(null, mapDispatchToProps)(Login));

--- a/src/containers/Accounts/LoginCallback.js
+++ b/src/containers/Accounts/LoginCallback.js
@@ -8,10 +8,12 @@ import PropTypes from 'prop-types';
 import { withCookies, Cookies } from 'react-cookie';
 import jwtDecode from 'jwt-decode';
 
+import { updateValidAuth as actionUpdateValidAuth } from '@/actions/auth';
 import { updateUser as actionUpdateUser } from '@/actions/user';
 
 const mapDispatchToProps = dispatch => ({
   updateUser: data => dispatch(actionUpdateUser(data)),
+  updateValidAuth: isValidAuth => dispatch(actionUpdateValidAuth(isValidAuth)),
 });
 
 class LoginCallback extends Component {
@@ -26,7 +28,7 @@ class LoginCallback extends Component {
 
   componentDidMount() {
     const {
-      cookies, location, match, updateUser,
+      cookies, location, match, updateUser, updateValidAuth,
     } = this.props;
     const queryParams = queryString.parse(location.search);
 
@@ -37,6 +39,7 @@ class LoginCallback extends Component {
       .then((response) => {
         updateUser(jwtDecode(response.data.token));
         cookies.set('auth_jwt', response.data.token, { path: '/' });
+        updateValidAuth(true);
         this.setState({
           loading: false,
           loginSuccess: true,
@@ -84,6 +87,7 @@ LoginCallback.propTypes = {
     }).isRequired,
   }).isRequired,
   updateUser: PropTypes.func.isRequired,
+  updateValidAuth: PropTypes.func.isRequired,
 };
 
 export default withCookies(connect(null, mapDispatchToProps)(LoginCallback));

--- a/src/containers/Accounts/__tests__/Login.test.js
+++ b/src/containers/Accounts/__tests__/Login.test.js
@@ -8,6 +8,7 @@ import MockAdapter from 'axios-mock-adapter';
 import configureStore from 'redux-mock-store';
 import jwtDecode from 'jwt-decode';
 
+import { updateValidAuth } from '@/actions/auth';
 import { updateUser } from '@/actions/user';
 
 import Login from '../Login';
@@ -121,6 +122,7 @@ test('Login redirects to root after basic login success', async () => {
   expect(cookies.get('auth_jwt')).toBe(token);
   expect(wrapper.find(Redirect).exists()).toBe(true);
   expect(store.dispatch).toHaveBeenCalledWith(updateUser(jwtDecode(token)));
+  expect(store.dispatch).toHaveBeenCalledWith(updateValidAuth(true));
 
   cookies.remove('auth_jwt');
 });

--- a/src/containers/Accounts/__tests__/LoginCallback.test.js
+++ b/src/containers/Accounts/__tests__/LoginCallback.test.js
@@ -8,6 +8,7 @@ import MockAdapter from 'axios-mock-adapter';
 import configureStore from 'redux-mock-store';
 import jwtDecode from 'jwt-decode';
 
+import { updateValidAuth } from '@/actions/auth';
 import { updateUser } from '@/actions/user';
 
 import LoginCallback from '../LoginCallback';
@@ -100,4 +101,5 @@ test('LoginCallback redirects to root after success', async () => {
   expect(wrapper.find(Loader).exists()).toBe(false);
   expect(cookies.get('auth_jwt')).toBe(token);
   expect(store.dispatch).toHaveBeenCalledWith(updateUser(jwtDecode(token)));
+  expect(store.dispatch).toHaveBeenCalledWith(updateValidAuth(true));
 });

--- a/src/containers/Accounts/__tests__/__snapshots__/Login.test.js.snap
+++ b/src/containers/Accounts/__tests__/__snapshots__/Login.test.js.snap
@@ -32,6 +32,7 @@ ShallowWrapper {
       }
     }
     updateUser={[Function]}
+    updateValidAuth={[Function]}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],

--- a/src/containers/RoverList.js
+++ b/src/containers/RoverList.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { hot } from 'react-hot-loader';
 import { withCookies, Cookies } from 'react-cookie';
 import { fetchRovers } from '../actions/rover';
+import { updateValidAuth } from '../actions/auth';
 import RoverList from '../components/RoverList';
 
 const mapStateToProps = ({ rover }) => ({ ...rover });
@@ -13,7 +14,12 @@ const mapDispatchToProps = (dispatch, { cookies }) => ({
         Authorization: `JWT ${cookies.get('auth_jwt')}`,
       },
     });
-    return dispatch(fetchRoversAction);
+    return dispatch(fetchRoversAction).catch((error) => {
+      if (error.response.status === 401) {
+        // Authentication is no longer valid
+        dispatch(updateValidAuth(false));
+      }
+    });
   },
 });
 

--- a/src/reducers/__tests__/auth.test.js
+++ b/src/reducers/__tests__/auth.test.js
@@ -1,0 +1,20 @@
+import reducer from '../auth';
+import { UPDATE_VALID_AUTH } from '../../actions/auth';
+
+describe('The auth reducer', () => {
+  test('should handle UPDATE_VALID_AUTH', () => {
+    expect(
+      reducer({}, {
+        type: UPDATE_VALID_AUTH,
+        payload: false,
+      }),
+    ).toEqual({
+      isValidAuth: false,
+    });
+  });
+
+  test('should return unmodified state for an unhandled action type', () => {
+    const state = { hello: 'world' };
+    expect(reducer(state, { type: 'FAKE_ACTION' })).toEqual(state);
+  });
+});

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -1,0 +1,18 @@
+import { UPDATE_VALID_AUTH } from '../actions/auth';
+
+export default function auth(
+  state = {
+    isValidAuth: true,
+  },
+  action,
+) {
+  switch (action.type) {
+    case UPDATE_VALID_AUTH:
+      return {
+        ...state,
+        isValidAuth: action.payload,
+      };
+    default:
+      return state;
+  }
+}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,4 +1,5 @@
 import { combineReducers } from 'redux';
+import auth from './auth';
 import code from './code';
 import console from './console';
 import rover from './rover';
@@ -6,6 +7,7 @@ import sensor from './sensor';
 import user from './user';
 
 export default combineReducers({
+  auth,
   code,
   console,
   rover,


### PR DESCRIPTION
Closes #23 

When a `401` is received from the API, redirect to the login page as the token has expired or is no longer valid.
This can be tested by going to mission control, clearing cookies, and trying to modify the program or the program name.