### PR TITLE
Highlight card background for active rover

### DIFF
--- a/src/components/RoverConnection.js
+++ b/src/components/RoverConnection.js
@@ -6,6 +6,8 @@ import PropTypes from 'prop-types';
 import Websocket from 'react-websocket';
 import { COVERED, NOT_COVERED } from '@/actions/sensor';
 
+import '@/css/card.css';
+
 const heartbeatTimeout = 8000; // milliseconds
 
 class RoverConnection extends Component {
@@ -89,7 +91,7 @@ class RoverConnection extends Component {
 
     return (
       <Fragment>
-        <Card color={isActive ? 'blue' : null} onClick={this.setActive}>
+        <Card className={isActive ? 'highlight' : null} onClick={this.setActive}>
           <Card.Content>
             <Label corner="right" style={{ borderColor: 'white' }}>
               {

--- a/src/components/__tests__/RoverConnection.test.js
+++ b/src/components/__tests__/RoverConnection.test.js
@@ -60,7 +60,7 @@ describe('The RoverConnection component', () => {
     );
 
     expect(wrapper.find(Card).length).toBe(1);
-    expect(wrapper.find(Card).first().prop('color')).toBe('blue');
+    expect(wrapper.find(Card).first().hasClass('highlight')).toBe(true);
     expect(wrapper.find(Card.Meta).first().children().find(FormattedMessage)
       .prop('defaultMessage')).toBe('Active');
     expect(wrapper.find(Card.Header).first().prop('children')).toBe('Sparky');
@@ -87,7 +87,7 @@ describe('The RoverConnection component', () => {
     );
 
     expect(wrapper.find(Card).length).toBe(1);
-    expect(wrapper.find(Card).first().prop('color')).toBeNull();
+    expect(wrapper.find(Card).first().hasClass('highlight')).toBe(false);
     expect(wrapper.find(Card.Meta).first().children().find(FormattedMessage)
       .prop('defaultMessage')).toBe('Inactive');
     expect(wrapper.find(Card.Header).first().prop('children')).toBe('Sparky');

--- a/src/components/__tests__/__snapshots__/RoverConnection.test.js.snap
+++ b/src/components/__tests__/__snapshots__/RoverConnection.test.js.snap
@@ -3,7 +3,7 @@
 exports[`The RoverConnection component renders on the page with no errors 1`] = `
 <Fragment>
   <Card
-    color="blue"
+    className="highlight"
     onClick={[Function]}
   >
     <CardContent>

--- a/src/css/card.css
+++ b/src/css/card.css
@@ -1,0 +1,5 @@
+.ui.cards a.card.highlight,
+.ui.cards a.card.highlight:active,
+.ui.cards a.card.highlight:hover {
+  background-color: #cce6ff;
+}


### PR DESCRIPTION
Closes #106 

Highlights the active rover card so it's more apparent to the user:
![image](https://user-images.githubusercontent.com/1184314/64499331-8debc400-d286-11e9-9141-75626caec414.png)
