### PR TITLE
Add node version requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains the [react](https://reactjs.org/) application frontend 
 Requirements
 ============
 
-[nodejs] LTS version v8.x is required. Newer versions may have issues.
+[nodejs](https://nodejs.org) LTS version v8.x is required. Newer versions may have issues.
 
 [yarn](https://yarnpkg.com/) is required for installing dependencies. Instructions for installing `yarn` can be found [here](https://yarnpkg.com/lang/en/docs/install/).
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains the [react](https://reactjs.org/) application frontend 
 Requirements
 ============
 
+[nodejs] LTS version v8.x is required. Newer versions may have issues.
+
 [yarn](https://yarnpkg.com/) is required for installing dependencies. Instructions for installing `yarn` can be found [here](https://yarnpkg.com/lang/en/docs/install/).
 
 Dependencies


### PR DESCRIPTION
Taylor ran into this node version issue, so I think we should add it to the README. See PR #21 for discussion of why we need this older LTS version for now.