### PR TITLE
Force scrollbars in Blockly workspace

### DIFF
--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -258,6 +258,7 @@ class Workspace extends Component {
       },
       trashcan: true,
       readOnly: code.isReadOnly,
+      scrollbars: true,
     });
 
     workspace.addChangeListener(this.updateCode);


### PR DESCRIPTION
Some large programs seem to be showing up off-screen in read-only mode. I haven't been able to reproduce it locally, but this PR forces scrollbars, which are off by default in read-only mode.