### PR TITLE
Move common auth check code to one place

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -13,3 +13,19 @@ export const updateValidAuth = isValidAuth => ({
 export const logout = () => ({
   type: USER_LOGOUT,
 });
+
+// helper functions
+export const checkAuthError = dispatch => (error) => {
+  if (error.response.status === 401) {
+    // Authentication is no longer valid
+    dispatch(updateValidAuth(false));
+  } else {
+    throw error;
+  }
+};
+
+export const authHeader = cookies => ({
+  headers: {
+    Authorization: `JWT ${cookies.get('auth_jwt')}`,
+  },
+});

--- a/src/components/ProgramName.js
+++ b/src/components/ProgramName.js
@@ -6,24 +6,13 @@ import { withCookies } from 'react-cookie';
 import { injectIntl, intlShape } from 'react-intl';
 import PropTypes from 'prop-types';
 
-import { updateValidAuth } from '@/actions/auth';
+import { checkAuthError, authHeader } from '@/actions/auth';
 import { changeName as actionChangeName } from '@/actions/code';
 
 const mapStateToProps = ({ code }) => ({ code });
 const mapDispatchToProps = (dispatch, { cookies }) => ({
-  changeName: (id, name) => {
-    const changeNameAction = actionChangeName(id, name, {
-      headers: {
-        Authorization: `JWT ${cookies.get('auth_jwt')}`,
-      },
-    });
-    return dispatch(changeNameAction).catch((error) => {
-      if (error.response.status === 401) {
-        // Authentication is no longer valid
-        dispatch(updateValidAuth(false));
-      }
-    });
-  },
+  changeName: (id, name) => dispatch(actionChangeName(id, name, authHeader(cookies)))
+    .catch(checkAuthError(dispatch)),
 });
 
 class ProgramName extends Component {

--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -8,7 +8,7 @@ import { hot } from 'react-hot-loader';
 import { withCookies } from 'react-cookie';
 import Interpreter from 'js-interpreter';
 
-import { updateValidAuth } from '@/actions/auth';
+import { checkAuthError, authHeader } from '@/actions/auth';
 import {
   updateJsCode as actionUpdateJsCode,
   updateXmlCode as actionUpdateXmlCode,
@@ -36,45 +36,13 @@ const mapDispatchToProps = (dispatch, { cookies }) => ({
   updateXmlCode: xmlCode => dispatch(actionUpdateXmlCode(xmlCode)),
   sendToRover: command => dispatch(pushCommand(command)),
   changeReadOnly: isReadOnly => dispatch(actionChangeReadOnly(isReadOnly)),
-  saveProgram: (id, content, name) => {
-    const saveProgramAction = actionSaveProgram(id, content, name, {
-      headers: {
-        Authorization: `JWT ${cookies.get('auth_jwt')}`,
-      },
-    });
-    return dispatch(saveProgramAction).catch((error) => {
-      if (error.response.status === 401) {
-        // Authentication is no longer valid
-        dispatch(updateValidAuth(false));
-      }
-    });
-  },
-  createProgram: (name) => {
-    const createProgramAction = actionCreateProgram(name, {
-      headers: {
-        Authorization: `JWT ${cookies.get('auth_jwt')}`,
-      },
-    });
-    return dispatch(createProgramAction).catch((error) => {
-      if (error.response.status === 401) {
-        // Authentication is no longer valid
-        dispatch(updateValidAuth(false));
-      }
-    });
-  },
-  fetchProgram: (id) => {
-    const fetchProgramAction = actionFetchProgram(id, {
-      headers: {
-        Authorization: `JWT ${cookies.get('auth_jwt')}`,
-      },
-    });
-    return dispatch(fetchProgramAction).catch((error) => {
-      if (error.response.status === 401) {
-        // Authentication is no longer valid
-        dispatch(updateValidAuth(false));
-      }
-    });
-  },
+  saveProgram: (id, content, name) => dispatch(
+    actionSaveProgram(id, content, name, authHeader(cookies)),
+  ).catch(checkAuthError(dispatch)),
+  createProgram: name => dispatch(actionCreateProgram(name, authHeader(cookies)))
+    .catch(checkAuthError(dispatch)),
+  fetchProgram: id => dispatch(actionFetchProgram(id, authHeader(cookies)))
+    .catch(checkAuthError(dispatch)),
 });
 
 const toolbox = `

--- a/src/components/__tests__/ProgramName.test.js
+++ b/src/components/__tests__/ProgramName.test.js
@@ -121,7 +121,9 @@ describe('The ProgramName component', () => {
     error.response = {
       status: 401,
     };
-    store.dispatch = jest.fn(() => Promise.reject(error));
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(Promise.reject(error));
+    store.dispatch.mockReturnValue(Promise.resolve());
 
     const wrapper = shallowWithIntl(<ProgramName store={store} />, { context }).dive();
     wrapper.dive().props().changeName(1, 'testname').then(() => {
@@ -146,7 +148,7 @@ describe('The ProgramName component', () => {
     store.dispatch = jest.fn(() => Promise.reject(error));
 
     const wrapper = shallowWithIntl(<ProgramName store={store} />, { context }).dive();
-    wrapper.dive().props().changeName(1, 'testname').then(() => {
+    wrapper.dive().props().changeName(1, 'testname').catch(() => {
       expect(store.dispatch.mock.calls.length).toBe(1);
       expect(store.dispatch).toHaveBeenCalledWith(
         changeName(1, 'testname', {

--- a/src/components/__tests__/Workspace.test.js
+++ b/src/components/__tests__/Workspace.test.js
@@ -527,7 +527,9 @@ describe('The Workspace component', () => {
     error.response = {
       status: 401,
     };
-    store.dispatch = jest.fn(() => Promise.reject(error));
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(Promise.reject(error));
+    store.dispatch.mockReturnValue(Promise.resolve());
 
     const wrapper = shallowWithIntl(
       <Workspace store={store}>
@@ -560,7 +562,7 @@ describe('The Workspace component', () => {
         <div />
       </Workspace>, { context },
     ).dive();
-    wrapper.dive().props().saveProgram(1, '<xml></xml>', 'test').then(() => {
+    wrapper.dive().props().saveProgram(1, '<xml></xml>', 'test').catch(() => {
       expect(store.dispatch.mock.calls.length).toBe(1);
       expect(store.dispatch).toHaveBeenCalledWith(
         saveProgram(1, '<xml></xml>', 'test', {
@@ -578,7 +580,9 @@ describe('The Workspace component', () => {
     error.response = {
       status: 401,
     };
-    store.dispatch = jest.fn(() => Promise.reject(error));
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(Promise.reject(error));
+    store.dispatch.mockReturnValue(Promise.resolve());
 
     const wrapper = shallowWithIntl(
       <Workspace store={store}>
@@ -611,7 +615,7 @@ describe('The Workspace component', () => {
         <div />
       </Workspace>, { context },
     ).dive();
-    wrapper.dive().props().createProgram('test').then(() => {
+    wrapper.dive().props().createProgram('test').catch(() => {
       expect(store.dispatch.mock.calls.length).toBe(1);
       expect(store.dispatch).toHaveBeenCalledWith(
         createProgram('test', {
@@ -629,7 +633,9 @@ describe('The Workspace component', () => {
     error.response = {
       status: 401,
     };
-    store.dispatch = jest.fn(() => Promise.reject(error));
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(Promise.reject(error));
+    store.dispatch.mockReturnValue(Promise.resolve());
 
     const wrapper = shallowWithIntl(
       <Workspace store={store}>
@@ -662,7 +668,7 @@ describe('The Workspace component', () => {
         <div />
       </Workspace>, { context },
     ).dive();
-    wrapper.dive().props().fetchProgram(1).then(() => {
+    wrapper.dive().props().fetchProgram(1).catch(() => {
       expect(store.dispatch.mock.calls.length).toBe(1);
       expect(store.dispatch).toHaveBeenCalledWith(
         fetchProgram(1, {

--- a/src/containers/ProgramList.js
+++ b/src/containers/ProgramList.js
@@ -4,53 +4,22 @@ import { hot } from 'react-hot-loader';
 import { withCookies, Cookies } from 'react-cookie';
 import { changeReadOnly as actionChangeReadOnly, fetchProgram } from '../actions/code';
 import { fetchPrograms, removeProgram } from '../actions/program';
-import { updateValidAuth } from '../actions/auth';
+import { checkAuthError, authHeader } from '../actions/auth';
 import ProgramList from '../components/ProgramList';
 
 const mapStateToProps = ({ code, program, user }) => ({ code, ...program, user });
 const mapDispatchToProps = (dispatch, { cookies }) => ({
-  fetchProgram: (id) => {
-    const fetchProgramAction = fetchProgram(id, {
-      headers: {
-        Authorization: `JWT ${cookies.get('auth_jwt')}`,
-      },
-    });
-    return dispatch(fetchProgramAction).catch((error) => {
-      if (error.response.status === 401) {
-        // Authentication is no longer valid
-        dispatch(updateValidAuth(false));
-      }
-    });
-  },
+  fetchProgram: id => dispatch(fetchProgram(id, authHeader(cookies)))
+    .catch(checkAuthError(dispatch)),
   fetchPrograms: (params) => {
-    const xhrOptions = {
-      headers: {
-        Authorization: `JWT ${cookies.get('auth_jwt')}`,
-      },
-      params,
-    };
+    const xhrOptions = authHeader(cookies);
 
-    const fetchProgramsAction = fetchPrograms(xhrOptions);
-    return dispatch(fetchProgramsAction).catch((error) => {
-      if (error.response.status === 401) {
-        // Authentication is no longer valid
-        dispatch(updateValidAuth(false));
-      }
-    });
+    xhrOptions.params = params;
+
+    return dispatch(fetchPrograms(xhrOptions)).catch(checkAuthError(dispatch));
   },
-  removeProgram: (id) => {
-    const removeProgramAction = removeProgram(id, {
-      headers: {
-        Authorization: `JWT ${cookies.get('auth_jwt')}`,
-      },
-    });
-    return dispatch(removeProgramAction).catch((error) => {
-      if (error.response.status === 401) {
-        // Authentication is no longer valid
-        dispatch(updateValidAuth(false));
-      }
-    });
-  },
+  removeProgram: id => dispatch(removeProgram(id, authHeader(cookies)))
+    .catch(checkAuthError(dispatch)),
   changeReadOnly: isReadOnly => dispatch(actionChangeReadOnly(isReadOnly)),
 });
 

--- a/src/containers/RoverConnectionList.js
+++ b/src/containers/RoverConnectionList.js
@@ -12,24 +12,12 @@ import {
   changeLeftSensorState as actionChangeLeftSensorState,
   changeRightSensorState as actionChangeRightSensorState,
 } from '@/actions/sensor';
-import { updateValidAuth } from '@/actions/auth';
+import { checkAuthError, authHeader } from '@/actions/auth';
 import RoverConnectionList from '@/components/RoverConnectionList';
 
 const mapStateToProps = ({ rover }) => ({ ...rover });
 const mapDispatchToProps = (dispatch, { cookies }) => ({
-  fetchRovers: () => {
-    const fetchRoversAction = fetchRovers({
-      headers: {
-        Authorization: `JWT ${cookies.get('auth_jwt')}`,
-      },
-    });
-    return dispatch(fetchRoversAction).catch((error) => {
-      if (error.response.status === 401) {
-        // Authentication is no longer valid
-        dispatch(updateValidAuth(false));
-      }
-    });
-  },
+  fetchRovers: () => dispatch(fetchRovers(authHeader(cookies))).catch(checkAuthError(dispatch)),
   changeLeftSensorState: state => dispatch(actionChangeLeftSensorState(state)),
   changeRightSensorState: state => dispatch(actionChangeRightSensorState(state)),
   changeActiveRover: clientId => dispatch(actionChangeActiveRover(clientId)),

--- a/src/containers/RoverDetail.js
+++ b/src/containers/RoverDetail.js
@@ -3,38 +3,16 @@ import { connect } from 'react-redux';
 import { hot } from 'react-hot-loader';
 import { withCookies, Cookies } from 'react-cookie';
 import { editRover, fetchRover } from '../actions/rover';
-import { updateValidAuth } from '../actions/auth';
+import { checkAuthError, authHeader } from '../actions/auth';
 import RoverDetail from '../components/RoverDetail';
 
 const mapStateToProps = ({ rover }) => ({ ...rover });
 const mapDispatchToProps = (dispatch, { cookies, match }) => ({
   id: parseInt(match.params.id, 10),
-  editRover: (id, settings) => {
-    const editRoverAction = editRover(id, settings, {
-      headers: {
-        Authorization: `JWT ${cookies.get('auth_jwt')}`,
-      },
-    });
-    return dispatch(editRoverAction).catch((error) => {
-      if (error.response.status === 401) {
-        // Authentication is no longer valid
-        dispatch(updateValidAuth(false));
-      }
-    });
-  },
-  fetchRover: (id) => {
-    const fetchRoverAction = fetchRover(id, {
-      headers: {
-        Authorization: `JWT ${cookies.get('auth_jwt')}`,
-      },
-    });
-    return dispatch(fetchRoverAction).catch((error) => {
-      if (error.response.status === 401) {
-        // Authentication is no longer valid
-        dispatch(updateValidAuth(false));
-      }
-    });
-  },
+  editRover: (id, settings) => dispatch(editRover(id, settings, authHeader(cookies)))
+    .catch(checkAuthError(dispatch)),
+  fetchRover: id => dispatch(fetchRover(id, authHeader(cookies)))
+    .catch(checkAuthError(dispatch)),
 });
 
 const RoverDetailContainer = connect(

--- a/src/containers/RoverList.js
+++ b/src/containers/RoverList.js
@@ -3,56 +3,24 @@ import { connect } from 'react-redux';
 import { hot } from 'react-hot-loader';
 import { withCookies, Cookies } from 'react-cookie';
 import { createRover, fetchRovers, removeRover } from '../actions/rover';
-import { updateValidAuth } from '../actions/auth';
+import { checkAuthError, authHeader } from '../actions/auth';
 import RoverList from '../components/RoverList';
 
 const mapStateToProps = ({ rover }) => ({ ...rover });
 const mapDispatchToProps = (dispatch, { cookies }) => ({
   fetchRovers: (page) => {
-    const xhrOptions = {
-      headers: {
-        Authorization: `JWT ${cookies.get('auth_jwt')}`,
-      },
-    };
+    const xhrOptions = authHeader(cookies);
 
     if (page) {
       xhrOptions.params = { page };
     }
 
-    const fetchRoversAction = fetchRovers(xhrOptions);
-    return dispatch(fetchRoversAction).catch((error) => {
-      if (error.response.status === 401) {
-        // Authentication is no longer valid
-        dispatch(updateValidAuth(false));
-      }
-    });
+    return dispatch(fetchRovers(xhrOptions)).catch(checkAuthError(dispatch));
   },
-  createRover: (settings) => {
-    const createRoverAction = createRover(settings, {
-      headers: {
-        Authorization: `JWT ${cookies.get('auth_jwt')}`,
-      },
-    });
-    return dispatch(createRoverAction).catch((error) => {
-      if (error.response.status === 401) {
-        // Authentication is no longer valid
-        dispatch(updateValidAuth(false));
-      }
-    });
-  },
-  removeRover: (id) => {
-    const removeRoverAction = removeRover(id, {
-      headers: {
-        Authorization: `JWT ${cookies.get('auth_jwt')}`,
-      },
-    });
-    return dispatch(removeRoverAction).catch((error) => {
-      if (error.response.status === 401) {
-        // Authentication is no longer valid
-        dispatch(updateValidAuth(false));
-      }
-    });
-  },
+  createRover: settings => dispatch(createRover(settings, authHeader(cookies)))
+    .catch(checkAuthError(dispatch)),
+  removeRover: id => dispatch(removeRover(id, authHeader(cookies)))
+    .catch(checkAuthError(dispatch)),
 });
 
 const RoverListContainer = connect(

--- a/src/containers/UserSetting.js
+++ b/src/containers/UserSetting.js
@@ -3,39 +3,15 @@ import { connect } from 'react-redux';
 import { hot } from 'react-hot-loader';
 import { withCookies, Cookies } from 'react-cookie';
 import { editUserPassword, editUserUsername } from '@/actions/user';
-import { updateValidAuth } from '@/actions/auth';
+import { checkAuthError, authHeader } from '@/actions/auth';
 import UserSetting from '@/components/UserSetting';
 
 const mapStateToProps = ({ user }) => ({ user });
 const mapDispatchToProps = (dispatch, { cookies }) => ({
-  editUserUsername: (username) => {
-    const editUserUsernameAction = editUserUsername(username, {
-      headers: {
-        Authorization: `JWT ${cookies.get('auth_jwt')}`,
-      },
-    });
-    return dispatch(editUserUsernameAction).catch((error) => {
-      if (error.response.status === 401) {
-        // Authentication is no longer valid
-        return dispatch(updateValidAuth(false));
-      }
-      throw error;
-    });
-  },
-  editUserPassword: (password) => {
-    const editUserPasswordAction = editUserPassword(password, {
-      headers: {
-        Authorization: `JWT ${cookies.get('auth_jwt')}`,
-      },
-    });
-    return dispatch(editUserPasswordAction).catch((error) => {
-      if (error.response.status === 401) {
-        // Authentication is no longer valid
-        return dispatch(updateValidAuth(false));
-      }
-      throw error;
-    });
-  },
+  editUserUsername: username => dispatch(editUserUsername(username, authHeader(cookies)))
+    .catch(checkAuthError(dispatch)),
+  editUserPassword: password => dispatch(editUserPassword(password, authHeader(cookies)))
+    .catch(checkAuthError(dispatch)),
 });
 
 const UserSettingContainer = connect(

--- a/src/containers/__tests__/ProgramList.test.js
+++ b/src/containers/__tests__/ProgramList.test.js
@@ -145,7 +145,9 @@ describe('The ProgramListContainer', () => {
     error.response = {
       status: 401,
     };
-    store.dispatch = jest.fn(() => Promise.reject(error));
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(Promise.reject(error));
+    store.dispatch.mockReturnValue(Promise.resolve());
 
     wrapper.dive().props().fetchPrograms().then(() => {
       expect(store.dispatch.mock.calls.length).toBe(2);
@@ -166,7 +168,9 @@ describe('The ProgramListContainer', () => {
     error.response = {
       status: 401,
     };
-    store.dispatch = jest.fn(() => Promise.reject(error));
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(Promise.reject(error));
+    store.dispatch.mockReturnValue(Promise.resolve());
 
     wrapper.dive().props().fetchProgram().then(() => {
       expect(store.dispatch.mock.calls.length).toBe(2);
@@ -187,7 +191,9 @@ describe('The ProgramListContainer', () => {
     error.response = {
       status: 401,
     };
-    store.dispatch = jest.fn(() => Promise.reject(error));
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(Promise.reject(error));
+    store.dispatch.mockReturnValue(Promise.resolve());
 
     wrapper.dive().props().removeProgram(1).then(() => {
       expect(store.dispatch.mock.calls.length).toBe(2);
@@ -210,7 +216,7 @@ describe('The ProgramListContainer', () => {
     };
     store.dispatch = jest.fn(() => Promise.reject(error));
 
-    wrapper.dive().props().fetchPrograms().then(() => {
+    wrapper.dive().props().fetchPrograms().catch(() => {
       expect(store.dispatch.mock.calls.length).toBe(1);
       expect(store.dispatch).toHaveBeenCalledWith(
         fetchPrograms({
@@ -230,7 +236,7 @@ describe('The ProgramListContainer', () => {
     };
     store.dispatch = jest.fn(() => Promise.reject(error));
 
-    wrapper.dive().props().fetchProgram().then(() => {
+    wrapper.dive().props().fetchProgram().catch(() => {
       expect(store.dispatch.mock.calls.length).toBe(1);
       expect(store.dispatch).toHaveBeenCalledWith(
         fetchProgram({
@@ -250,7 +256,7 @@ describe('The ProgramListContainer', () => {
     };
     store.dispatch = jest.fn(() => Promise.reject(error));
 
-    wrapper.dive().props().removeProgram(1).then(() => {
+    wrapper.dive().props().removeProgram(1).catch(() => {
       expect(store.dispatch.mock.calls.length).toBe(1);
       expect(store.dispatch).toHaveBeenCalledWith(
         removeProgram(1, {

--- a/src/containers/__tests__/RoverConnectionList.test.js
+++ b/src/containers/__tests__/RoverConnectionList.test.js
@@ -86,7 +86,9 @@ describe('The RoverListConnectionContainer', () => {
     error.response = {
       status: 401,
     };
-    store.dispatch = jest.fn(() => Promise.reject(error));
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(Promise.reject(error));
+    store.dispatch.mockReturnValue(Promise.resolve());
 
     wrapper.dive().props().fetchRovers().then(() => {
       expect(store.dispatch.mock.calls.length).toBe(2);
@@ -109,7 +111,7 @@ describe('The RoverListConnectionContainer', () => {
     };
     store.dispatch = jest.fn(() => Promise.reject(error));
 
-    wrapper.dive().props().fetchRovers().then(() => {
+    wrapper.dive().props().fetchRovers().catch(() => {
       expect(store.dispatch.mock.calls.length).toBe(1);
       expect(store.dispatch).toHaveBeenCalledWith(
         fetchRovers({

--- a/src/containers/__tests__/RoverDetail.test.js
+++ b/src/containers/__tests__/RoverDetail.test.js
@@ -79,7 +79,9 @@ describe('The RoverDetailContainer', () => {
     error.response = {
       status: 401,
     };
-    store.dispatch = jest.fn(() => Promise.reject(error));
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(Promise.reject(error));
+    store.dispatch.mockReturnValue(Promise.resolve());
 
     wrapper.dive().props().fetchRover().then(() => {
       expect(store.dispatch.mock.calls.length).toBe(2);
@@ -104,7 +106,9 @@ describe('The RoverDetailContainer', () => {
     error.response = {
       status: 401,
     };
-    store.dispatch = jest.fn(() => Promise.reject(error));
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(Promise.reject(error));
+    store.dispatch.mockReturnValue(Promise.resolve());
 
     wrapper.dive().props().editRover(1, rover).then(() => {
       expect(store.dispatch.mock.calls.length).toBe(2);
@@ -127,7 +131,7 @@ describe('The RoverDetailContainer', () => {
     };
     store.dispatch = jest.fn(() => Promise.reject(error));
 
-    wrapper.dive().props().fetchRover().then(() => {
+    wrapper.dive().props().fetchRover().catch(() => {
       expect(store.dispatch.mock.calls.length).toBe(1);
       expect(store.dispatch).toHaveBeenCalledWith(
         fetchRover({
@@ -151,7 +155,7 @@ describe('The RoverDetailContainer', () => {
     };
     store.dispatch = jest.fn(() => Promise.reject(error));
 
-    wrapper.dive().props().editRover(1, rover).then(() => {
+    wrapper.dive().props().editRover(1, rover).catch(() => {
       expect(store.dispatch.mock.calls.length).toBe(1);
       expect(store.dispatch).toHaveBeenCalledWith(
         editRover(1, rover, {

--- a/src/containers/__tests__/RoverList.test.js
+++ b/src/containers/__tests__/RoverList.test.js
@@ -94,7 +94,9 @@ describe('The RoverListContainer', () => {
     error.response = {
       status: 401,
     };
-    store.dispatch = jest.fn(() => Promise.reject(error));
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(Promise.reject(error));
+    store.dispatch.mockReturnValue(Promise.resolve());
 
     wrapper.dive().props().fetchRovers().then(() => {
       expect(store.dispatch.mock.calls.length).toBe(2);
@@ -119,7 +121,9 @@ describe('The RoverListContainer', () => {
     error.response = {
       status: 401,
     };
-    store.dispatch = jest.fn(() => Promise.reject(error));
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(Promise.reject(error));
+    store.dispatch.mockReturnValue(Promise.resolve());
 
     wrapper.dive().props().createRover(rover).then(() => {
       expect(store.dispatch.mock.calls.length).toBe(2);
@@ -140,7 +144,9 @@ describe('The RoverListContainer', () => {
     error.response = {
       status: 401,
     };
-    store.dispatch = jest.fn(() => Promise.reject(error));
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(Promise.reject(error));
+    store.dispatch.mockReturnValue(Promise.resolve());
 
     wrapper.dive().props().removeRover(1).then(() => {
       expect(store.dispatch.mock.calls.length).toBe(2);
@@ -163,7 +169,7 @@ describe('The RoverListContainer', () => {
     };
     store.dispatch = jest.fn(() => Promise.reject(error));
 
-    wrapper.dive().props().fetchRovers().then(() => {
+    wrapper.dive().props().fetchRovers().catch(() => {
       expect(store.dispatch.mock.calls.length).toBe(1);
       expect(store.dispatch).toHaveBeenCalledWith(
         fetchRovers({
@@ -187,7 +193,7 @@ describe('The RoverListContainer', () => {
     };
     store.dispatch = jest.fn(() => Promise.reject(error));
 
-    wrapper.dive().props().createRover(rover).then(() => {
+    wrapper.dive().props().createRover(rover).catch(() => {
       expect(store.dispatch.mock.calls.length).toBe(1);
       expect(store.dispatch).toHaveBeenCalledWith(
         createRover(rover, {
@@ -207,7 +213,7 @@ describe('The RoverListContainer', () => {
     };
     store.dispatch = jest.fn(() => Promise.reject(error));
 
-    wrapper.dive().props().removeRover(1).then(() => {
+    wrapper.dive().props().removeRover(1).catch(() => {
       expect(store.dispatch.mock.calls.length).toBe(1);
       expect(store.dispatch).toHaveBeenCalledWith(
         removeRover(1, {


### PR DESCRIPTION
This removes a significant amount of duplicated code as well as makes the authentication check for each API call be consistent. This will also allow other errors to be caught by the specific component to show contextual error messages.