### PR TITLE
Fix mission control layout

### DIFF
--- a/src/components/CodeViewer.js
+++ b/src/components/CodeViewer.js
@@ -30,7 +30,7 @@ class CodeViewer extends Component {
         closeIcon
         dimmer="blurring"
         trigger={(
-          <Button>
+          <Button primary>
             { children }
           </Button>
         )}

--- a/src/components/Console.js
+++ b/src/components/Console.js
@@ -44,7 +44,7 @@ class Console extends Component {
           }
           <div ref={this.bottomRef} />
         </div>
-        <Button onClick={this.handleClear} style={{ marginTop: '10px' }}>
+        <Button primary onClick={this.handleClear} style={{ marginTop: '10px' }}>
           Clear
         </Button>
       </Fragment>

--- a/src/components/__tests__/__snapshots__/CodeViewer.test.js.snap
+++ b/src/components/__tests__/__snapshots__/CodeViewer.test.js.snap
@@ -63,6 +63,7 @@ exports[`The CodeViewer component handles blank code with no errors 1`] = `
       trigger={
         <Button
           as="button"
+          primary={true}
           role="button"
         >
           Show Me The Code!
@@ -84,6 +85,7 @@ exports[`The CodeViewer component handles blank code with no errors 1`] = `
         trigger={
           <Button
             as="button"
+            primary={true}
             role="button"
           >
             Show Me The Code!
@@ -100,10 +102,11 @@ exports[`The CodeViewer component handles blank code with no errors 1`] = `
             onFocus={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            primary={true}
             role="button"
           >
             <button
-              className="ui button"
+              className="ui primary button"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -184,6 +187,7 @@ exports[`The CodeViewer component renders on the page with no errors 1`] = `
       trigger={
         <Button
           as="button"
+          primary={true}
           role="button"
         >
           Show Me The Code!
@@ -205,6 +209,7 @@ exports[`The CodeViewer component renders on the page with no errors 1`] = `
         trigger={
           <Button
             as="button"
+            primary={true}
             role="button"
           >
             Show Me The Code!
@@ -221,10 +226,11 @@ exports[`The CodeViewer component renders on the page with no errors 1`] = `
             onFocus={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            primary={true}
             role="button"
           >
             <button
-              className="ui button"
+              className="ui primary button"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}

--- a/src/components/__tests__/__snapshots__/Console.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Console.test.js.snap
@@ -78,6 +78,7 @@ exports[`The Console component renders on the page with no errors 1`] = `
     <Button
       as="button"
       onClick={[Function]}
+      primary={true}
       role="button"
       style={
         Object {
@@ -86,7 +87,7 @@ exports[`The Console component renders on the page with no errors 1`] = `
       }
     >
       <button
-        className="ui button"
+        className="ui primary button"
         onClick={[Function]}
         role="button"
         style={

--- a/src/containers/MissionControl.js
+++ b/src/containers/MissionControl.js
@@ -1,7 +1,11 @@
 import React from 'react';
-import { Button, Grid } from 'semantic-ui-react';
+import {
+  Divider,
+  Grid,
+  Header,
+  Segment,
+} from 'semantic-ui-react';
 import { hot } from 'react-hot-loader';
-import { Link } from 'react-router-dom';
 
 import CodeViewer from '@/components/CodeViewer';
 import Console from '@/components/Console';
@@ -11,38 +15,44 @@ import ProgramName from '@/components/ProgramName';
 import Workspace from '@/components/Workspace';
 
 const MissionControl = () => (
-  <Grid columns={16} divided style={{ height: '100vh' }}>
+  <Grid style={{ height: '100vh' }}>
     <Grid.Row>
-      <Grid.Column width={10}>
+      <Grid.Column width={13}>
         <Workspace>
           <Control />
         </Workspace>
       </Grid.Column>
       <Grid.Column width={3}>
         <Grid.Row>
-          <ProgramName />
+          <Segment basic compact>
+            <ProgramName />
+          </Segment>
         </Grid.Row>
-        <hr />
+        <Divider />
         <Grid.Row>
-          <CodeViewer>
-            Show Me The Code!
-          </CodeViewer>
+          <Header as="h2" textAlign="center">
+            Sensors
+          </Header>
+          <Segment raised style={{ margin: '10px' }}>
+            <Indicator />
+          </Segment>
         </Grid.Row>
-        <hr />
+        <Divider />
         <Grid.Row>
-          <Link to="/">
-            <Button>
-              Home
-            </Button>
-          </Link>
+          <Header as="h2" textAlign="center">
+            Debug Console
+          </Header>
+          <Segment style={{ margin: '10px' }}>
+            <Console />
+          </Segment>
         </Grid.Row>
-      </Grid.Column>
-      <Grid.Column width={3}>
+        <Divider />
         <Grid.Row>
-          <Console />
-        </Grid.Row>
-        <Grid.Row>
-          <Indicator />
+          <Segment basic compact>
+            <CodeViewer>
+              Show Me The Code!
+            </CodeViewer>
+          </Segment>
         </Grid.Row>
       </Grid.Column>
     </Grid.Row>

--- a/src/containers/__tests__/__snapshots__/MissionControl.test.js.snap
+++ b/src/containers/__tests__/__snapshots__/MissionControl.test.js.snap
@@ -14,8 +14,6 @@ exports[`The MissionControl container renders on the page with no errors 1`] = `
   }
 >
   <Grid
-    columns={16}
-    divided={true}
     style={
       Object {
         "height": "100vh",
@@ -23,7 +21,7 @@ exports[`The MissionControl container renders on the page with no errors 1`] = `
     }
   >
     <div
-      className="ui divided sixteen column grid"
+      className="ui grid"
       style={
         Object {
           "height": "100vh",
@@ -35,10 +33,10 @@ exports[`The MissionControl container renders on the page with no errors 1`] = `
           className="row"
         >
           <GridColumn
-            width={10}
+            width={13}
           >
             <div
-              className="ten wide column"
+              className="thirteen wide column"
             >
               <Component>
                 <div />
@@ -55,74 +53,124 @@ exports[`The MissionControl container renders on the page with no errors 1`] = `
                 <div
                   className="row"
                 >
-                  <Component>
-                    <div />
-                  </Component>
-                </div>
-              </GridRow>
-              <hr />
-              <GridRow>
-                <div
-                  className="row"
-                >
-                  <Component>
-                    <div />
-                  </Component>
-                </div>
-              </GridRow>
-              <hr />
-              <GridRow>
-                <div
-                  className="row"
-                >
-                  <Link
-                    replace={false}
-                    to="/"
+                  <Segment
+                    basic={true}
+                    compact={true}
                   >
-                    <a
-                      href="/"
-                      onClick={[Function]}
+                    <div
+                      className="ui basic compact segment"
                     >
-                      <Button
-                        as="button"
-                        role="button"
-                      >
-                        <button
-                          className="ui button"
-                          onClick={[Function]}
-                          role="button"
-                        >
-                          Home
-                        </button>
-                      </Button>
-                    </a>
-                  </Link>
+                      <Component>
+                        <div />
+                      </Component>
+                    </div>
+                  </Segment>
                 </div>
               </GridRow>
-            </div>
-          </GridColumn>
-          <GridColumn
-            width={3}
-          >
-            <div
-              className="three wide column"
-            >
+              <Divider>
+                <div
+                  className="ui divider"
+                />
+              </Divider>
               <GridRow>
                 <div
                   className="row"
                 >
-                  <Component>
-                    <div />
-                  </Component>
+                  <Header
+                    as="h2"
+                    textAlign="center"
+                  >
+                    <h2
+                      className="ui center aligned header"
+                    >
+                      Sensors
+                    </h2>
+                  </Header>
+                  <Segment
+                    raised={true}
+                    style={
+                      Object {
+                        "margin": "10px",
+                      }
+                    }
+                  >
+                    <div
+                      className="ui raised segment"
+                      style={
+                        Object {
+                          "margin": "10px",
+                        }
+                      }
+                    >
+                      <Component>
+                        <div />
+                      </Component>
+                    </div>
+                  </Segment>
                 </div>
               </GridRow>
+              <Divider>
+                <div
+                  className="ui divider"
+                />
+              </Divider>
               <GridRow>
                 <div
                   className="row"
                 >
-                  <Component>
-                    <div />
-                  </Component>
+                  <Header
+                    as="h2"
+                    textAlign="center"
+                  >
+                    <h2
+                      className="ui center aligned header"
+                    >
+                      Debug Console
+                    </h2>
+                  </Header>
+                  <Segment
+                    style={
+                      Object {
+                        "margin": "10px",
+                      }
+                    }
+                  >
+                    <div
+                      className="ui segment"
+                      style={
+                        Object {
+                          "margin": "10px",
+                        }
+                      }
+                    >
+                      <Component>
+                        <div />
+                      </Component>
+                    </div>
+                  </Segment>
+                </div>
+              </GridRow>
+              <Divider>
+                <div
+                  className="ui divider"
+                />
+              </Divider>
+              <GridRow>
+                <div
+                  className="row"
+                >
+                  <Segment
+                    basic={true}
+                    compact={true}
+                  >
+                    <div
+                      className="ui basic compact segment"
+                    >
+                      <Component>
+                        <div />
+                      </Component>
+                    </div>
+                  </Segment>
                 </div>
               </GridRow>
             </div>


### PR DESCRIPTION
Provides more space for the workspace and uses some semantic components for better look. The buttons are now set to `primary` for when the theme is setup. Once the navbar is setup, the name and code viewer buttons might work better there.
![image](https://user-images.githubusercontent.com/1184314/52168908-3557b580-26fe-11e9-87af-70b600ce817b.png)
