### PR TITLE
Add error message when social login callback fails

### DIFF
--- a/src/containers/Accounts/Login.js
+++ b/src/containers/Accounts/Login.js
@@ -93,7 +93,7 @@ class Login extends Component {
   }
 
   render() {
-    const { intl } = this.props;
+    const { intl, location } = this.props;
     const { basicError, basicSuccess, socialError } = this.state;
 
     const usernamePlaceholder = intl.formatMessage({
@@ -152,6 +152,24 @@ class Login extends Component {
                       description="Second part of instructions for contacting support"
                       defaultMessage="for help with this issue."
                     />
+                  </p>
+                </Message>
+              </Grid.Row>
+            ) : (null)
+          }
+          {
+            location && location.state && location.state.callbackError ? (
+              <Grid.Row>
+                <Message negative>
+                  <Message.Header>
+                    <FormattedMessage
+                      id="app.login.social_callback_error"
+                      description="Notifies the user of an error in third-party registration"
+                      defaultMessage="There was an error creating an account using social provider."
+                    />
+                  </Message.Header>
+                  <p>
+                    {location.state.callbackError}
                   </p>
                 </Message>
               </Grid.Row>
@@ -254,11 +272,24 @@ class Login extends Component {
   }
 }
 
+Login.defaultProps = {
+  location: {
+    state: {
+      callbackError: null,
+    },
+  },
+};
+
 Login.propTypes = {
   cookies: PropTypes.instanceOf(Cookies).isRequired,
   updateUser: PropTypes.func.isRequired,
   updateValidAuth: PropTypes.func.isRequired,
   intl: intlShape.isRequired,
+  location: PropTypes.shape({
+    state: PropTypes.shape({
+      callbackError: PropTypes.arrayOf(PropTypes.string),
+    }),
+  }),
 };
 
 export default withCookies(injectIntl(connect(null, mapDispatchToProps)(Login)));

--- a/src/containers/Accounts/LoginCallback.js
+++ b/src/containers/Accounts/LoginCallback.js
@@ -24,6 +24,7 @@ class LoginCallback extends Component {
     this.state = {
       loading: true,
       loginSuccess: false,
+      error: null,
     };
   }
 
@@ -46,17 +47,22 @@ class LoginCallback extends Component {
           loginSuccess: true,
         });
       })
-      .catch(() => {
+      .catch((error) => {
+        let errorMessage = null;
+        if (error.response) {
+          errorMessage = error.response.data.non_field_errors;
+        }
         this.setState({
           loading: false,
           loginSuccess: false,
+          error: errorMessage,
         });
       });
   }
 
   redirect = () => {
     const { intl } = this.props;
-    const { loading, loginSuccess } = this.state;
+    const { error, loading, loginSuccess } = this.state;
 
     const loggingIn = intl.formatMessage({
       id: 'app.login_callback.logging_in',
@@ -72,7 +78,13 @@ class LoginCallback extends Component {
       return <Redirect to="/" />;
     }
 
-    return <Redirect to="/accounts/login" />;
+    return (
+      <Redirect to={{
+        pathname: '/accounts/login',
+        state: { callbackError: error },
+      }}
+      />
+    );
   }
 
   render() {

--- a/src/containers/Accounts/__tests__/Login.test.js
+++ b/src/containers/Accounts/__tests__/Login.test.js
@@ -95,6 +95,27 @@ test('Login shows error message on api error', async () => {
   expect(window.location.assign).not.toBeCalled();
 });
 
+test('Login shows error message on callback error', () => {
+  const localLocation = {
+    pathname: '/login',
+    state: {
+      callbackError: ['User is already registered with this e-mail address'],
+    },
+  };
+
+  const cookiesWrapper = shallowWithIntl(<Login location={localLocation} store={store} />, {
+    context: { cookies },
+  });
+
+  const wrapper = cookiesWrapper.dive().dive().dive();
+
+  expect(wrapper.find(Message).exists()).toBe(true);
+  expect(wrapper.find(MessageHeader).children().find(FormattedMessage).prop('defaultMessage')).toBe(
+    'There was an error creating an account using social provider.',
+  );
+  expect(wrapper.find(Message).find('p').text()).toBe(localLocation.state.callbackError[0]);
+});
+
 test('Login redirects to root after basic login success', async () => {
   const token = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VybmFtZSI6ImFkbWluIiwiZXhwIjoxNTQwMzQzMjIxLCJlbWFpbCI6ImFkbWluQGV4YW1wbGUuY29tIiwib3JpZ19pYXQiOjE1NDAzMzk2MjF9.tumcSSAbKeWXc2QDd7KFR9IGh3PCsyHnCe6JLSszWpc';
   const username = 'admin';

--- a/src/containers/Accounts/__tests__/LoginCallback.test.js
+++ b/src/containers/Accounts/__tests__/LoginCallback.test.js
@@ -73,7 +73,10 @@ test('LoginCallback redirects to login after failure', async () => {
 
   const redirect = wrapper.find(Redirect);
   expect(redirect.exists()).toBe(true);
-  expect(redirect.prop('to')).toBe('/accounts/login');
+  expect(redirect.prop('to')).toStrictEqual({
+    pathname: '/accounts/login',
+    state: { callbackError: null },
+  });
   expect(wrapper.find(Loader).exists()).toBe(false);
   expect(cookies.get('auth_jwt')).toBeUndefined();
 });

--- a/src/translations/locales/en.json
+++ b/src/translations/locales/en.json
@@ -22,6 +22,7 @@
   "app.login.password": "Password",
   "app.login.sign_in": "Sign In",
   "app.login.social": "You can sign up / sign in with one of your existing third-party accounts.",
+  "app.login.social_callback_error": "There was an error creating an account using social provider.",
   "app.login.social_contact_1": "Contact",
   "app.login.social_contact_2": "for help with this issue.",
   "app.login.social_error": "There was an error initiating social login.",

--- a/src/translations/locales/es.json
+++ b/src/translations/locales/es.json
@@ -22,6 +22,7 @@
   "app.login.password": "Password",
   "app.login.sign_in": "Sign In",
   "app.login.social": "You can sign up / sign in with one of your existing third-party accounts.",
+  "app.login.social_callback_error": "There was an error creating an account using social provider.",
   "app.login.social_contact_1": "Contact",
   "app.login.social_contact_2": "for help with this issue.",
   "app.login.social_error": "There was an error initiating social login.",


### PR DESCRIPTION
Added notification when the callback from the social provider fails:
![image](https://user-images.githubusercontent.com/1184314/62000851-d0c75300-b0af-11e9-8e16-ca1d679110ae.png)
