### PR TITLE
User settings

### DIFF
--- a/src/actions/__test__/user.test.js
+++ b/src/actions/__test__/user.test.js
@@ -1,4 +1,6 @@
-import { updateUser } from '../user';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { editUserUsername, editUserPassword, updateUser } from '../user';
 
 
 describe('User actions', () => {
@@ -14,5 +16,41 @@ describe('User actions', () => {
 
     expect(type).toEqual('UPDATE_USER');
     expect(payload).toEqual(user);
+  });
+  test('editUserUsername', async () => {
+    const mock = new MockAdapter(axios);
+    const username = 'test_username';
+    const user = {
+      pk: 1,
+      username,
+      email: 'test@example.com',
+    };
+
+    mock.onPut('/jwt/auth/user/', {
+      username,
+    }).reply(200, user);
+
+    const action = editUserUsername(username);
+    const { type } = action;
+    const payload = await action.payload;
+
+    expect(type).toEqual('EDIT_USER_USERNAME');
+    expect(payload).toEqual(user);
+  });
+  test('editUserPassword', async () => {
+    const mock = new MockAdapter(axios);
+    const password = 'password123';
+
+    mock.onPost('/jwt/auth/password/change/', {
+      new_password1: password,
+      new_password2: password,
+    }).reply(200, 'Password changed');
+
+    const action = editUserPassword(password);
+    const { type } = action;
+    const payload = await action.payload;
+
+    expect(type).toEqual('EDIT_USER_PASSWORD');
+    expect(payload).toEqual('Password changed');
   });
 });

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -1,10 +1,36 @@
 // actions https://redux.js.org/basics/actions
 // async actions https://redux.js.org/advanced/asyncactions
+import axios from 'axios';
 
 export const UPDATE_USER = 'UPDATE_USER';
+export const EDIT_USER_USERNAME = 'EDIT_USER_USERNAME';
+export const EDIT_USER_USERNAME_FULFILLED = `${EDIT_USER_USERNAME}_FULFILLED`;
+export const EDIT_USER_USERNAME_REJECTED = `${EDIT_USER_USERNAME}_REJECTED`;
+export const EDIT_USER_PASSWORD = 'EDIT_USER_PASSWORD';
+export const EDIT_USER_PASSWORD_FULFILLED = `${EDIT_USER_PASSWORD}_FULFILLED`;
+export const EDIT_USER_PASSWORD_REJECTED = `${EDIT_USER_PASSWORD}_REJECTED`;
 
 // action creators
 export const updateUser = data => ({
   type: UPDATE_USER,
   payload: data,
+});
+
+export const editUserUsername = (username, xhrOptions) => ({
+  type: EDIT_USER_USERNAME,
+  payload: axios.put('/jwt/auth/user/', { username }, xhrOptions)
+    .then(({ data }) => (
+      data
+    )),
+});
+
+export const editUserPassword = (password, xhrOptions) => ({
+  type: EDIT_USER_PASSWORD,
+  payload: axios.post('/jwt/auth/password/change/', {
+    new_password1: password,
+    new_password2: password,
+  }, xhrOptions)
+    .then(({ data }) => (
+      data
+    )),
 });

--- a/src/components/TopNav.js
+++ b/src/components/TopNav.js
@@ -52,7 +52,7 @@ class TopNav extends Component {
           <Menu.Menu position="right">
             <Dropdown item text={userName}>
               <Dropdown.Menu>
-                <Dropdown.Item as={Link} to="/accounts/settings">
+                <Dropdown.Item as={Link} to="/user/settings">
                   Settings
                 </Dropdown.Item>
                 <Dropdown.Divider />

--- a/src/components/UserSetting.js
+++ b/src/components/UserSetting.js
@@ -1,0 +1,222 @@
+import React, { Component, Fragment } from 'react';
+import { Redirect } from 'react-router-dom';
+import {
+  Form,
+  Grid,
+  Header,
+  Icon,
+  List,
+  Message,
+  Segment,
+} from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+
+class UserSetting extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      username: null,
+      password1: null,
+      password2: null,
+      saveSuccess: false,
+      usernameError: null,
+      password1Error: null,
+      password2Error: null,
+      nonFieldError: null,
+    };
+  }
+
+  errorMessage = () => {
+    const {
+      usernameError,
+      password1Error,
+      password2Error,
+      nonFieldError,
+    } = this.state;
+
+    const errors = [
+      usernameError,
+      password1Error,
+      password2Error,
+      nonFieldError,
+    ];
+
+    const activeErrors = errors.filter(Boolean);
+
+    if (activeErrors.length === 0) {
+      return (null);
+    }
+
+    const messages = [];
+
+    activeErrors.forEach((error) => {
+      error.forEach((message) => {
+        messages.push(message);
+      });
+    });
+
+    /* eslint react/no-array-index-key: 0 */
+    return (
+      <Grid.Row>
+        <Message negative>
+          <List bulleted>
+            {
+              messages.map((message, i) => (
+                <List.Item key={i}>
+                  {message}
+                </List.Item>
+              ))
+            }
+          </List>
+        </Message>
+      </Grid.Row>
+    );
+  }
+
+  saveUserUsername = () => {
+    const { editUserUsername } = this.props;
+    const { username } = this.state;
+
+    return editUserUsername(username)
+      .then(() => this.setState({ saveSuccess: true }))
+      .catch(error => this.setState({ usernameError: error.response.data.username }));
+  }
+
+  saveUserPassword = () => {
+    const { editUserPassword } = this.props;
+    const { password1, password2 } = this.state;
+
+    if (password1 !== password2) {
+      this.setState({
+        password1Error: ['Passwords must match'],
+        password2Error: ['Passwords must match'],
+      });
+      return null;
+    }
+
+    return editUserPassword(password1)
+      .then(() => this.setState({ saveSuccess: true }))
+      .catch((error) => {
+        this.setState({
+          password1Error: error.response.data.new_password1,
+          password2Error: error.response.data.new_password2,
+        });
+      });
+  }
+
+  handleChange = (e, { name, value }) => this.setState({ [name]: value })
+
+  render() {
+    const { user } = this.props;
+    const {
+      saveSuccess,
+      usernameError,
+      password1Error,
+      password2Error,
+    } = this.state;
+
+    return (
+      <Grid centered divided="vertically" columns={16}>
+        <Grid.Row>
+          <Header as="h1">
+            <Icon name="settings" />
+            <Header.Content>
+              My Settings
+            </Header.Content>
+          </Header>
+        </Grid.Row>
+        <Grid.Row>
+          <Grid.Column width={5}>
+            {
+              saveSuccess ? (
+                <Redirect to="/accounts/login" />
+              ) : (null)
+            }
+            {
+              <Fragment>
+                <Message info>
+                  Changing any of these settings requires signing back in.
+                </Message>
+                {this.errorMessage()}
+                <Grid.Row style={{ paddingBottom: '10px', paddingTop: '10px' }}>
+                  <Segment raised>
+                    <Header dividing>
+                      <Icon name="user" />
+                      <Header.Content>
+                        Change Username
+                      </Header.Content>
+                    </Header>
+                    <Form key={user.user_id} onSubmit={this.saveUserUsername}>
+                      <Form.Input
+                        inline
+                        label="Username:"
+                        name="username"
+                        error={usernameError}
+                        defaultValue={user.username}
+                        onChange={this.handleChange}
+                        required
+                      />
+                      <Form.Button primary>
+                        Save
+                      </Form.Button>
+                    </Form>
+                  </Segment>
+                </Grid.Row>
+                {
+                  !user.isSocial ? (
+                    <Grid.Row>
+                      <Segment raised>
+                        <Header dividing>
+                          <Icon name="lock" />
+                          <Header.Content>
+                            Change Password
+                          </Header.Content>
+                        </Header>
+                        <Form key={user.user_id} onSubmit={this.saveUserPassword}>
+                          <Form.Group widths="equal">
+                            <Form.Input
+                              label="New Password:"
+                              name="password1"
+                              error={password1Error}
+                              onChange={this.handleChange}
+                              type="password"
+                              required
+                            />
+                            <Form.Input
+                              label="Verify:"
+                              name="password2"
+                              error={password2Error}
+                              onChange={this.handleChange}
+                              type="password"
+                              required
+                            />
+                          </Form.Group>
+                          <Form.Button primary>
+                            Save
+                          </Form.Button>
+                        </Form>
+                      </Segment>
+                    </Grid.Row>
+                  ) : (null)
+                }
+              </Fragment>
+            }
+          </Grid.Column>
+        </Grid.Row>
+      </Grid>
+    );
+  }
+}
+
+UserSetting.propTypes = {
+  editUserUsername: PropTypes.func.isRequired,
+  editUserPassword: PropTypes.func.isRequired,
+  user: PropTypes.shape({
+    user_id: PropTypes.number.isRequired,
+    username: PropTypes.string.isRequired,
+    email: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default UserSetting;

--- a/src/components/UserSetting.js
+++ b/src/components/UserSetting.js
@@ -15,8 +15,10 @@ class UserSetting extends Component {
   constructor(props) {
     super(props);
 
+    const { user } = props;
+
     this.state = {
-      username: null,
+      username: user.username,
       password1: null,
       password2: null,
       saveSuccess: false,

--- a/src/components/__tests__/UserSetting.test.js
+++ b/src/components/__tests__/UserSetting.test.js
@@ -1,0 +1,215 @@
+import React from 'react';
+import { Redirect } from 'react-router-dom';
+import { Form, Message } from 'semantic-ui-react';
+import { shallow } from 'enzyme';
+import UserSetting from '../UserSetting';
+
+let editUserPassword;
+let editUserUsername;
+
+describe('The UserSetting component', () => {
+  beforeEach(() => {
+    editUserPassword = jest.fn(() => Promise.resolve({}));
+    editUserUsername = jest.fn(() => Promise.resolve({}));
+  });
+
+  test('renders on the page with no errors', () => {
+    const user = {
+      user_id: 1,
+      username: 'testuser',
+      email: 'test@example.com',
+      isSocial: false,
+    };
+    const wrapper = shallow(
+      <UserSetting
+        user={user}
+        editUserPassword={editUserPassword}
+        editUserUsername={editUserUsername}
+      />,
+    );
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find({ type: 'password' }).length).toBe(2);
+  });
+
+  test('hides password edit when social user', () => {
+    const user = {
+      user_id: 1,
+      username: 'testuser',
+      email: 'test@example.com',
+      isSocial: true,
+    };
+    const wrapper = shallow(
+      <UserSetting
+        user={user}
+        editUserPassword={editUserPassword}
+        editUserUsername={editUserUsername}
+      />,
+    );
+    expect(wrapper.find({ type: 'password' }).exists()).toBe(false);
+  });
+
+  test('saves user username', async () => {
+    const user = {
+      user_id: 1,
+      username: 'testuser',
+      email: 'test@example.com',
+    };
+    const wrapper = shallow(
+      <UserSetting
+        user={user}
+        editUserPassword={editUserPassword}
+        editUserUsername={editUserUsername}
+      />,
+    );
+
+    wrapper.find(Form.Input).first().simulate('change', null, {
+      name: 'username',
+      value: 'newuser',
+    });
+    wrapper.update();
+    await wrapper.instance().saveUserUsername();
+
+    expect(wrapper.state('saveSuccess')).toBe(true);
+    expect(wrapper.state('usernameError')).toBeNull();
+    expect(wrapper.find(Redirect).exists()).toBe(true);
+    expect(wrapper.find(Redirect).prop('to')).toBe('/accounts/login');
+    expect(editUserPassword).not.toHaveBeenCalled();
+    expect(editUserUsername).toHaveBeenCalledWith('newuser');
+  });
+
+  test('saves user password', async () => {
+    const user = {
+      user_id: 1,
+      username: 'testuser',
+      email: 'test@example.com',
+    };
+    const wrapper = shallow(
+      <UserSetting
+        user={user}
+        editUserPassword={editUserPassword}
+        editUserUsername={editUserUsername}
+      />,
+    );
+
+    wrapper.find(Form.Input).at(1).simulate('change', null, {
+      name: 'password1',
+      value: 'password',
+    });
+    wrapper.find(Form.Input).at(2).simulate('change', null, {
+      name: 'password2',
+      value: 'password',
+    });
+    wrapper.update();
+    await wrapper.instance().saveUserPassword();
+
+    expect(wrapper.state('saveSuccess')).toBe(true);
+    expect(wrapper.state('password1Error')).toBeNull();
+    expect(wrapper.state('password2Error')).toBeNull();
+    expect(wrapper.find(Redirect).exists()).toBe(true);
+    expect(wrapper.find(Redirect).prop('to')).toBe('/accounts/login');
+    expect(editUserUsername).not.toHaveBeenCalled();
+    expect(editUserPassword).toHaveBeenCalledWith('password');
+  });
+
+  test('errors on password mismatch', async () => {
+    const user = {
+      user_id: 1,
+      username: 'testuser',
+      email: 'test@example.com',
+    };
+    const wrapper = shallow(
+      <UserSetting
+        user={user}
+        editUserPassword={editUserPassword}
+        editUserUsername={editUserUsername}
+      />,
+    );
+
+    wrapper.find(Form.Input).at(1).simulate('change', null, {
+      name: 'password1',
+      value: '1234',
+    });
+    wrapper.find(Form.Input).at(2).simulate('change', null, {
+      name: 'password2',
+      value: '5678',
+    });
+    wrapper.update();
+    await wrapper.instance().saveUserPassword();
+
+    expect(wrapper.state('saveSuccess')).toBe(false);
+    expect(wrapper.state('password1Error')).toEqual(['Passwords must match']);
+    expect(wrapper.state('password2Error')).toEqual(['Passwords must match']);
+    expect(wrapper.find(Message).exists()).toBe(true);
+    expect(wrapper.find(Message).last().prop('negative')).toBe(true);
+    expect(editUserUsername).not.toHaveBeenCalled();
+    expect(editUserPassword).not.toHaveBeenCalled();
+  });
+
+  test('displays error on username save error', async () => {
+    const user = {
+      user_id: 1,
+      username: 'testuser',
+      email: 'test@example.com',
+    };
+    const error = new Error();
+    error.response = {
+      status: 400,
+      data: {
+        username: ['Username taken'],
+      },
+    };
+    editUserUsername = jest.fn(() => Promise.reject(error));
+    const wrapper = shallow(
+      <UserSetting
+        user={user}
+        editUserPassword={editUserPassword}
+        editUserUsername={editUserUsername}
+      />,
+    );
+
+    await wrapper.instance().saveUserUsername();
+
+    expect(wrapper.state('saveSuccess')).toBe(false);
+    expect(wrapper.state('usernameError')).toEqual(['Username taken']);
+    expect(wrapper.find(Message).exists()).toBe(true);
+    expect(wrapper.find(Message).last().prop('negative')).toBe(true);
+    expect(wrapper.find(Form.Input).first().prop('error')).not.toBeNull();
+    expect(wrapper.find(Form.Input).at(1).prop('error')).toBeNull();
+    expect(wrapper.find(Form.Input).at(2).prop('error')).toBeNull();
+  });
+
+  test('displays error on password save error', async () => {
+    const user = {
+      user_id: 1,
+      username: 'testuser',
+      email: 'test@example.com',
+    };
+    const error = new Error();
+    error.response = {
+      status: 400,
+      data: {
+        new_password1: ['Too short'],
+        new_password2: ['Too short'],
+      },
+    };
+    editUserPassword = jest.fn(() => Promise.reject(error));
+    const wrapper = shallow(
+      <UserSetting
+        user={user}
+        editUserPassword={editUserPassword}
+        editUserUsername={editUserUsername}
+      />,
+    );
+
+    await wrapper.instance().saveUserPassword();
+
+    expect(wrapper.state('saveSuccess')).toBe(false);
+    expect(wrapper.state('password1Error')).toEqual(['Too short']);
+    expect(wrapper.state('password2Error')).toEqual(['Too short']);
+    expect(wrapper.find(Message).exists()).toBe(true);
+    expect(wrapper.find(Message).last().prop('negative')).toBe(true);
+    expect(wrapper.find(Form.Input).first().prop('error')).toBeNull();
+    expect(wrapper.find(Form.Input).at(1).prop('error')).not.toBeNull();
+    expect(wrapper.find(Form.Input).at(2).prop('error')).not.toBeNull();
+  });
+});

--- a/src/components/__tests__/__snapshots__/TopNav.js.snap
+++ b/src/components/__tests__/__snapshots__/TopNav.js.snap
@@ -89,7 +89,7 @@ ShallowWrapper {
               <DropdownMenu>
                 <DropdownItem
                   as={[Function]}
-                  to="/accounts/settings"
+                  to="/user/settings"
                 >
                   Settings
                 </DropdownItem>
@@ -161,7 +161,7 @@ ShallowWrapper {
                 <DropdownMenu>
                   <DropdownItem
                     as={[Function]}
-                    to="/accounts/settings"
+                    to="/user/settings"
                   >
                     Settings
                   </DropdownItem>
@@ -263,7 +263,7 @@ ShallowWrapper {
                 <DropdownMenu>
                   <DropdownItem
                     as={[Function]}
-                    to="/accounts/settings"
+                    to="/user/settings"
                   >
                     Settings
                   </DropdownItem>
@@ -289,7 +289,7 @@ ShallowWrapper {
                 "children": <DropdownMenu>
                   <DropdownItem
                     as={[Function]}
-                    to="/accounts/settings"
+                    to="/user/settings"
                   >
                     Settings
                   </DropdownItem>
@@ -324,7 +324,7 @@ ShallowWrapper {
                   "children": Array [
                     <DropdownItem
                       as={[Function]}
-                      to="/accounts/settings"
+                      to="/user/settings"
                     >
                       Settings
                     </DropdownItem>,
@@ -346,7 +346,7 @@ ShallowWrapper {
                     "props": Object {
                       "as": [Function],
                       "children": "Settings",
-                      "to": "/accounts/settings",
+                      "to": "/user/settings",
                     },
                     "ref": null,
                     "rendered": "Settings",
@@ -445,7 +445,7 @@ ShallowWrapper {
                 <DropdownMenu>
                   <DropdownItem
                     as={[Function]}
-                    to="/accounts/settings"
+                    to="/user/settings"
                   >
                     Settings
                   </DropdownItem>
@@ -517,7 +517,7 @@ ShallowWrapper {
                   <DropdownMenu>
                     <DropdownItem
                       as={[Function]}
-                      to="/accounts/settings"
+                      to="/user/settings"
                     >
                       Settings
                     </DropdownItem>
@@ -619,7 +619,7 @@ ShallowWrapper {
                   <DropdownMenu>
                     <DropdownItem
                       as={[Function]}
-                      to="/accounts/settings"
+                      to="/user/settings"
                     >
                       Settings
                     </DropdownItem>
@@ -645,7 +645,7 @@ ShallowWrapper {
                   "children": <DropdownMenu>
                     <DropdownItem
                       as={[Function]}
-                      to="/accounts/settings"
+                      to="/user/settings"
                     >
                       Settings
                     </DropdownItem>
@@ -680,7 +680,7 @@ ShallowWrapper {
                     "children": Array [
                       <DropdownItem
                         as={[Function]}
-                        to="/accounts/settings"
+                        to="/user/settings"
                       >
                         Settings
                       </DropdownItem>,
@@ -702,7 +702,7 @@ ShallowWrapper {
                       "props": Object {
                         "as": [Function],
                         "children": "Settings",
-                        "to": "/accounts/settings",
+                        "to": "/user/settings",
                       },
                       "ref": null,
                       "rendered": "Settings",

--- a/src/components/__tests__/__snapshots__/UserSetting.test.js.snap
+++ b/src/components/__tests__/__snapshots__/UserSetting.test.js.snap
@@ -1,0 +1,2221 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The UserSetting component renders on the page with no errors 1`] = `
+ShallowWrapper {
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <UserSetting
+    editUserPassword={[MockFunction]}
+    editUserUsername={[MockFunction]}
+    user={
+      Object {
+        "email": "test@example.com",
+        "isSocial": false,
+        "user_id": 1,
+        "username": "testuser",
+      }
+    }
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "function",
+    "props": Object {
+      "centered": true,
+      "children": Array [
+        <GridRow>
+          <Header
+            as="h1"
+          >
+            <Icon
+              as="i"
+              name="settings"
+            />
+            <HeaderContent>
+              My Settings
+            </HeaderContent>
+          </Header>
+        </GridRow>,
+        <GridRow>
+          <GridColumn
+            width={5}
+          >
+            <React.Fragment>
+              <Message
+                info={true}
+              >
+                Changing any of these settings requires signing back in.
+              </Message>
+              <GridRow
+                style={
+                  Object {
+                    "paddingBottom": "10px",
+                    "paddingTop": "10px",
+                  }
+                }
+              >
+                <Segment
+                  raised={true}
+                >
+                  <Header
+                    dividing={true}
+                  >
+                    <Icon
+                      as="i"
+                      name="user"
+                    />
+                    <HeaderContent>
+                      Change Username
+                    </HeaderContent>
+                  </Header>
+                  <Form
+                    as="form"
+                    onSubmit={[Function]}
+                  >
+                    <FormInput
+                      as={[Function]}
+                      control={[Function]}
+                      defaultValue="testuser"
+                      error={null}
+                      inline={true}
+                      label="Username:"
+                      name="username"
+                      onChange={[Function]}
+                      required={true}
+                    />
+                    <FormButton
+                      as={[Function]}
+                      control={[Function]}
+                      primary={true}
+                    >
+                      Save
+                    </FormButton>
+                  </Form>
+                </Segment>
+              </GridRow>
+              <GridRow>
+                <Segment
+                  raised={true}
+                >
+                  <Header
+                    dividing={true}
+                  >
+                    <Icon
+                      as="i"
+                      name="lock"
+                    />
+                    <HeaderContent>
+                      Change Password
+                    </HeaderContent>
+                  </Header>
+                  <Form
+                    as="form"
+                    onSubmit={[Function]}
+                  >
+                    <FormGroup
+                      widths="equal"
+                    >
+                      <FormInput
+                        as={[Function]}
+                        control={[Function]}
+                        error={null}
+                        label="New Password:"
+                        name="password1"
+                        onChange={[Function]}
+                        required={true}
+                        type="password"
+                      />
+                      <FormInput
+                        as={[Function]}
+                        control={[Function]}
+                        error={null}
+                        label="Verify:"
+                        name="password2"
+                        onChange={[Function]}
+                        required={true}
+                        type="password"
+                      />
+                    </FormGroup>
+                    <FormButton
+                      as={[Function]}
+                      control={[Function]}
+                      primary={true}
+                    >
+                      Save
+                    </FormButton>
+                  </Form>
+                </Segment>
+              </GridRow>
+            </React.Fragment>
+          </GridColumn>
+        </GridRow>,
+      ],
+      "columns": 16,
+      "divided": "vertically",
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "children": <Header
+            as="h1"
+          >
+            <Icon
+              as="i"
+              name="settings"
+            />
+            <HeaderContent>
+              My Settings
+            </HeaderContent>
+          </Header>,
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "as": "h1",
+            "children": Array [
+              <Icon
+                as="i"
+                name="settings"
+              />,
+              <HeaderContent>
+                My Settings
+              </HeaderContent>,
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "as": "i",
+                "name": "settings",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "children": "My Settings",
+              },
+              "ref": null,
+              "rendered": "My Settings",
+              "type": [Function],
+            },
+          ],
+          "type": [Function],
+        },
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "children": <GridColumn
+            width={5}
+          >
+            <React.Fragment>
+              <Message
+                info={true}
+              >
+                Changing any of these settings requires signing back in.
+              </Message>
+              <GridRow
+                style={
+                  Object {
+                    "paddingBottom": "10px",
+                    "paddingTop": "10px",
+                  }
+                }
+              >
+                <Segment
+                  raised={true}
+                >
+                  <Header
+                    dividing={true}
+                  >
+                    <Icon
+                      as="i"
+                      name="user"
+                    />
+                    <HeaderContent>
+                      Change Username
+                    </HeaderContent>
+                  </Header>
+                  <Form
+                    as="form"
+                    onSubmit={[Function]}
+                  >
+                    <FormInput
+                      as={[Function]}
+                      control={[Function]}
+                      defaultValue="testuser"
+                      error={null}
+                      inline={true}
+                      label="Username:"
+                      name="username"
+                      onChange={[Function]}
+                      required={true}
+                    />
+                    <FormButton
+                      as={[Function]}
+                      control={[Function]}
+                      primary={true}
+                    >
+                      Save
+                    </FormButton>
+                  </Form>
+                </Segment>
+              </GridRow>
+              <GridRow>
+                <Segment
+                  raised={true}
+                >
+                  <Header
+                    dividing={true}
+                  >
+                    <Icon
+                      as="i"
+                      name="lock"
+                    />
+                    <HeaderContent>
+                      Change Password
+                    </HeaderContent>
+                  </Header>
+                  <Form
+                    as="form"
+                    onSubmit={[Function]}
+                  >
+                    <FormGroup
+                      widths="equal"
+                    >
+                      <FormInput
+                        as={[Function]}
+                        control={[Function]}
+                        error={null}
+                        label="New Password:"
+                        name="password1"
+                        onChange={[Function]}
+                        required={true}
+                        type="password"
+                      />
+                      <FormInput
+                        as={[Function]}
+                        control={[Function]}
+                        error={null}
+                        label="Verify:"
+                        name="password2"
+                        onChange={[Function]}
+                        required={true}
+                        type="password"
+                      />
+                    </FormGroup>
+                    <FormButton
+                      as={[Function]}
+                      control={[Function]}
+                      primary={true}
+                    >
+                      Save
+                    </FormButton>
+                  </Form>
+                </Segment>
+              </GridRow>
+            </React.Fragment>
+          </GridColumn>,
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "children": Array [
+              null,
+              <React.Fragment>
+                <Message
+                  info={true}
+                >
+                  Changing any of these settings requires signing back in.
+                </Message>
+                <GridRow
+                  style={
+                    Object {
+                      "paddingBottom": "10px",
+                      "paddingTop": "10px",
+                    }
+                  }
+                >
+                  <Segment
+                    raised={true}
+                  >
+                    <Header
+                      dividing={true}
+                    >
+                      <Icon
+                        as="i"
+                        name="user"
+                      />
+                      <HeaderContent>
+                        Change Username
+                      </HeaderContent>
+                    </Header>
+                    <Form
+                      as="form"
+                      onSubmit={[Function]}
+                    >
+                      <FormInput
+                        as={[Function]}
+                        control={[Function]}
+                        defaultValue="testuser"
+                        error={null}
+                        inline={true}
+                        label="Username:"
+                        name="username"
+                        onChange={[Function]}
+                        required={true}
+                      />
+                      <FormButton
+                        as={[Function]}
+                        control={[Function]}
+                        primary={true}
+                      >
+                        Save
+                      </FormButton>
+                    </Form>
+                  </Segment>
+                </GridRow>
+                <GridRow>
+                  <Segment
+                    raised={true}
+                  >
+                    <Header
+                      dividing={true}
+                    >
+                      <Icon
+                        as="i"
+                        name="lock"
+                      />
+                      <HeaderContent>
+                        Change Password
+                      </HeaderContent>
+                    </Header>
+                    <Form
+                      as="form"
+                      onSubmit={[Function]}
+                    >
+                      <FormGroup
+                        widths="equal"
+                      >
+                        <FormInput
+                          as={[Function]}
+                          control={[Function]}
+                          error={null}
+                          label="New Password:"
+                          name="password1"
+                          onChange={[Function]}
+                          required={true}
+                          type="password"
+                        />
+                        <FormInput
+                          as={[Function]}
+                          control={[Function]}
+                          error={null}
+                          label="Verify:"
+                          name="password2"
+                          onChange={[Function]}
+                          required={true}
+                          type="password"
+                        />
+                      </FormGroup>
+                      <FormButton
+                        as={[Function]}
+                        control={[Function]}
+                        primary={true}
+                      >
+                        Save
+                      </FormButton>
+                    </Form>
+                  </Segment>
+                </GridRow>
+              </React.Fragment>,
+            ],
+            "width": 5,
+          },
+          "ref": null,
+          "rendered": Array [
+            null,
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "children": Array [
+                  <Message
+                    info={true}
+                  >
+                    Changing any of these settings requires signing back in.
+                  </Message>,
+                  null,
+                  <GridRow
+                    style={
+                      Object {
+                        "paddingBottom": "10px",
+                        "paddingTop": "10px",
+                      }
+                    }
+                  >
+                    <Segment
+                      raised={true}
+                    >
+                      <Header
+                        dividing={true}
+                      >
+                        <Icon
+                          as="i"
+                          name="user"
+                        />
+                        <HeaderContent>
+                          Change Username
+                        </HeaderContent>
+                      </Header>
+                      <Form
+                        as="form"
+                        onSubmit={[Function]}
+                      >
+                        <FormInput
+                          as={[Function]}
+                          control={[Function]}
+                          defaultValue="testuser"
+                          error={null}
+                          inline={true}
+                          label="Username:"
+                          name="username"
+                          onChange={[Function]}
+                          required={true}
+                        />
+                        <FormButton
+                          as={[Function]}
+                          control={[Function]}
+                          primary={true}
+                        >
+                          Save
+                        </FormButton>
+                      </Form>
+                    </Segment>
+                  </GridRow>,
+                  <GridRow>
+                    <Segment
+                      raised={true}
+                    >
+                      <Header
+                        dividing={true}
+                      >
+                        <Icon
+                          as="i"
+                          name="lock"
+                        />
+                        <HeaderContent>
+                          Change Password
+                        </HeaderContent>
+                      </Header>
+                      <Form
+                        as="form"
+                        onSubmit={[Function]}
+                      >
+                        <FormGroup
+                          widths="equal"
+                        >
+                          <FormInput
+                            as={[Function]}
+                            control={[Function]}
+                            error={null}
+                            label="New Password:"
+                            name="password1"
+                            onChange={[Function]}
+                            required={true}
+                            type="password"
+                          />
+                          <FormInput
+                            as={[Function]}
+                            control={[Function]}
+                            error={null}
+                            label="Verify:"
+                            name="password2"
+                            onChange={[Function]}
+                            required={true}
+                            type="password"
+                          />
+                        </FormGroup>
+                        <FormButton
+                          as={[Function]}
+                          control={[Function]}
+                          primary={true}
+                        >
+                          Save
+                        </FormButton>
+                      </Form>
+                    </Segment>
+                  </GridRow>,
+                ],
+              },
+              "ref": null,
+              "rendered": Array [
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "class",
+                  "props": Object {
+                    "children": "Changing any of these settings requires signing back in.",
+                    "info": true,
+                  },
+                  "ref": null,
+                  "rendered": "Changing any of these settings requires signing back in.",
+                  "type": [Function],
+                },
+                null,
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "function",
+                  "props": Object {
+                    "children": <Segment
+                      raised={true}
+                    >
+                      <Header
+                        dividing={true}
+                      >
+                        <Icon
+                          as="i"
+                          name="user"
+                        />
+                        <HeaderContent>
+                          Change Username
+                        </HeaderContent>
+                      </Header>
+                      <Form
+                        as="form"
+                        onSubmit={[Function]}
+                      >
+                        <FormInput
+                          as={[Function]}
+                          control={[Function]}
+                          defaultValue="testuser"
+                          error={null}
+                          inline={true}
+                          label="Username:"
+                          name="username"
+                          onChange={[Function]}
+                          required={true}
+                        />
+                        <FormButton
+                          as={[Function]}
+                          control={[Function]}
+                          primary={true}
+                        >
+                          Save
+                        </FormButton>
+                      </Form>
+                    </Segment>,
+                    "style": Object {
+                      "paddingBottom": "10px",
+                      "paddingTop": "10px",
+                    },
+                  },
+                  "ref": null,
+                  "rendered": Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "function",
+                    "props": Object {
+                      "children": Array [
+                        <Header
+                          dividing={true}
+                        >
+                          <Icon
+                            as="i"
+                            name="user"
+                          />
+                          <HeaderContent>
+                            Change Username
+                          </HeaderContent>
+                        </Header>,
+                        <Form
+                          as="form"
+                          onSubmit={[Function]}
+                        >
+                          <FormInput
+                            as={[Function]}
+                            control={[Function]}
+                            defaultValue="testuser"
+                            error={null}
+                            inline={true}
+                            label="Username:"
+                            name="username"
+                            onChange={[Function]}
+                            required={true}
+                          />
+                          <FormButton
+                            as={[Function]}
+                            control={[Function]}
+                            primary={true}
+                          >
+                            Save
+                          </FormButton>
+                        </Form>,
+                      ],
+                      "raised": true,
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "function",
+                        "props": Object {
+                          "children": Array [
+                            <Icon
+                              as="i"
+                              name="user"
+                            />,
+                            <HeaderContent>
+                              Change Username
+                            </HeaderContent>,
+                          ],
+                          "dividing": true,
+                        },
+                        "ref": null,
+                        "rendered": Array [
+                          Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "class",
+                            "props": Object {
+                              "as": "i",
+                              "name": "user",
+                            },
+                            "ref": null,
+                            "rendered": null,
+                            "type": [Function],
+                          },
+                          Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "function",
+                            "props": Object {
+                              "children": "Change Username",
+                            },
+                            "ref": null,
+                            "rendered": "Change Username",
+                            "type": [Function],
+                          },
+                        ],
+                        "type": [Function],
+                      },
+                      Object {
+                        "instance": null,
+                        "key": "1",
+                        "nodeType": "class",
+                        "props": Object {
+                          "as": "form",
+                          "children": Array [
+                            <FormInput
+                              as={[Function]}
+                              control={[Function]}
+                              defaultValue="testuser"
+                              error={null}
+                              inline={true}
+                              label="Username:"
+                              name="username"
+                              onChange={[Function]}
+                              required={true}
+                            />,
+                            <FormButton
+                              as={[Function]}
+                              control={[Function]}
+                              primary={true}
+                            >
+                              Save
+                            </FormButton>,
+                          ],
+                          "onSubmit": [Function],
+                        },
+                        "ref": null,
+                        "rendered": Array [
+                          Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "function",
+                            "props": Object {
+                              "as": [Function],
+                              "control": [Function],
+                              "defaultValue": "testuser",
+                              "error": null,
+                              "inline": true,
+                              "label": "Username:",
+                              "name": "username",
+                              "onChange": [Function],
+                              "required": true,
+                            },
+                            "ref": null,
+                            "rendered": null,
+                            "type": [Function],
+                          },
+                          Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "function",
+                            "props": Object {
+                              "as": [Function],
+                              "children": "Save",
+                              "control": [Function],
+                              "primary": true,
+                            },
+                            "ref": null,
+                            "rendered": "Save",
+                            "type": [Function],
+                          },
+                        ],
+                        "type": [Function],
+                      },
+                    ],
+                    "type": [Function],
+                  },
+                  "type": [Function],
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "function",
+                  "props": Object {
+                    "children": <Segment
+                      raised={true}
+                    >
+                      <Header
+                        dividing={true}
+                      >
+                        <Icon
+                          as="i"
+                          name="lock"
+                        />
+                        <HeaderContent>
+                          Change Password
+                        </HeaderContent>
+                      </Header>
+                      <Form
+                        as="form"
+                        onSubmit={[Function]}
+                      >
+                        <FormGroup
+                          widths="equal"
+                        >
+                          <FormInput
+                            as={[Function]}
+                            control={[Function]}
+                            error={null}
+                            label="New Password:"
+                            name="password1"
+                            onChange={[Function]}
+                            required={true}
+                            type="password"
+                          />
+                          <FormInput
+                            as={[Function]}
+                            control={[Function]}
+                            error={null}
+                            label="Verify:"
+                            name="password2"
+                            onChange={[Function]}
+                            required={true}
+                            type="password"
+                          />
+                        </FormGroup>
+                        <FormButton
+                          as={[Function]}
+                          control={[Function]}
+                          primary={true}
+                        >
+                          Save
+                        </FormButton>
+                      </Form>
+                    </Segment>,
+                  },
+                  "ref": null,
+                  "rendered": Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "function",
+                    "props": Object {
+                      "children": Array [
+                        <Header
+                          dividing={true}
+                        >
+                          <Icon
+                            as="i"
+                            name="lock"
+                          />
+                          <HeaderContent>
+                            Change Password
+                          </HeaderContent>
+                        </Header>,
+                        <Form
+                          as="form"
+                          onSubmit={[Function]}
+                        >
+                          <FormGroup
+                            widths="equal"
+                          >
+                            <FormInput
+                              as={[Function]}
+                              control={[Function]}
+                              error={null}
+                              label="New Password:"
+                              name="password1"
+                              onChange={[Function]}
+                              required={true}
+                              type="password"
+                            />
+                            <FormInput
+                              as={[Function]}
+                              control={[Function]}
+                              error={null}
+                              label="Verify:"
+                              name="password2"
+                              onChange={[Function]}
+                              required={true}
+                              type="password"
+                            />
+                          </FormGroup>
+                          <FormButton
+                            as={[Function]}
+                            control={[Function]}
+                            primary={true}
+                          >
+                            Save
+                          </FormButton>
+                        </Form>,
+                      ],
+                      "raised": true,
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "function",
+                        "props": Object {
+                          "children": Array [
+                            <Icon
+                              as="i"
+                              name="lock"
+                            />,
+                            <HeaderContent>
+                              Change Password
+                            </HeaderContent>,
+                          ],
+                          "dividing": true,
+                        },
+                        "ref": null,
+                        "rendered": Array [
+                          Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "class",
+                            "props": Object {
+                              "as": "i",
+                              "name": "lock",
+                            },
+                            "ref": null,
+                            "rendered": null,
+                            "type": [Function],
+                          },
+                          Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "function",
+                            "props": Object {
+                              "children": "Change Password",
+                            },
+                            "ref": null,
+                            "rendered": "Change Password",
+                            "type": [Function],
+                          },
+                        ],
+                        "type": [Function],
+                      },
+                      Object {
+                        "instance": null,
+                        "key": "1",
+                        "nodeType": "class",
+                        "props": Object {
+                          "as": "form",
+                          "children": Array [
+                            <FormGroup
+                              widths="equal"
+                            >
+                              <FormInput
+                                as={[Function]}
+                                control={[Function]}
+                                error={null}
+                                label="New Password:"
+                                name="password1"
+                                onChange={[Function]}
+                                required={true}
+                                type="password"
+                              />
+                              <FormInput
+                                as={[Function]}
+                                control={[Function]}
+                                error={null}
+                                label="Verify:"
+                                name="password2"
+                                onChange={[Function]}
+                                required={true}
+                                type="password"
+                              />
+                            </FormGroup>,
+                            <FormButton
+                              as={[Function]}
+                              control={[Function]}
+                              primary={true}
+                            >
+                              Save
+                            </FormButton>,
+                          ],
+                          "onSubmit": [Function],
+                        },
+                        "ref": null,
+                        "rendered": Array [
+                          Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "function",
+                            "props": Object {
+                              "children": Array [
+                                <FormInput
+                                  as={[Function]}
+                                  control={[Function]}
+                                  error={null}
+                                  label="New Password:"
+                                  name="password1"
+                                  onChange={[Function]}
+                                  required={true}
+                                  type="password"
+                                />,
+                                <FormInput
+                                  as={[Function]}
+                                  control={[Function]}
+                                  error={null}
+                                  label="Verify:"
+                                  name="password2"
+                                  onChange={[Function]}
+                                  required={true}
+                                  type="password"
+                                />,
+                              ],
+                              "widths": "equal",
+                            },
+                            "ref": null,
+                            "rendered": Array [
+                              Object {
+                                "instance": null,
+                                "key": undefined,
+                                "nodeType": "function",
+                                "props": Object {
+                                  "as": [Function],
+                                  "control": [Function],
+                                  "error": null,
+                                  "label": "New Password:",
+                                  "name": "password1",
+                                  "onChange": [Function],
+                                  "required": true,
+                                  "type": "password",
+                                },
+                                "ref": null,
+                                "rendered": null,
+                                "type": [Function],
+                              },
+                              Object {
+                                "instance": null,
+                                "key": undefined,
+                                "nodeType": "function",
+                                "props": Object {
+                                  "as": [Function],
+                                  "control": [Function],
+                                  "error": null,
+                                  "label": "Verify:",
+                                  "name": "password2",
+                                  "onChange": [Function],
+                                  "required": true,
+                                  "type": "password",
+                                },
+                                "ref": null,
+                                "rendered": null,
+                                "type": [Function],
+                              },
+                            ],
+                            "type": [Function],
+                          },
+                          Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "function",
+                            "props": Object {
+                              "as": [Function],
+                              "children": "Save",
+                              "control": [Function],
+                              "primary": true,
+                            },
+                            "ref": null,
+                            "rendered": "Save",
+                            "type": [Function],
+                          },
+                        ],
+                        "type": [Function],
+                      },
+                    ],
+                    "type": [Function],
+                  },
+                  "type": [Function],
+                },
+              ],
+              "type": Symbol(react.fragment),
+            },
+          ],
+          "type": [Function],
+        },
+        "type": [Function],
+      },
+    ],
+    "type": [Function],
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "function",
+      "props": Object {
+        "centered": true,
+        "children": Array [
+          <GridRow>
+            <Header
+              as="h1"
+            >
+              <Icon
+                as="i"
+                name="settings"
+              />
+              <HeaderContent>
+                My Settings
+              </HeaderContent>
+            </Header>
+          </GridRow>,
+          <GridRow>
+            <GridColumn
+              width={5}
+            >
+              <React.Fragment>
+                <Message
+                  info={true}
+                >
+                  Changing any of these settings requires signing back in.
+                </Message>
+                <GridRow
+                  style={
+                    Object {
+                      "paddingBottom": "10px",
+                      "paddingTop": "10px",
+                    }
+                  }
+                >
+                  <Segment
+                    raised={true}
+                  >
+                    <Header
+                      dividing={true}
+                    >
+                      <Icon
+                        as="i"
+                        name="user"
+                      />
+                      <HeaderContent>
+                        Change Username
+                      </HeaderContent>
+                    </Header>
+                    <Form
+                      as="form"
+                      onSubmit={[Function]}
+                    >
+                      <FormInput
+                        as={[Function]}
+                        control={[Function]}
+                        defaultValue="testuser"
+                        error={null}
+                        inline={true}
+                        label="Username:"
+                        name="username"
+                        onChange={[Function]}
+                        required={true}
+                      />
+                      <FormButton
+                        as={[Function]}
+                        control={[Function]}
+                        primary={true}
+                      >
+                        Save
+                      </FormButton>
+                    </Form>
+                  </Segment>
+                </GridRow>
+                <GridRow>
+                  <Segment
+                    raised={true}
+                  >
+                    <Header
+                      dividing={true}
+                    >
+                      <Icon
+                        as="i"
+                        name="lock"
+                      />
+                      <HeaderContent>
+                        Change Password
+                      </HeaderContent>
+                    </Header>
+                    <Form
+                      as="form"
+                      onSubmit={[Function]}
+                    >
+                      <FormGroup
+                        widths="equal"
+                      >
+                        <FormInput
+                          as={[Function]}
+                          control={[Function]}
+                          error={null}
+                          label="New Password:"
+                          name="password1"
+                          onChange={[Function]}
+                          required={true}
+                          type="password"
+                        />
+                        <FormInput
+                          as={[Function]}
+                          control={[Function]}
+                          error={null}
+                          label="Verify:"
+                          name="password2"
+                          onChange={[Function]}
+                          required={true}
+                          type="password"
+                        />
+                      </FormGroup>
+                      <FormButton
+                        as={[Function]}
+                        control={[Function]}
+                        primary={true}
+                      >
+                        Save
+                      </FormButton>
+                    </Form>
+                  </Segment>
+                </GridRow>
+              </React.Fragment>
+            </GridColumn>
+          </GridRow>,
+        ],
+        "columns": 16,
+        "divided": "vertically",
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "children": <Header
+              as="h1"
+            >
+              <Icon
+                as="i"
+                name="settings"
+              />
+              <HeaderContent>
+                My Settings
+              </HeaderContent>
+            </Header>,
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "as": "h1",
+              "children": Array [
+                <Icon
+                  as="i"
+                  name="settings"
+                />,
+                <HeaderContent>
+                  My Settings
+                </HeaderContent>,
+              ],
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "as": "i",
+                  "name": "settings",
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "function",
+                "props": Object {
+                  "children": "My Settings",
+                },
+                "ref": null,
+                "rendered": "My Settings",
+                "type": [Function],
+              },
+            ],
+            "type": [Function],
+          },
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "children": <GridColumn
+              width={5}
+            >
+              <React.Fragment>
+                <Message
+                  info={true}
+                >
+                  Changing any of these settings requires signing back in.
+                </Message>
+                <GridRow
+                  style={
+                    Object {
+                      "paddingBottom": "10px",
+                      "paddingTop": "10px",
+                    }
+                  }
+                >
+                  <Segment
+                    raised={true}
+                  >
+                    <Header
+                      dividing={true}
+                    >
+                      <Icon
+                        as="i"
+                        name="user"
+                      />
+                      <HeaderContent>
+                        Change Username
+                      </HeaderContent>
+                    </Header>
+                    <Form
+                      as="form"
+                      onSubmit={[Function]}
+                    >
+                      <FormInput
+                        as={[Function]}
+                        control={[Function]}
+                        defaultValue="testuser"
+                        error={null}
+                        inline={true}
+                        label="Username:"
+                        name="username"
+                        onChange={[Function]}
+                        required={true}
+                      />
+                      <FormButton
+                        as={[Function]}
+                        control={[Function]}
+                        primary={true}
+                      >
+                        Save
+                      </FormButton>
+                    </Form>
+                  </Segment>
+                </GridRow>
+                <GridRow>
+                  <Segment
+                    raised={true}
+                  >
+                    <Header
+                      dividing={true}
+                    >
+                      <Icon
+                        as="i"
+                        name="lock"
+                      />
+                      <HeaderContent>
+                        Change Password
+                      </HeaderContent>
+                    </Header>
+                    <Form
+                      as="form"
+                      onSubmit={[Function]}
+                    >
+                      <FormGroup
+                        widths="equal"
+                      >
+                        <FormInput
+                          as={[Function]}
+                          control={[Function]}
+                          error={null}
+                          label="New Password:"
+                          name="password1"
+                          onChange={[Function]}
+                          required={true}
+                          type="password"
+                        />
+                        <FormInput
+                          as={[Function]}
+                          control={[Function]}
+                          error={null}
+                          label="Verify:"
+                          name="password2"
+                          onChange={[Function]}
+                          required={true}
+                          type="password"
+                        />
+                      </FormGroup>
+                      <FormButton
+                        as={[Function]}
+                        control={[Function]}
+                        primary={true}
+                      >
+                        Save
+                      </FormButton>
+                    </Form>
+                  </Segment>
+                </GridRow>
+              </React.Fragment>
+            </GridColumn>,
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "children": Array [
+                null,
+                <React.Fragment>
+                  <Message
+                    info={true}
+                  >
+                    Changing any of these settings requires signing back in.
+                  </Message>
+                  <GridRow
+                    style={
+                      Object {
+                        "paddingBottom": "10px",
+                        "paddingTop": "10px",
+                      }
+                    }
+                  >
+                    <Segment
+                      raised={true}
+                    >
+                      <Header
+                        dividing={true}
+                      >
+                        <Icon
+                          as="i"
+                          name="user"
+                        />
+                        <HeaderContent>
+                          Change Username
+                        </HeaderContent>
+                      </Header>
+                      <Form
+                        as="form"
+                        onSubmit={[Function]}
+                      >
+                        <FormInput
+                          as={[Function]}
+                          control={[Function]}
+                          defaultValue="testuser"
+                          error={null}
+                          inline={true}
+                          label="Username:"
+                          name="username"
+                          onChange={[Function]}
+                          required={true}
+                        />
+                        <FormButton
+                          as={[Function]}
+                          control={[Function]}
+                          primary={true}
+                        >
+                          Save
+                        </FormButton>
+                      </Form>
+                    </Segment>
+                  </GridRow>
+                  <GridRow>
+                    <Segment
+                      raised={true}
+                    >
+                      <Header
+                        dividing={true}
+                      >
+                        <Icon
+                          as="i"
+                          name="lock"
+                        />
+                        <HeaderContent>
+                          Change Password
+                        </HeaderContent>
+                      </Header>
+                      <Form
+                        as="form"
+                        onSubmit={[Function]}
+                      >
+                        <FormGroup
+                          widths="equal"
+                        >
+                          <FormInput
+                            as={[Function]}
+                            control={[Function]}
+                            error={null}
+                            label="New Password:"
+                            name="password1"
+                            onChange={[Function]}
+                            required={true}
+                            type="password"
+                          />
+                          <FormInput
+                            as={[Function]}
+                            control={[Function]}
+                            error={null}
+                            label="Verify:"
+                            name="password2"
+                            onChange={[Function]}
+                            required={true}
+                            type="password"
+                          />
+                        </FormGroup>
+                        <FormButton
+                          as={[Function]}
+                          control={[Function]}
+                          primary={true}
+                        >
+                          Save
+                        </FormButton>
+                      </Form>
+                    </Segment>
+                  </GridRow>
+                </React.Fragment>,
+              ],
+              "width": 5,
+            },
+            "ref": null,
+            "rendered": Array [
+              null,
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "function",
+                "props": Object {
+                  "children": Array [
+                    <Message
+                      info={true}
+                    >
+                      Changing any of these settings requires signing back in.
+                    </Message>,
+                    null,
+                    <GridRow
+                      style={
+                        Object {
+                          "paddingBottom": "10px",
+                          "paddingTop": "10px",
+                        }
+                      }
+                    >
+                      <Segment
+                        raised={true}
+                      >
+                        <Header
+                          dividing={true}
+                        >
+                          <Icon
+                            as="i"
+                            name="user"
+                          />
+                          <HeaderContent>
+                            Change Username
+                          </HeaderContent>
+                        </Header>
+                        <Form
+                          as="form"
+                          onSubmit={[Function]}
+                        >
+                          <FormInput
+                            as={[Function]}
+                            control={[Function]}
+                            defaultValue="testuser"
+                            error={null}
+                            inline={true}
+                            label="Username:"
+                            name="username"
+                            onChange={[Function]}
+                            required={true}
+                          />
+                          <FormButton
+                            as={[Function]}
+                            control={[Function]}
+                            primary={true}
+                          >
+                            Save
+                          </FormButton>
+                        </Form>
+                      </Segment>
+                    </GridRow>,
+                    <GridRow>
+                      <Segment
+                        raised={true}
+                      >
+                        <Header
+                          dividing={true}
+                        >
+                          <Icon
+                            as="i"
+                            name="lock"
+                          />
+                          <HeaderContent>
+                            Change Password
+                          </HeaderContent>
+                        </Header>
+                        <Form
+                          as="form"
+                          onSubmit={[Function]}
+                        >
+                          <FormGroup
+                            widths="equal"
+                          >
+                            <FormInput
+                              as={[Function]}
+                              control={[Function]}
+                              error={null}
+                              label="New Password:"
+                              name="password1"
+                              onChange={[Function]}
+                              required={true}
+                              type="password"
+                            />
+                            <FormInput
+                              as={[Function]}
+                              control={[Function]}
+                              error={null}
+                              label="Verify:"
+                              name="password2"
+                              onChange={[Function]}
+                              required={true}
+                              type="password"
+                            />
+                          </FormGroup>
+                          <FormButton
+                            as={[Function]}
+                            control={[Function]}
+                            primary={true}
+                          >
+                            Save
+                          </FormButton>
+                        </Form>
+                      </Segment>
+                    </GridRow>,
+                  ],
+                },
+                "ref": null,
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "children": "Changing any of these settings requires signing back in.",
+                      "info": true,
+                    },
+                    "ref": null,
+                    "rendered": "Changing any of these settings requires signing back in.",
+                    "type": [Function],
+                  },
+                  null,
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "function",
+                    "props": Object {
+                      "children": <Segment
+                        raised={true}
+                      >
+                        <Header
+                          dividing={true}
+                        >
+                          <Icon
+                            as="i"
+                            name="user"
+                          />
+                          <HeaderContent>
+                            Change Username
+                          </HeaderContent>
+                        </Header>
+                        <Form
+                          as="form"
+                          onSubmit={[Function]}
+                        >
+                          <FormInput
+                            as={[Function]}
+                            control={[Function]}
+                            defaultValue="testuser"
+                            error={null}
+                            inline={true}
+                            label="Username:"
+                            name="username"
+                            onChange={[Function]}
+                            required={true}
+                          />
+                          <FormButton
+                            as={[Function]}
+                            control={[Function]}
+                            primary={true}
+                          >
+                            Save
+                          </FormButton>
+                        </Form>
+                      </Segment>,
+                      "style": Object {
+                        "paddingBottom": "10px",
+                        "paddingTop": "10px",
+                      },
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "function",
+                      "props": Object {
+                        "children": Array [
+                          <Header
+                            dividing={true}
+                          >
+                            <Icon
+                              as="i"
+                              name="user"
+                            />
+                            <HeaderContent>
+                              Change Username
+                            </HeaderContent>
+                          </Header>,
+                          <Form
+                            as="form"
+                            onSubmit={[Function]}
+                          >
+                            <FormInput
+                              as={[Function]}
+                              control={[Function]}
+                              defaultValue="testuser"
+                              error={null}
+                              inline={true}
+                              label="Username:"
+                              name="username"
+                              onChange={[Function]}
+                              required={true}
+                            />
+                            <FormButton
+                              as={[Function]}
+                              control={[Function]}
+                              primary={true}
+                            >
+                              Save
+                            </FormButton>
+                          </Form>,
+                        ],
+                        "raised": true,
+                      },
+                      "ref": null,
+                      "rendered": Array [
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "function",
+                          "props": Object {
+                            "children": Array [
+                              <Icon
+                                as="i"
+                                name="user"
+                              />,
+                              <HeaderContent>
+                                Change Username
+                              </HeaderContent>,
+                            ],
+                            "dividing": true,
+                          },
+                          "ref": null,
+                          "rendered": Array [
+                            Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "class",
+                              "props": Object {
+                                "as": "i",
+                                "name": "user",
+                              },
+                              "ref": null,
+                              "rendered": null,
+                              "type": [Function],
+                            },
+                            Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "function",
+                              "props": Object {
+                                "children": "Change Username",
+                              },
+                              "ref": null,
+                              "rendered": "Change Username",
+                              "type": [Function],
+                            },
+                          ],
+                          "type": [Function],
+                        },
+                        Object {
+                          "instance": null,
+                          "key": "1",
+                          "nodeType": "class",
+                          "props": Object {
+                            "as": "form",
+                            "children": Array [
+                              <FormInput
+                                as={[Function]}
+                                control={[Function]}
+                                defaultValue="testuser"
+                                error={null}
+                                inline={true}
+                                label="Username:"
+                                name="username"
+                                onChange={[Function]}
+                                required={true}
+                              />,
+                              <FormButton
+                                as={[Function]}
+                                control={[Function]}
+                                primary={true}
+                              >
+                                Save
+                              </FormButton>,
+                            ],
+                            "onSubmit": [Function],
+                          },
+                          "ref": null,
+                          "rendered": Array [
+                            Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "function",
+                              "props": Object {
+                                "as": [Function],
+                                "control": [Function],
+                                "defaultValue": "testuser",
+                                "error": null,
+                                "inline": true,
+                                "label": "Username:",
+                                "name": "username",
+                                "onChange": [Function],
+                                "required": true,
+                              },
+                              "ref": null,
+                              "rendered": null,
+                              "type": [Function],
+                            },
+                            Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "function",
+                              "props": Object {
+                                "as": [Function],
+                                "children": "Save",
+                                "control": [Function],
+                                "primary": true,
+                              },
+                              "ref": null,
+                              "rendered": "Save",
+                              "type": [Function],
+                            },
+                          ],
+                          "type": [Function],
+                        },
+                      ],
+                      "type": [Function],
+                    },
+                    "type": [Function],
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "function",
+                    "props": Object {
+                      "children": <Segment
+                        raised={true}
+                      >
+                        <Header
+                          dividing={true}
+                        >
+                          <Icon
+                            as="i"
+                            name="lock"
+                          />
+                          <HeaderContent>
+                            Change Password
+                          </HeaderContent>
+                        </Header>
+                        <Form
+                          as="form"
+                          onSubmit={[Function]}
+                        >
+                          <FormGroup
+                            widths="equal"
+                          >
+                            <FormInput
+                              as={[Function]}
+                              control={[Function]}
+                              error={null}
+                              label="New Password:"
+                              name="password1"
+                              onChange={[Function]}
+                              required={true}
+                              type="password"
+                            />
+                            <FormInput
+                              as={[Function]}
+                              control={[Function]}
+                              error={null}
+                              label="Verify:"
+                              name="password2"
+                              onChange={[Function]}
+                              required={true}
+                              type="password"
+                            />
+                          </FormGroup>
+                          <FormButton
+                            as={[Function]}
+                            control={[Function]}
+                            primary={true}
+                          >
+                            Save
+                          </FormButton>
+                        </Form>
+                      </Segment>,
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "function",
+                      "props": Object {
+                        "children": Array [
+                          <Header
+                            dividing={true}
+                          >
+                            <Icon
+                              as="i"
+                              name="lock"
+                            />
+                            <HeaderContent>
+                              Change Password
+                            </HeaderContent>
+                          </Header>,
+                          <Form
+                            as="form"
+                            onSubmit={[Function]}
+                          >
+                            <FormGroup
+                              widths="equal"
+                            >
+                              <FormInput
+                                as={[Function]}
+                                control={[Function]}
+                                error={null}
+                                label="New Password:"
+                                name="password1"
+                                onChange={[Function]}
+                                required={true}
+                                type="password"
+                              />
+                              <FormInput
+                                as={[Function]}
+                                control={[Function]}
+                                error={null}
+                                label="Verify:"
+                                name="password2"
+                                onChange={[Function]}
+                                required={true}
+                                type="password"
+                              />
+                            </FormGroup>
+                            <FormButton
+                              as={[Function]}
+                              control={[Function]}
+                              primary={true}
+                            >
+                              Save
+                            </FormButton>
+                          </Form>,
+                        ],
+                        "raised": true,
+                      },
+                      "ref": null,
+                      "rendered": Array [
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "function",
+                          "props": Object {
+                            "children": Array [
+                              <Icon
+                                as="i"
+                                name="lock"
+                              />,
+                              <HeaderContent>
+                                Change Password
+                              </HeaderContent>,
+                            ],
+                            "dividing": true,
+                          },
+                          "ref": null,
+                          "rendered": Array [
+                            Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "class",
+                              "props": Object {
+                                "as": "i",
+                                "name": "lock",
+                              },
+                              "ref": null,
+                              "rendered": null,
+                              "type": [Function],
+                            },
+                            Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "function",
+                              "props": Object {
+                                "children": "Change Password",
+                              },
+                              "ref": null,
+                              "rendered": "Change Password",
+                              "type": [Function],
+                            },
+                          ],
+                          "type": [Function],
+                        },
+                        Object {
+                          "instance": null,
+                          "key": "1",
+                          "nodeType": "class",
+                          "props": Object {
+                            "as": "form",
+                            "children": Array [
+                              <FormGroup
+                                widths="equal"
+                              >
+                                <FormInput
+                                  as={[Function]}
+                                  control={[Function]}
+                                  error={null}
+                                  label="New Password:"
+                                  name="password1"
+                                  onChange={[Function]}
+                                  required={true}
+                                  type="password"
+                                />
+                                <FormInput
+                                  as={[Function]}
+                                  control={[Function]}
+                                  error={null}
+                                  label="Verify:"
+                                  name="password2"
+                                  onChange={[Function]}
+                                  required={true}
+                                  type="password"
+                                />
+                              </FormGroup>,
+                              <FormButton
+                                as={[Function]}
+                                control={[Function]}
+                                primary={true}
+                              >
+                                Save
+                              </FormButton>,
+                            ],
+                            "onSubmit": [Function],
+                          },
+                          "ref": null,
+                          "rendered": Array [
+                            Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "function",
+                              "props": Object {
+                                "children": Array [
+                                  <FormInput
+                                    as={[Function]}
+                                    control={[Function]}
+                                    error={null}
+                                    label="New Password:"
+                                    name="password1"
+                                    onChange={[Function]}
+                                    required={true}
+                                    type="password"
+                                  />,
+                                  <FormInput
+                                    as={[Function]}
+                                    control={[Function]}
+                                    error={null}
+                                    label="Verify:"
+                                    name="password2"
+                                    onChange={[Function]}
+                                    required={true}
+                                    type="password"
+                                  />,
+                                ],
+                                "widths": "equal",
+                              },
+                              "ref": null,
+                              "rendered": Array [
+                                Object {
+                                  "instance": null,
+                                  "key": undefined,
+                                  "nodeType": "function",
+                                  "props": Object {
+                                    "as": [Function],
+                                    "control": [Function],
+                                    "error": null,
+                                    "label": "New Password:",
+                                    "name": "password1",
+                                    "onChange": [Function],
+                                    "required": true,
+                                    "type": "password",
+                                  },
+                                  "ref": null,
+                                  "rendered": null,
+                                  "type": [Function],
+                                },
+                                Object {
+                                  "instance": null,
+                                  "key": undefined,
+                                  "nodeType": "function",
+                                  "props": Object {
+                                    "as": [Function],
+                                    "control": [Function],
+                                    "error": null,
+                                    "label": "Verify:",
+                                    "name": "password2",
+                                    "onChange": [Function],
+                                    "required": true,
+                                    "type": "password",
+                                  },
+                                  "ref": null,
+                                  "rendered": null,
+                                  "type": [Function],
+                                },
+                              ],
+                              "type": [Function],
+                            },
+                            Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "function",
+                              "props": Object {
+                                "as": [Function],
+                                "children": "Save",
+                                "control": [Function],
+                                "primary": true,
+                              },
+                              "ref": null,
+                              "rendered": "Save",
+                              "type": [Function],
+                            },
+                          ],
+                          "type": [Function],
+                        },
+                      ],
+                      "type": [Function],
+                    },
+                    "type": [Function],
+                  },
+                ],
+                "type": Symbol(react.fragment),
+              },
+            ],
+            "type": [Function],
+          },
+          "type": [Function],
+        },
+      ],
+      "type": [Function],
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
+          },
+          "getDerivedStateFromProps": true,
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+  },
+}
+`;

--- a/src/containers/Accounts/Login.js
+++ b/src/containers/Accounts/Login.js
@@ -20,7 +20,7 @@ import { updateValidAuth as actionUpdateValidAuth } from '@/actions/auth';
 import { updateUser as actionUpdateUser } from '@/actions/user';
 
 const mapDispatchToProps = dispatch => ({
-  updateUser: data => dispatch(actionUpdateUser(data)),
+  updateUser: data => dispatch(actionUpdateUser({ ...data, isSocial: false })),
   updateValidAuth: isValidAuth => dispatch(actionUpdateValidAuth(isValidAuth)),
 });
 

--- a/src/containers/Accounts/LoginCallback.js
+++ b/src/containers/Accounts/LoginCallback.js
@@ -12,7 +12,7 @@ import { updateValidAuth as actionUpdateValidAuth } from '@/actions/auth';
 import { updateUser as actionUpdateUser } from '@/actions/user';
 
 const mapDispatchToProps = dispatch => ({
-  updateUser: data => dispatch(actionUpdateUser(data)),
+  updateUser: data => dispatch(actionUpdateUser({ ...data, isSocial: true })),
   updateValidAuth: isValidAuth => dispatch(actionUpdateValidAuth(isValidAuth)),
 });
 

--- a/src/containers/Accounts/SignUp.js
+++ b/src/containers/Accounts/SignUp.js
@@ -17,7 +17,7 @@ import axios from 'axios';
 import { updateUser as actionUpdateUser } from '@/actions/user';
 
 const mapDispatchToProps = dispatch => ({
-  updateUser: data => dispatch(actionUpdateUser(data)),
+  updateUser: data => dispatch(actionUpdateUser({ ...data, isSocial: false })),
 });
 
 class SignUp extends Component {

--- a/src/containers/Accounts/__tests__/Login.test.js
+++ b/src/containers/Accounts/__tests__/Login.test.js
@@ -121,7 +121,7 @@ test('Login redirects to root after basic login success', async () => {
 
   expect(cookies.get('auth_jwt')).toBe(token);
   expect(wrapper.find(Redirect).exists()).toBe(true);
-  expect(store.dispatch).toHaveBeenCalledWith(updateUser(jwtDecode(token)));
+  expect(store.dispatch).toHaveBeenCalledWith(updateUser({ ...jwtDecode(token), isSocial: false }));
   expect(store.dispatch).toHaveBeenCalledWith(updateValidAuth(true));
 
   cookies.remove('auth_jwt');

--- a/src/containers/Accounts/__tests__/LoginCallback.test.js
+++ b/src/containers/Accounts/__tests__/LoginCallback.test.js
@@ -100,6 +100,6 @@ test('LoginCallback redirects to root after success', async () => {
   expect(redirect.prop('to')).toBe('/');
   expect(wrapper.find(Loader).exists()).toBe(false);
   expect(cookies.get('auth_jwt')).toBe(token);
-  expect(store.dispatch).toHaveBeenCalledWith(updateUser(jwtDecode(token)));
+  expect(store.dispatch).toHaveBeenCalledWith(updateUser({ ...jwtDecode(token), isSocial: true }));
   expect(store.dispatch).toHaveBeenCalledWith(updateValidAuth(true));
 });

--- a/src/containers/Accounts/__tests__/SignUp.test.js
+++ b/src/containers/Accounts/__tests__/SignUp.test.js
@@ -113,7 +113,7 @@ test('SignUp redirects to root after success', async () => {
   expect(cookies.get('auth_jwt')).toBe(token);
   expect(wrapper.find(Redirect).exists()).toBe(true);
   expect(wrapper.find(Redirect).prop('to')).toBe('/');
-  expect(store.dispatch).toHaveBeenCalledWith(updateUser(jwtDecode(token)));
+  expect(store.dispatch).toHaveBeenCalledWith(updateUser({ ...jwtDecode(token), isSocial: false }));
 
   cookies.remove('auth_jwt');
 });

--- a/src/containers/UserSetting.js
+++ b/src/containers/UserSetting.js
@@ -1,0 +1,50 @@
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { hot } from 'react-hot-loader';
+import { withCookies, Cookies } from 'react-cookie';
+import { editUserPassword, editUserUsername } from '@/actions/user';
+import { updateValidAuth } from '@/actions/auth';
+import UserSetting from '@/components/UserSetting';
+
+const mapStateToProps = ({ user }) => ({ user });
+const mapDispatchToProps = (dispatch, { cookies }) => ({
+  editUserUsername: (username) => {
+    const editUserUsernameAction = editUserUsername(username, {
+      headers: {
+        Authorization: `JWT ${cookies.get('auth_jwt')}`,
+      },
+    });
+    return dispatch(editUserUsernameAction).catch((error) => {
+      if (error.response.status === 401) {
+        // Authentication is no longer valid
+        return dispatch(updateValidAuth(false));
+      }
+      throw error;
+    });
+  },
+  editUserPassword: (password) => {
+    const editUserPasswordAction = editUserPassword(password, {
+      headers: {
+        Authorization: `JWT ${cookies.get('auth_jwt')}`,
+      },
+    });
+    return dispatch(editUserPasswordAction).catch((error) => {
+      if (error.response.status === 401) {
+        // Authentication is no longer valid
+        return dispatch(updateValidAuth(false));
+      }
+      throw error;
+    });
+  },
+});
+
+const UserSettingContainer = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(UserSetting);
+
+UserSettingContainer.propTypes = {
+  cookies: PropTypes.instanceOf(Cookies).isRequired,
+};
+
+export default hot(module)(withCookies(UserSettingContainer));

--- a/src/containers/__tests__/UserSetting.test.js
+++ b/src/containers/__tests__/UserSetting.test.js
@@ -1,0 +1,165 @@
+import React from 'react';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { shallow } from 'enzyme';
+import { Cookies } from 'react-cookie';
+import configureStore from 'redux-mock-store';
+import UserSetting from '../UserSetting';
+import { editUserUsername, editUserPassword } from '../../actions/user';
+import { updateValidAuth } from '../../actions/auth';
+
+const cookiesValues = { auth_jwt: '1234' };
+const cookies = new Cookies(cookiesValues);
+
+describe('The UserSettingContainer', () => {
+  const mockStore = configureStore();
+  let store;
+  let wrapper;
+  beforeEach(() => {
+    store = mockStore({
+      user: {
+        user_id: 1,
+        username: 'testuser',
+        email: 'test@example.com',
+      },
+    });
+    store.dispatch = jest.fn(() => Promise.resolve());
+    const context = { cookies };
+    wrapper = shallow(<UserSetting store={store} />, { context });
+  });
+  test('dispatches an action to edit user username', () => {
+    const username = 'testuser';
+    const user = {
+      pk: 1,
+      username,
+      email: 'test@example.com',
+    };
+    const mockAxios = new MockAdapter(axios);
+
+    mockAxios.onPut('/jwt/auth/user/', {
+      username,
+    }).reply(200, user);
+    wrapper.dive().props().editUserUsername(username);
+
+    expect(store.dispatch).toHaveBeenCalledWith(
+      editUserUsername(username, {
+        headers: {
+          Authorization: `JWT ${cookiesValues.auth_jwt}`,
+        },
+      }),
+    );
+
+    mockAxios.restore();
+  });
+
+  test('dispatches an action to edit user password', () => {
+    const password = 'password123';
+    const mockAxios = new MockAdapter(axios);
+
+    mockAxios.onPost('/jwt/auth/password/change/', {
+      new_password1: password,
+      new_password2: password,
+    }).reply(200, 'Password changed');
+    wrapper.dive().props().editUserPassword(password);
+
+    expect(store.dispatch).toHaveBeenCalledWith(
+      editUserPassword(password, {
+        headers: {
+          Authorization: `JWT ${cookiesValues.auth_jwt}`,
+        },
+      }),
+    );
+
+    mockAxios.restore();
+  });
+
+  test('handles authentication error editing user username', (done) => {
+    const username = 'testuser';
+    const error = new Error();
+    error.response = {
+      status: 401,
+    };
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(Promise.reject(error));
+    store.dispatch.mockReturnValueOnce(Promise.resolve({}));
+
+    wrapper.dive().props().editUserUsername(username).then(() => {
+      expect(store.dispatch.mock.calls.length).toBe(2);
+      expect(store.dispatch).toHaveBeenCalledWith(
+        editUserUsername(username, {
+          headers: {
+            Authorization: `JWT ${cookiesValues.auth_jwt}`,
+          },
+        }),
+      );
+      expect(store.dispatch).toHaveBeenCalledWith(updateValidAuth(false));
+      done();
+    });
+  });
+
+  test('handles authentication error editing user password', (done) => {
+    const password = 'password123';
+    const error = new Error();
+    error.response = {
+      status: 401,
+    };
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(Promise.reject(error));
+    store.dispatch.mockReturnValueOnce(Promise.resolve({}));
+
+    wrapper.dive().props().editUserPassword(password).then(() => {
+      expect(store.dispatch.mock.calls.length).toBe(2);
+      expect(store.dispatch).toHaveBeenCalledWith(
+        editUserPassword(password, {
+          headers: {
+            Authorization: `JWT ${cookiesValues.auth_jwt}`,
+          },
+        }),
+      );
+      expect(store.dispatch).toHaveBeenCalledWith(updateValidAuth(false));
+      done();
+    });
+  });
+
+  test('handles other error editing user username', (done) => {
+    const username = 'testuser';
+    const error = new Error();
+    error.response = {
+      status: 500,
+    };
+    store.dispatch = jest.fn(() => Promise.reject(error));
+
+    wrapper.dive().props().editUserUsername(username).catch(() => {
+      expect(store.dispatch.mock.calls.length).toBe(1);
+      expect(store.dispatch).toHaveBeenCalledWith(
+        editUserUsername(username, {
+          headers: {
+            Authorization: `JWT ${cookiesValues.auth_jwt}`,
+          },
+        }),
+      );
+      done();
+    });
+  });
+
+  test('handles other error editing user password', (done) => {
+    const password = 'password123';
+    const error = new Error();
+    error.response = {
+      status: 500,
+    };
+    store.dispatch = jest.fn(() => Promise.reject(error));
+
+    wrapper.dive().props().editUserPassword(password).catch(() => {
+      expect(store.dispatch.mock.calls.length).toBe(1);
+      expect(store.dispatch).toHaveBeenCalledWith(
+        editUserPassword(password, {
+          headers: {
+            Authorization: `JWT ${cookiesValues.auth_jwt}`,
+          },
+        }),
+      );
+      done();
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ import RoverDetail from './containers/RoverDetail';
 import RoverList from './containers/RoverList';
 import Accounts from './containers/Accounts/Base';
 import MissionControl from './containers/MissionControl';
+import UserSetting from './containers/UserSetting';
 import ProtectedRoute from './components/ProtectedRoute';
 
 Sentry.init({
@@ -56,6 +57,7 @@ render(
           <ProtectedRoute exact path="/rovers" component={RoverList} />
           <ProtectedRoute exact path="/rovers/:id(\d+)" component={RoverDetail} />
           <ProtectedRoute exact path="/mission-control" component={MissionControl} />
+          <ProtectedRoute exact path="/user/settings" component={UserSetting} />
           <Route component={NotFound} />
         </Switch>
       </CookiesProvider>

--- a/src/reducers/__tests__/user.test.js
+++ b/src/reducers/__tests__/user.test.js
@@ -1,5 +1,13 @@
 import reducer from '../user';
-import { UPDATE_USER } from '../../actions/user';
+import {
+  UPDATE_USER,
+  EDIT_USER_USERNAME,
+  EDIT_USER_USERNAME_FULFILLED,
+  EDIT_USER_USERNAME_REJECTED,
+  EDIT_USER_PASSWORD,
+  EDIT_USER_PASSWORD_FULFILLED,
+  EDIT_USER_PASSWORD_REJECTED,
+} from '../../actions/user';
 
 describe('The user reducer', () => {
   test('should handle UPDATE_USER', () => {
@@ -19,6 +27,100 @@ describe('The user reducer', () => {
       username: user.username,
       email: user.email,
       exp: user.exp,
+    });
+  });
+
+  test('should handle EDIT_USER_USERNAME', () => {
+    expect(
+      reducer(undefined, {
+        type: EDIT_USER_USERNAME,
+      }),
+    ).toEqual({
+      user_id: null,
+      username: null,
+      email: null,
+      exp: null,
+      isEditingUsername: true,
+      isEditingPassword: false,
+      editUsernameError: null,
+      editPasswordError: null,
+    });
+  });
+
+  test('should handle EDIT_USER_USERNAME_FULFILLED', () => {
+    const user = {
+      pk: 1,
+      username: 'testuser',
+      email: 'testuser@example.com',
+    };
+    expect(
+      reducer({}, {
+        type: EDIT_USER_USERNAME_FULFILLED,
+        payload: user,
+      }),
+    ).toEqual({
+      username: user.username,
+      email: user.email,
+      isEditingUsername: false,
+    });
+  });
+
+  test('should handle EDIT_USER_USERNAME_REJECTED', () => {
+    const error = 'woops';
+    expect(
+      reducer({}, {
+        type: EDIT_USER_USERNAME_REJECTED,
+        payload: error,
+      }),
+    ).toEqual({
+      isEditingUsername: false,
+      editUsernameError: error,
+    });
+  });
+
+  test('should handle EDIT_USER_PASSWORD', () => {
+    expect(
+      reducer(undefined, {
+        type: EDIT_USER_PASSWORD,
+      }),
+    ).toEqual({
+      user_id: null,
+      username: null,
+      email: null,
+      exp: null,
+      isEditingUsername: false,
+      isEditingPassword: true,
+      editUsernameError: null,
+      editPasswordError: null,
+    });
+  });
+
+  test('should handle EDIT_USER_PASSWORD_FULFILLED', () => {
+    const user = {
+      pk: 1,
+      username: 'testuser',
+      email: 'testuser@example.com',
+    };
+    expect(
+      reducer({}, {
+        type: EDIT_USER_PASSWORD_FULFILLED,
+        payload: user,
+      }),
+    ).toEqual({
+      isEditingPassword: false,
+    });
+  });
+
+  test('should handle EDIT_USER_PASSWORD_REJECTED', () => {
+    const error = 'woops';
+    expect(
+      reducer({}, {
+        type: EDIT_USER_PASSWORD_REJECTED,
+        payload: error,
+      }),
+    ).toEqual({
+      isEditingPassword: false,
+      editPasswordError: error,
     });
   });
 

--- a/src/reducers/__tests__/user.test.js
+++ b/src/reducers/__tests__/user.test.js
@@ -16,6 +16,7 @@ describe('The user reducer', () => {
       username: 'testuser',
       email: 'testuser@example.com',
       exp: 1540178211,
+      isSocial: false,
     };
     expect(
       reducer({}, {
@@ -27,6 +28,7 @@ describe('The user reducer', () => {
       username: user.username,
       email: user.email,
       exp: user.exp,
+      isSocial: user.isSocial,
     });
   });
 
@@ -40,6 +42,7 @@ describe('The user reducer', () => {
       username: null,
       email: null,
       exp: null,
+      isSocial: false,
       isEditingUsername: true,
       isEditingPassword: false,
       editUsernameError: null,
@@ -88,6 +91,7 @@ describe('The user reducer', () => {
       username: null,
       email: null,
       exp: null,
+      isSocial: false,
       isEditingUsername: false,
       isEditingPassword: true,
       editUsernameError: null,

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -1,4 +1,12 @@
-import { UPDATE_USER } from '../actions/user';
+import {
+  UPDATE_USER,
+  EDIT_USER_USERNAME,
+  EDIT_USER_USERNAME_FULFILLED,
+  EDIT_USER_USERNAME_REJECTED,
+  EDIT_USER_PASSWORD,
+  EDIT_USER_PASSWORD_FULFILLED,
+  EDIT_USER_PASSWORD_REJECTED,
+} from '../actions/user';
 
 export default function user(
   state = {
@@ -6,6 +14,10 @@ export default function user(
     username: null,
     email: null,
     exp: null,
+    isEditingUsername: false,
+    isEditingPassword: false,
+    editUsernameError: null,
+    editPasswordError: null,
   },
   action,
 ) {
@@ -17,6 +29,40 @@ export default function user(
         username: action.payload.username,
         email: action.payload.email,
         exp: action.payload.exp,
+      };
+    case EDIT_USER_USERNAME:
+      return {
+        ...state,
+        isEditingUsername: true,
+      };
+    case EDIT_USER_USERNAME_FULFILLED:
+      return {
+        ...state,
+        isEditingUsername: false,
+        username: action.payload.username,
+        email: action.payload.email,
+      };
+    case EDIT_USER_USERNAME_REJECTED:
+      return {
+        ...state,
+        isEditingUsername: false,
+        editUsernameError: action.payload,
+      };
+    case EDIT_USER_PASSWORD:
+      return {
+        ...state,
+        isEditingPassword: true,
+      };
+    case EDIT_USER_PASSWORD_FULFILLED:
+      return {
+        ...state,
+        isEditingPassword: false,
+      };
+    case EDIT_USER_PASSWORD_REJECTED:
+      return {
+        ...state,
+        isEditingPassword: false,
+        editPasswordError: action.payload,
       };
     default:
       return state;

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -14,6 +14,7 @@ export default function user(
     username: null,
     email: null,
     exp: null,
+    isSocial: false,
     isEditingUsername: false,
     isEditingPassword: false,
     editUsernameError: null,
@@ -29,6 +30,7 @@ export default function user(
         username: action.payload.username,
         email: action.payload.email,
         exp: action.payload.exp,
+        isSocial: action.payload.isSocial,
       };
     case EDIT_USER_USERNAME:
       return {


### PR DESCRIPTION
Closes #19 

Adds the user settings page:
![image](https://user-images.githubusercontent.com/1184314/54004151-89e9b880-4122-11e9-8942-611ede3f0f06.png)
Handles errors from the backend:
![image](https://user-images.githubusercontent.com/1184314/54004194-ae459500-4122-11e9-9d40-57b491aa2509.png)
Password form is hidden for social auth users:
![image](https://user-images.githubusercontent.com/1184314/54004320-2318cf00-4123-11e9-9f18-41b2e27ab83c.png)

The backend API has different endpoints for username and password, so they were split into different forms. Redirects the user back to the login page since changing these settings logs the user out of the backend. There currently is no endpoint for changing email. This seems to be a limitation of `django-rest-auth` and `django-allauth`