### PR TITLE
Read-only Mission Control

### DIFF
--- a/src/components/ProgramCollection.js
+++ b/src/components/ProgramCollection.js
@@ -134,7 +134,7 @@ class ProgramCollection extends Component {
                   </Card.Meta>
                 </Card.Content>
                 <Card.Content extra>
-                  <Button primary id={program.id} onClick={onProgramClick}>
+                  <Button primary id={program.id} data-owned={owned} onClick={onProgramClick}>
                     { owned ? 'Keep Working' : 'View' }
                   </Button>
                   {

--- a/src/components/ProgramList.js
+++ b/src/components/ProgramList.js
@@ -13,6 +13,7 @@ import ProgramCollection from './ProgramCollection';
 
 const defaultState = {
   programLoaded: false,
+  programReadOnly: false,
   confirmOpen: false,
   focusProgram: {
     id: null,
@@ -63,9 +64,11 @@ class ProgramList extends Component {
 
   loadProgram = (e) => {
     const { fetchProgram } = this.props;
+    const readOnly = e.target.dataset.owned === 'false';
 
     fetchProgram(e.target.id).then(() => this.setState({
       programLoaded: true,
+      programReadOnly: readOnly,
     }));
   }
 
@@ -100,7 +103,12 @@ class ProgramList extends Component {
 
   render() {
     const { programs, userPrograms } = this.props;
-    const { confirmOpen, focusProgram, programLoaded } = this.state;
+    const {
+      confirmOpen,
+      focusProgram,
+      programLoaded,
+      programReadOnly,
+    } = this.state;
 
     return (
       <Fragment>
@@ -109,9 +117,13 @@ class ProgramList extends Component {
           New Program
         </Button>
         {
-          programLoaded
-            ? (<Redirect to="/mission-control" />)
-            : (null)
+          programLoaded ? (
+            <Redirect to={{
+              pathname: '/mission-control',
+              state: { readOnly: programReadOnly },
+            }}
+            />
+          ) : (null)
         }
         {
           userPrograms === null

--- a/src/components/ProgramName.js
+++ b/src/components/ProgramName.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Fragment } from 'react';
 import { Confirm, Input } from 'semantic-ui-react';
 import { connect } from 'react-redux';
 import { hot } from 'react-hot-loader';
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 
 import { updateValidAuth } from '@/actions/auth';
 import { changeName as actionChangeName } from '@/actions/code';
+import ReadOnlyComponent from '@/components/ReadOnly';
 
 const mapStateToProps = ({ code }) => ({ code });
 const mapDispatchToProps = (dispatch, { cookies }) => ({
@@ -25,7 +26,7 @@ const mapDispatchToProps = (dispatch, { cookies }) => ({
   },
 });
 
-class Console extends Component {
+class ProgramName extends ReadOnlyComponent {
   constructor(props) {
     super(props);
 
@@ -88,6 +89,7 @@ class Console extends Component {
           type="text"
           label="Name:"
           defaultValue={editingName}
+          disabled={this.isReadOnly()}
           onChange={this.handleChange}
           {...actionProp}
         />
@@ -102,7 +104,7 @@ class Console extends Component {
   }
 }
 
-Console.propTypes = {
+ProgramName.propTypes = {
   code: PropTypes.shape({
     id: PropTypes.number,
     name: PropTypes.string,
@@ -110,4 +112,4 @@ Console.propTypes = {
   changeName: PropTypes.func.isRequired,
 };
 
-export default hot(module)(withCookies(connect(mapStateToProps, mapDispatchToProps)(Console)));
+export default hot(module)(withCookies(connect(mapStateToProps, mapDispatchToProps)(ProgramName)));

--- a/src/components/ReadOnly.js
+++ b/src/components/ReadOnly.js
@@ -1,0 +1,36 @@
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+
+class ReadOnly extends Component {
+  isReadOnly = () => {
+    const { location } = this.props;
+
+    if (!location.state) {
+      location.state = {
+        readOnly: false,
+      };
+    }
+
+    const { state: { readOnly } } = location;
+
+    return readOnly;
+  }
+}
+
+ReadOnly.defaultProps = {
+  location: {
+    state: {
+      readOnly: false,
+    },
+  },
+};
+
+ReadOnly.propTypes = {
+  location: PropTypes.shape({
+    state: PropTypes.shape({
+      readOnly: PropTypes.bool,
+    }),
+  }),
+};
+
+export default ReadOnly;

--- a/src/components/RoverConnection.js
+++ b/src/components/RoverConnection.js
@@ -26,6 +26,10 @@ class RoverConnection extends Component {
     this.sendCommand();
   }
 
+  componentWillUnmount() {
+    clearTimeout(this.timeout);
+  }
+
   startHeartbeatTimer = () => {
     this.timeout = setTimeout(this.setOffline, heartbeatTimeout);
   }

--- a/src/components/__tests__/ProgramList.test.js
+++ b/src/components/__tests__/ProgramList.test.js
@@ -127,7 +127,12 @@ describe('The ProgramList component', () => {
     });
 
     expect(wrapper.find(Redirect).exists()).toBe(true);
-    expect(wrapper.find(Redirect).at(0).prop('to')).toBe('/mission-control');
+    expect(wrapper.find(Redirect).at(0).prop('to')).toEqual({
+      pathname: '/mission-control',
+      state: {
+        readOnly: false,
+      },
+    });
   });
 
   test('loads a program', async () => {
@@ -157,6 +162,9 @@ describe('The ProgramList component', () => {
     await wrapper.instance().loadProgram({
       target: {
         id: 33,
+        dataset: {
+          owned: 'false',
+        },
       },
     });
 

--- a/src/components/__tests__/ProgramName.test.js
+++ b/src/components/__tests__/ProgramName.test.js
@@ -37,6 +37,16 @@ describe('The Console component', () => {
     expect(wrapper.find(Confirm).prop('open')).toBe(false);
     expect(wrapper.find(Input).length).toBe(1);
     expect(wrapper.find(Input).props().defaultValue).toBe('test name');
+    expect(wrapper.find(Input).props().disabled).toBe(false);
+  });
+
+  test('disabled when read only', () => {
+    const wrapper = shallow(
+      <ProgramName store={store} location={{ state: { readOnly: true } }} />,
+      { context },
+    ).dive().dive();
+
+    expect(wrapper.find(Input).props().disabled).toBe(true);
   });
 
   test('handles change', () => {

--- a/src/components/__tests__/RoverConnection.test.js
+++ b/src/components/__tests__/RoverConnection.test.js
@@ -354,6 +354,10 @@ describe('The RoverList component', () => {
     jest.runAllTimers();
 
     expect(wrapper.state('online')).toBe(false);
+
+    wrapper.unmount();
+
+    expect(clearTimeout).toHaveBeenCalledTimes(1);
   });
 
   test('sends all commands when active', () => {

--- a/src/components/__tests__/Workspace.test.js
+++ b/src/components/__tests__/Workspace.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Message } from 'semantic-ui-react';
 import { mount, shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import { Cookies } from 'react-cookie';
@@ -82,6 +83,7 @@ describe('The Workspace component', () => {
 
     wrapper.dive().dive().instance().updateJsCode();
     expect(Blockly.JavaScript.STATEMENT_PREFIX).toEqual('highlightBlock(%1);\n');
+    expect(wrapper.find(Message).exists()).toBe(false);
   });
 
   test('goes to running state on state change', () => {
@@ -200,7 +202,7 @@ describe('The Workspace component', () => {
 
   test('updates javascript code', () => {
     const wrapper = shallow(
-      <Workspace store={store}>
+      <Workspace store={store} location={{}}>
         <div />
       </Workspace>, { context },
     );
@@ -211,6 +213,24 @@ describe('The Workspace component', () => {
     workspace.instance().updateCode();
 
     expect(workspace.instance().updateJsCode).toHaveBeenCalled();
+    expect(store.dispatch).toHaveBeenCalledWith(saveProgram());
+  });
+
+  test('updates javascript code when read only', () => {
+    const wrapper = shallow(
+      <Workspace store={store} location={{ state: { readOnly: true } }}>
+        <div />
+      </Workspace>, { context },
+    );
+
+    const workspace = wrapper.dive().dive();
+    workspace.instance().updateJsCode = jest.fn();
+    workspace.update();
+    workspace.instance().updateCode();
+
+    expect(workspace.instance().updateJsCode).toHaveBeenCalled();
+    expect(store.dispatch).not.toHaveBeenCalledWith(saveProgram());
+    expect(workspace.find(Message).exists()).toBe(true);
   });
 
   test('runs code after waking if running', () => {

--- a/src/components/__tests__/__snapshots__/ProgramCollection.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ProgramCollection.test.js.snap
@@ -130,6 +130,7 @@ ShallowWrapper {
             >
               <Button
                 as="button"
+                data-owned={true}
                 id={33}
                 onClick={[MockFunction]}
                 primary={true}
@@ -162,6 +163,7 @@ ShallowWrapper {
             >
               <Button
                 as="button"
+                data-owned={true}
                 id={5}
                 onClick={[MockFunction]}
                 primary={true}
@@ -566,6 +568,7 @@ ShallowWrapper {
               >
                 <Button
                   as="button"
+                  data-owned={true}
                   id={33}
                   onClick={[MockFunction]}
                   primary={true}
@@ -598,6 +601,7 @@ ShallowWrapper {
               >
                 <Button
                   as="button"
+                  data-owned={true}
                   id={5}
                   onClick={[MockFunction]}
                   primary={true}
@@ -639,6 +643,7 @@ ShallowWrapper {
                 >
                   <Button
                     as="button"
+                    data-owned={true}
                     id={33}
                     onClick={[MockFunction]}
                     primary={true}
@@ -709,6 +714,7 @@ ShallowWrapper {
                   "children": Array [
                     <Button
                       as="button"
+                      data-owned={true}
                       id={33}
                       onClick={[MockFunction]}
                       primary={true}
@@ -737,6 +743,7 @@ ShallowWrapper {
                     "props": Object {
                       "as": "button",
                       "children": "Keep Working",
+                      "data-owned": true,
                       "id": 33,
                       "onClick": [MockFunction],
                       "primary": true,
@@ -787,6 +794,7 @@ ShallowWrapper {
                 >
                   <Button
                     as="button"
+                    data-owned={true}
                     id={5}
                     onClick={[MockFunction]}
                     primary={true}
@@ -857,6 +865,7 @@ ShallowWrapper {
                   "children": Array [
                     <Button
                       as="button"
+                      data-owned={true}
                       id={5}
                       onClick={[MockFunction]}
                       primary={true}
@@ -885,6 +894,7 @@ ShallowWrapper {
                     "props": Object {
                       "as": "button",
                       "children": "Keep Working",
+                      "data-owned": true,
                       "id": 5,
                       "onClick": [MockFunction],
                       "primary": true,
@@ -1053,6 +1063,7 @@ ShallowWrapper {
               >
                 <Button
                   as="button"
+                  data-owned={true}
                   id={33}
                   onClick={[MockFunction]}
                   primary={true}
@@ -1085,6 +1096,7 @@ ShallowWrapper {
               >
                 <Button
                   as="button"
+                  data-owned={true}
                   id={5}
                   onClick={[MockFunction]}
                   primary={true}
@@ -1489,6 +1501,7 @@ ShallowWrapper {
                 >
                   <Button
                     as="button"
+                    data-owned={true}
                     id={33}
                     onClick={[MockFunction]}
                     primary={true}
@@ -1521,6 +1534,7 @@ ShallowWrapper {
                 >
                   <Button
                     as="button"
+                    data-owned={true}
                     id={5}
                     onClick={[MockFunction]}
                     primary={true}
@@ -1562,6 +1576,7 @@ ShallowWrapper {
                   >
                     <Button
                       as="button"
+                      data-owned={true}
                       id={33}
                       onClick={[MockFunction]}
                       primary={true}
@@ -1632,6 +1647,7 @@ ShallowWrapper {
                     "children": Array [
                       <Button
                         as="button"
+                        data-owned={true}
                         id={33}
                         onClick={[MockFunction]}
                         primary={true}
@@ -1660,6 +1676,7 @@ ShallowWrapper {
                       "props": Object {
                         "as": "button",
                         "children": "Keep Working",
+                        "data-owned": true,
                         "id": 33,
                         "onClick": [MockFunction],
                         "primary": true,
@@ -1710,6 +1727,7 @@ ShallowWrapper {
                   >
                     <Button
                       as="button"
+                      data-owned={true}
                       id={5}
                       onClick={[MockFunction]}
                       primary={true}
@@ -1780,6 +1798,7 @@ ShallowWrapper {
                     "children": Array [
                       <Button
                         as="button"
+                        data-owned={true}
                         id={5}
                         onClick={[MockFunction]}
                         primary={true}
@@ -1808,6 +1827,7 @@ ShallowWrapper {
                       "props": Object {
                         "as": "button",
                         "children": "Keep Working",
+                        "data-owned": true,
                         "id": 5,
                         "onClick": [MockFunction],
                         "primary": true,

--- a/src/components/__tests__/__snapshots__/ProgramName.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ProgramName.test.js.snap
@@ -13,7 +13,7 @@ exports[`The Console component renders on the page with no errors 1`] = `
     }
   }
 >
-  <Connect(Console)
+  <Connect(ProgramName)
     allCookies={Object {}}
     cookies={
       Cookies {
@@ -36,7 +36,7 @@ exports[`The Console component renders on the page with no errors 1`] = `
       }
     }
   >
-    <Console
+    <ProgramName
       allCookies={Object {}}
       changeName={[Function]}
       code={
@@ -52,6 +52,13 @@ exports[`The Console component renders on the page with no errors 1`] = `
           ],
           "cookies": Object {},
           "hooks": undefined,
+        }
+      }
+      location={
+        Object {
+          "state": Object {
+            "readOnly": false,
+          },
         }
       }
       store={
@@ -88,6 +95,7 @@ exports[`The Console component renders on the page with no errors 1`] = `
     >
       <Input
         defaultValue="test name"
+        disabled={false}
         label="Name:"
         onChange={[Function]}
         type="text"
@@ -108,6 +116,7 @@ exports[`The Console component renders on the page with no errors 1`] = `
           </Label>
           <input
             defaultValue="test name"
+            disabled={false}
             onChange={[Function]}
             type="text"
           />
@@ -146,7 +155,7 @@ exports[`The Console component renders on the page with no errors 1`] = `
           />
         </Modal>
       </Confirm>
-    </Console>
-  </Connect(Console)>
+    </ProgramName>
+  </Connect(ProgramName)>
 </withCookies(Component)>
 `;

--- a/src/components/__tests__/__snapshots__/Workspace.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Workspace.test.js.snap
@@ -185,6 +185,13 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
         }
       }
       createProgram={[Function]}
+      location={
+        Object {
+          "state": Object {
+            "readOnly": false,
+          },
+        }
+      }
       saveProgram={[Function]}
       sendToRover={[Function]}
       sensor={
@@ -363,17 +370,18 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
             "position": "absolute",
           }
         }
-      />
-      <div
-        style={
-          Object {
-            "bottom": 30,
-            "position": "absolute",
-            "right": 100,
-          }
-        }
       >
-        <div />
+        <div
+          style={
+            Object {
+              "bottom": 30,
+              "position": "absolute",
+              "right": 100,
+            }
+          }
+        >
+          <div />
+        </div>
       </div>
     </Workspace>
   </Connect(Workspace)>

--- a/src/containers/MissionControl.js
+++ b/src/containers/MissionControl.js
@@ -6,6 +6,7 @@ import {
   Segment,
 } from 'semantic-ui-react';
 import { hot } from 'react-hot-loader';
+import PropTypes from 'prop-types';
 
 import RoverConnectionList from '@/containers/RoverConnectionList';
 
@@ -16,18 +17,18 @@ import Indicator from '@/components/Indicator';
 import ProgramName from '@/components/ProgramName';
 import Workspace from '@/components/Workspace';
 
-const MissionControl = () => (
+const MissionControl = ({ location }) => (
   <Grid style={{ height: '100vh' }}>
     <Grid.Row>
       <Grid.Column width={13}>
-        <Workspace>
+        <Workspace location={location}>
           <Control />
         </Workspace>
       </Grid.Column>
       <Grid.Column width={3}>
         <Grid.Row>
           <Segment basic compact>
-            <ProgramName />
+            <ProgramName location={location} />
           </Segment>
         </Grid.Row>
         <Divider />
@@ -69,5 +70,21 @@ const MissionControl = () => (
     </Grid.Row>
   </Grid>
 );
+
+MissionControl.defaultProps = {
+  location: {
+    state: {
+      readOnly: false,
+    },
+  },
+};
+
+MissionControl.propTypes = {
+  location: PropTypes.shape({
+    state: PropTypes.shape({
+      readOnly: PropTypes.bool,
+    }),
+  }),
+};
 
 export default hot(module)(MissionControl);

--- a/src/containers/__tests__/__snapshots__/MissionControl.test.js.snap
+++ b/src/containers/__tests__/__snapshots__/MissionControl.test.js.snap
@@ -2,6 +2,13 @@
 
 exports[`The MissionControl container renders on the page with no errors 1`] = `
 <MissionControl
+  location={
+    Object {
+      "state": Object {
+        "readOnly": false,
+      },
+    }
+  }
   store={
     Object {
       "dispatch": [MockFunction] {
@@ -52,7 +59,15 @@ exports[`The MissionControl container renders on the page with no errors 1`] = `
             <div
               className="thirteen wide column"
             >
-              <Component>
+              <Component
+                location={
+                  Object {
+                    "state": Object {
+                      "readOnly": false,
+                    },
+                  }
+                }
+              >
                 <div />
               </Component>
             </div>
@@ -74,7 +89,15 @@ exports[`The MissionControl container renders on the page with no errors 1`] = `
                     <div
                       className="ui basic compact segment"
                     >
-                      <Component>
+                      <Component
+                        location={
+                          Object {
+                            "state": Object {
+                              "readOnly": false,
+                            },
+                          }
+                        }
+                      >
                         <div />
                       </Component>
                     </div>


### PR DESCRIPTION
A part of #64 

Displays mission control read-only when the program is not owned by the user:
![image](https://user-images.githubusercontent.com/1184314/57052707-0d251780-6c57-11e9-964f-538e9289361e.png)

A message informs the user that they are only able to view the program. The program name and workspace are not editable.

The next step will be to add a remix button that copies the program and loads mission control in a writable state.