### PR TITLE
Clear program state on program list

### DIFF
--- a/src/actions/__test__/code.test.js
+++ b/src/actions/__test__/code.test.js
@@ -11,6 +11,7 @@ import {
   fetchProgram,
   saveProgram,
   createProgram,
+  clearProgram,
   EXECUTION_RUN,
 } from '../code';
 
@@ -158,5 +159,13 @@ describe('Code actions', () => {
 
     expect(type).toEqual('CHANGE_READ_ONLY');
     expect(payload).toEqual(true);
+  });
+
+  test('clearProgram', () => {
+    const action = clearProgram();
+    const { type, payload } = action;
+
+    expect(type).toEqual('CLEAR_PROGRAM');
+    expect(payload).toBeUndefined();
   });
 });

--- a/src/actions/code.js
+++ b/src/actions/code.js
@@ -24,6 +24,7 @@ export const CHANGE_PROGRAM_TAGS_FULFILLED = `${CHANGE_PROGRAM_TAGS}_FULFILLED`;
 export const CHANGE_PROGRAM_TAGS_REJECTED = `${CHANGE_PROGRAM_TAGS}_REJECTED`;
 export const CHANGE_ID = 'CHANGE_ID';
 export const CHANGE_READ_ONLY = 'CHANGE_READ_ONLY';
+export const CLEAR_PROGRAM = 'CLEAR_PROGRAM';
 
 // Execution States
 export const EXECUTION_RUN = 1;
@@ -105,4 +106,8 @@ export const changeProgramTags = (id, tags, xhroptions) => ({
 export const changeReadOnly = isReadOnly => ({
   type: CHANGE_READ_ONLY,
   payload: isReadOnly,
+});
+
+export const clearProgram = () => ({
+  type: CLEAR_PROGRAM,
 });

--- a/src/components/ProgramList.js
+++ b/src/components/ProgramList.js
@@ -29,7 +29,15 @@ class ProgramList extends Component {
   }
 
   componentDidMount() {
-    const { fetchPrograms, fetchTags, user } = this.props;
+    const {
+      clearProgram,
+      fetchPrograms,
+      fetchTags,
+      user,
+    } = this.props;
+
+    clearProgram();
+
     return fetchPrograms({
       user: user.user_id,
     }).then(() => fetchPrograms({
@@ -226,6 +234,7 @@ ProgramList.propTypes = {
   removeProgram: PropTypes.func.isRequired,
   changeReadOnly: PropTypes.func.isRequired,
   fetchTags: PropTypes.func.isRequired,
+  clearProgram: PropTypes.func.isRequired,
   user: PropTypes.shape({
     user_id: PropTypes.number.isRequired,
   }).isRequired,

--- a/src/components/__tests__/ProgramList.test.js
+++ b/src/components/__tests__/ProgramList.test.js
@@ -11,6 +11,7 @@ let fetchProgram;
 let fetchPrograms;
 let removeProgram;
 let fetchTags;
+let clearProgram;
 
 describe('The ProgramList component', () => {
   beforeEach(() => {
@@ -19,6 +20,7 @@ describe('The ProgramList component', () => {
     fetchPrograms = jest.fn(() => Promise.resolve({}));
     removeProgram = jest.fn(() => Promise.resolve({}));
     fetchTags = jest.fn(() => Promise.resolve({}));
+    clearProgram = jest.fn();
   });
 
   test('renders on the page with no errors', () => {
@@ -29,6 +31,7 @@ describe('The ProgramList component', () => {
         fetchPrograms={fetchPrograms}
         removeProgram={removeProgram}
         fetchTags={fetchTags}
+        clearProgram={clearProgram}
         user={{ user_id: 1 }}
       />,
     ).dive();
@@ -50,11 +53,13 @@ describe('The ProgramList component', () => {
           fetchPrograms={fetchPrograms}
           removeProgram={removeProgram}
           fetchTags={fetchTags}
+          clearProgram={clearProgram}
           user={{ user_id: 1 }}
         />
       </MemoryRouter>,
     );
     expect(fetchPrograms.mock.calls.length).toBe(2);
+    expect(clearProgram.mock.calls.length).toBe(1);
   });
 
   test('shows the correct number of programs for the user', async () => {
@@ -87,6 +92,7 @@ describe('The ProgramList component', () => {
         fetchPrograms={fetchPrograms}
         removeProgram={removeProgram}
         fetchTags={fetchTags}
+        clearProgram={clearProgram}
         user={{ user_id: 1 }}
       />,
     ).dive();
@@ -104,6 +110,7 @@ describe('The ProgramList component', () => {
         fetchPrograms={fetchPrograms}
         removeProgram={removeProgram}
         fetchTags={fetchTags}
+        clearProgram={clearProgram}
         user={{ user_id: 1 }}
         programs={null}
       />,
@@ -122,6 +129,7 @@ describe('The ProgramList component', () => {
         fetchPrograms={fetchPrograms}
         removeProgram={removeProgram}
         fetchTags={fetchTags}
+        clearProgram={clearProgram}
         user={{ user_id: 1 }}
         userPrograms={null}
       />,
@@ -140,6 +148,7 @@ describe('The ProgramList component', () => {
         fetchPrograms={fetchPrograms}
         removeProgram={removeProgram}
         fetchTags={fetchTags}
+        clearProgram={clearProgram}
         user={{ user_id: 1 }}
       />,
     ).dive();
@@ -176,6 +185,7 @@ describe('The ProgramList component', () => {
         fetchPrograms={fetchPrograms}
         removeProgram={removeProgram}
         fetchTags={fetchTags}
+        clearProgram={clearProgram}
         user={{ user_id: 1 }}
       />,
     ).dive();
@@ -238,6 +248,7 @@ describe('The ProgramList component', () => {
         fetchPrograms={fetchPrograms}
         removeProgram={removeProgram}
         fetchTags={fetchTags}
+        clearProgram={clearProgram}
         user={{ user_id: 1 }}
       />,
     ).dive();
@@ -274,6 +285,7 @@ describe('The ProgramList component', () => {
         fetchPrograms={fetchPrograms}
         removeProgram={removeProgram}
         fetchTags={fetchTags}
+        clearProgram={clearProgram}
         user={{ user_id: 1 }}
       />,
     ).dive();
@@ -310,6 +322,7 @@ describe('The ProgramList component', () => {
         fetchPrograms={fetchPrograms}
         removeProgram={removeProgram}
         fetchTags={fetchTags}
+        clearProgram={clearProgram}
         user={{ user_id: 1 }}
       />,
     ).dive();
@@ -348,6 +361,7 @@ describe('The ProgramList component', () => {
         fetchPrograms={fetchPrograms}
         removeProgram={removeProgram}
         fetchTags={fetchTags}
+        clearProgram={clearProgram}
         user={{ user_id: 1 }}
       />,
     ).dive();
@@ -386,6 +400,7 @@ describe('The ProgramList component', () => {
         fetchPrograms={fetchPrograms}
         removeProgram={removeProgram}
         fetchTags={fetchTags}
+        clearProgram={clearProgram}
         user={{ user_id: 1 }}
       />,
     ).dive();
@@ -410,6 +425,7 @@ describe('The ProgramList component', () => {
         fetchPrograms={fetchPrograms}
         removeProgram={removeProgram}
         fetchTags={fetchTags}
+        clearProgram={clearProgram}
         user={{ user_id: 1 }}
       />,
     ).dive();
@@ -435,6 +451,7 @@ describe('The ProgramList component', () => {
         fetchPrograms={fetchPrograms}
         removeProgram={removeProgram}
         fetchTags={fetchTags}
+        clearProgram={clearProgram}
         user={{ user_id: 1 }}
       />,
     ).dive();

--- a/src/containers/ProgramList.js
+++ b/src/containers/ProgramList.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { hot } from 'react-hot-loader';
 import { withCookies, Cookies } from 'react-cookie';
-import { changeReadOnly as actionChangeReadOnly, fetchProgram } from '../actions/code';
+import { changeReadOnly as actionChangeReadOnly, clearProgram, fetchProgram } from '../actions/code';
 import { fetchPrograms, removeProgram } from '../actions/program';
 import { checkAuthError, authHeader } from '../actions/auth';
 import { fetchTags } from '../actions/tag';
@@ -27,6 +27,7 @@ const mapDispatchToProps = (dispatch, { cookies }) => ({
     .catch(checkAuthError(dispatch)),
   changeReadOnly: isReadOnly => dispatch(actionChangeReadOnly(isReadOnly)),
   fetchTags: () => dispatch(fetchTags(authHeader(cookies))).catch(checkAuthError(dispatch)),
+  clearProgram: () => dispatch(clearProgram()),
 });
 
 const ProgramListContainer = connect(

--- a/src/containers/__tests__/ProgramList.test.js
+++ b/src/containers/__tests__/ProgramList.test.js
@@ -5,7 +5,7 @@ import { shallow } from 'enzyme';
 import { Cookies } from 'react-cookie';
 import configureStore from 'redux-mock-store';
 import ProgramList from '../ProgramList';
-import { changeReadOnly, fetchProgram } from '../../actions/code';
+import { changeReadOnly, clearProgram, fetchProgram } from '../../actions/code';
 import { fetchPrograms, removeProgram } from '../../actions/program';
 import { fetchTags } from '../../actions/tag';
 import { updateValidAuth } from '../../actions/auth';
@@ -335,6 +335,14 @@ describe('The ProgramListContainer', () => {
 
     expect(store.dispatch).toHaveBeenCalledWith(
       changeReadOnly(true),
+    );
+  });
+
+  test('dispatches an action to clear program', () => {
+    wrapper.dive().props().clearProgram();
+
+    expect(store.dispatch).toHaveBeenCalledWith(
+      clearProgram(),
     );
   });
 });

--- a/src/reducers/__tests__/code.test.js
+++ b/src/reducers/__tests__/code.test.js
@@ -21,6 +21,7 @@ import {
   CREATE_PROGRAM,
   CREATE_PROGRAM_FULFILLED,
   CREATE_PROGRAM_REJECTED,
+  CLEAR_PROGRAM,
 } from '../../actions/code';
 
 describe('The code reducer', () => {
@@ -304,6 +305,29 @@ describe('The code reducer', () => {
       }),
     ).toEqual({
       isReadOnly: true,
+    });
+  });
+
+  test('should handle CLEAR_PROGRAM', () => {
+    expect(
+      reducer({}, {
+        type: CLEAR_PROGRAM,
+        payload: undefined,
+      }),
+    ).toEqual({
+      jsCode: null,
+      xmlCode: null,
+      execution: null,
+      name: null,
+      id: null,
+      tags: [],
+      isFetching: false,
+      isSaving: false,
+      isCreating: false,
+      isChangingName: false,
+      isChangingProgramTags: false,
+      error: null,
+      isReadOnly: false,
     });
   });
 

--- a/src/reducers/code.js
+++ b/src/reducers/code.js
@@ -19,24 +19,27 @@ import {
   CREATE_PROGRAM,
   CREATE_PROGRAM_FULFILLED,
   CREATE_PROGRAM_REJECTED,
+  CLEAR_PROGRAM,
 } from '../actions/code';
 
+const defaultState = {
+  jsCode: null,
+  xmlCode: null,
+  execution: null,
+  name: null,
+  id: null,
+  tags: [],
+  isFetching: false,
+  isSaving: false,
+  isCreating: false,
+  isChangingName: false,
+  isChangingProgramTags: false,
+  error: null,
+  isReadOnly: false,
+};
+
 export default function code(
-  state = {
-    jsCode: null,
-    xmlCode: null,
-    execution: null,
-    name: null,
-    id: null,
-    tags: [],
-    isFetching: false,
-    isSaving: false,
-    isCreating: false,
-    isChangingName: false,
-    isChangingProgramTags: false,
-    error: null,
-    isReadOnly: false,
-  },
+  state = defaultState,
   action,
 ) {
   switch (action.type) {
@@ -157,6 +160,8 @@ export default function code(
         ...state,
         isReadOnly: action.payload,
       };
+    case CLEAR_PROGRAM:
+      return defaultState;
     default:
       return state;
   }


### PR DESCRIPTION
Closes #70 

Clears the loaded program state when going back to the program list to allow `New Program` to function correctly. Anytime a program is selected, the state is loaded each time anyway, so clearing has no performance impact. If the user wants the same program again, then the search can be used to find it and load it again.