### PR TITLE
Create separate start commands for local and alpha

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,6 +33,10 @@
         "no-param-reassign": "off"
     },
     "settings": {
-        "import/resolver": "webpack"
+        "import/resolver": {
+            "webpack":{
+                "config": "webpack.common.js"
+            }
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -31,9 +31,14 @@ Running
 
 **NOTE**: The application running the development webserver requires the [rovercode api](https://github.com/rovercode/rovercode-web) to be running at http://localhost:8000
 
-To run the development web server, run:
+To run the development web server using a locally running API instance, run:
 ```sh
-yarn start
+yarn start:local
+```
+
+To run the development web server using the API instance on alpha.rovercode.com, run:
+```sh
+yarn start:alpha
 ```
 
 Unit Testing

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "license": "GPL-3.0",
   "private": false,
   "scripts": {
-    "start": "webpack-dev-server --hot --mode development",
+    "start:local": "webpack-dev-server --hot --mode development --config webpack.local.js",
+    "start:alpha": "webpack-dev-server --hot --mode development --config webpack.alpha.js",
     "build": "webpack --mode production",
     "i18n:manage": "node src/translations/runner.js",
     "test": "jest --coverage --color",
@@ -74,7 +75,8 @@
     "webapp-webpack-plugin": "^2.6.0",
     "webpack": "^4.29.3",
     "webpack-cli": "^3.2.3",
-    "webpack-dev-server": "^3.1.14"
+    "webpack-dev-server": "^3.1.14",
+    "webpack-merge": "^4.2.2"
   },
   "dependencies": {
     "@sentry/browser": "^4.6.4",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "license": "GPL-3.0",
   "private": false,
   "scripts": {
-    "start:local": "webpack-dev-server --hot --mode development --config webpack.local.js",
-    "start:alpha": "webpack-dev-server --hot --mode development --config webpack.alpha.js",
-    "build": "webpack --mode production --config webpack.production.js",
+    "start:local": "webpack-dev-server --hot --config webpack.local.js",
+    "start:alpha": "webpack-dev-server --hot --config webpack.alpha.js",
+    "build": "webpack --config webpack.production.js",
     "i18n:manage": "node src/translations/runner.js",
     "test": "jest --coverage --color",
     "lint": "eslint webpack.config* src --color --format stylish",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "build": "webpack --config webpack.production.js",
     "i18n:manage": "node src/translations/runner.js",
     "test": "jest --coverage --color",
-    "lint": "eslint webpack.config* src --color --format stylish",
-    "lint:fix": "eslint webpack.config* src --fix --color --format stylish"
+    "lint": "eslint webpack.* src --color --format stylish",
+    "lint:fix": "eslint webpack.* src --fix --color --format stylish"
   },
   "jest": {
     "snapshotSerializers": [

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start:local": "webpack-dev-server --hot --mode development --config webpack.local.js",
     "start:alpha": "webpack-dev-server --hot --mode development --config webpack.alpha.js",
-    "build": "webpack --mode production",
+    "build": "webpack --mode production --config webpack.production.js",
     "i18n:manage": "node src/translations/runner.js",
     "test": "jest --coverage --color",
     "lint": "eslint webpack.config* src --color --format stylish",

--- a/webpack.alpha.js
+++ b/webpack.alpha.js
@@ -1,0 +1,20 @@
+const merge = require('webpack-merge');
+const common = require('./webpack.common.js');
+
+module.exports = merge(common, {
+  devServer: {
+    hot: true,
+    historyApiFallback: true,
+    contentBase: './',
+    proxy: {
+      '/api': {
+        target: 'https://alpha.rovercode.com',
+        changeOrigin: true,
+      },
+      '/jwt': {
+        target: 'https://alpha.rovercode.com',
+        changeOrigin: true,
+      },
+    },
+  },
+});

--- a/webpack.alpha.js
+++ b/webpack.alpha.js
@@ -1,3 +1,5 @@
+/* eslint-disable import/no-extraneous-dependencies */
+
 const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
 

--- a/webpack.alpha.js
+++ b/webpack.alpha.js
@@ -2,6 +2,7 @@ const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
 
 module.exports = merge(common, {
+  mode: 'development',
   devServer: {
     hot: true,
     historyApiFallback: true,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -82,13 +82,4 @@ module.exports = {
     }),
   ],
   devtool: 'source-map',
-  devServer: {
-    hot: true,
-    historyApiFallback: true,
-    contentBase: './',
-    proxy: {
-      '/api': 'http://localhost:8000',
-      '/jwt': 'http://localhost:8000',
-    },
-  },
 };

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,8 +1,10 @@
+/* eslint-disable import/no-extraneous-dependencies */
+
 const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const HtmlWebPackPlugin = require('html-webpack-plugin');
 const WebappWebpackPlugin = require('webapp-webpack-plugin');
-const path = require('path'); // eslint-disable-line import/no-extraneous-dependencies
+const path = require('path');
 
 module.exports = {
   output: {

--- a/webpack.local.js
+++ b/webpack.local.js
@@ -1,0 +1,14 @@
+const merge = require('webpack-merge');
+const common = require('./webpack.common.js');
+
+module.exports = merge(common, {
+  devServer: {
+    hot: true,
+    historyApiFallback: true,
+    contentBase: './',
+    proxy: {
+      '/api': 'http://localhost:8000',
+      '/jwt': 'http://localhost:8000',
+    },
+  },
+});

--- a/webpack.local.js
+++ b/webpack.local.js
@@ -1,3 +1,5 @@
+/* eslint-disable import/no-extraneous-dependencies */
+
 const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
 

--- a/webpack.local.js
+++ b/webpack.local.js
@@ -2,6 +2,7 @@ const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
 
 module.exports = merge(common, {
+  mode: 'development',
   devServer: {
     hot: true,
     historyApiFallback: true,

--- a/webpack.production.js
+++ b/webpack.production.js
@@ -1,0 +1,5 @@
+const merge = require('webpack-merge');
+const common = require('./webpack.common.js');
+
+module.exports = merge(common, {
+});

--- a/webpack.production.js
+++ b/webpack.production.js
@@ -2,4 +2,5 @@ const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
 
 module.exports = merge(common, {
+  mode: 'production',
 });

--- a/webpack.production.js
+++ b/webpack.production.js
@@ -1,3 +1,5 @@
+/* eslint-disable import/no-extraneous-dependencies */
+
 const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5867,6 +5867,11 @@ lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.3, lodash@^4.17.4:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
 
+lodash@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 loglevel@^1.6.2:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.3.tgz#77f2eb64be55a404c9fd04ad16d57c1d6d6b1280"
@@ -6273,7 +6278,6 @@ no-case@^2.2.0:
 
 "node-blockly@git+https://github.com/rovercode/node-blockly.git#073996e7952b5a9c7cda784966d40090e80d275a":
   version "1.0.35"
-  uid "073996e7952b5a9c7cda784966d40090e80d275a"
   resolved "git+https://github.com/rovercode/node-blockly.git#073996e7952b5a9c7cda784966d40090e80d275a"
   dependencies:
     jsdom "^11.3.0"
@@ -9234,6 +9238,13 @@ webpack-log@^2.0.0:
   dependencies:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
+
+webpack-merge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.2.2.tgz#a27c52ea783d1398afd2087f547d7b9d2f43634d"
+  integrity sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==
+  dependencies:
+    lodash "^4.17.15"
 
 webpack-sources@^1.1.0, webpack-sources@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
Closes #112 

Allows for starting the application using either a local instance of the API (`yarn start:local`) or the one on `alpha` (`yarn start:alpha`).