### PR TITLE
Fix blockly area size to fit

### DIFF
--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -223,20 +223,12 @@ class Workspace extends Component {
     // https://developers.google.com/blockly/guides/configure/web/resizable
     const { workspace } = this.state;
 
-    // Compute the absolute coordinates and dimensions of blocklyArea.
     const blocklyArea = document.getElementById('blocklyDiv').parentNode;
-    let element = blocklyArea;
-    let x = 0;
-    let y = 0;
-    do {
-      x += element.offsetLeft;
-      y += element.offsetTop;
-      element = element.parentNode;
-    } while (element);
+
     // Position blocklyDiv over blocklyArea.
     if (this.editorDiv) {
-      this.editorDiv.style.left = `${x}px`;
-      this.editorDiv.style.top = `${y}px`;
+      this.editorDiv.style.left = '0px';
+      this.editorDiv.style.top = '0px';
       this.editorDiv.style.width = `${blocklyArea.offsetWidth}px`;
       this.editorDiv.style.height = `${blocklyArea.offsetHeight}px`;
     }

--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -468,7 +468,7 @@ class Workspace extends Component {
             </Grid>
           ) : (null)
         }
-        <div ref={(editorDiv) => { this.editorDiv = editorDiv; }} style={{ position: 'absolute' }} id="blocklyDiv">
+        <div ref={(editorDiv) => { this.editorDiv = editorDiv; }} style={{ height: code.isReadOnly ? '80vh' : '90vh' }} id="blocklyDiv">
           <div style={{ position: 'absolute', bottom: 30, right: 100 }}>
             { children }
           </div>

--- a/src/components/__tests__/__snapshots__/Workspace.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Workspace.test.js.snap
@@ -559,7 +559,7 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
           id="blocklyDiv"
           style={
             Object {
-              "position": "absolute",
+              "height": "90vh",
             }
           }
         >

--- a/src/containers/MissionControl.js
+++ b/src/containers/MissionControl.js
@@ -20,7 +20,7 @@ import ProgramTags from '@/components/ProgramTags';
 import Workspace from '@/components/Workspace';
 
 const MissionControl = ({ location }) => (
-  <Grid style={{ height: '90vh' }}>
+  <Grid>
     <Grid.Row>
       <Grid.Column width={3}>
         <Grid.Row>

--- a/src/containers/MissionControl.js
+++ b/src/containers/MissionControl.js
@@ -20,13 +20,8 @@ import ProgramTags from '@/components/ProgramTags';
 import Workspace from '@/components/Workspace';
 
 const MissionControl = ({ location }) => (
-  <Grid style={{ height: '100vh' }}>
+  <Grid style={{ height: '90vh' }}>
     <Grid.Row>
-      <Grid.Column width={13}>
-        <Workspace location={location}>
-          <Control />
-        </Workspace>
-      </Grid.Column>
       <Grid.Column width={3}>
         <Grid.Row>
           <Segment basic compact>
@@ -45,6 +40,24 @@ const MissionControl = ({ location }) => (
           <ProgramTags />
         </Grid.Row>
         <Divider />
+        <Grid.Row>
+          <Segment basic compact>
+            <CodeViewer>
+              <FormattedMessage
+                id="app.mission_control.show_code"
+                description="Button label for displaying user's code"
+                defaultMessage="Show Me The Code!"
+              />
+            </CodeViewer>
+          </Segment>
+        </Grid.Row>
+      </Grid.Column>
+      <Grid.Column width={10}>
+        <Workspace location={location}>
+          <Control />
+        </Workspace>
+      </Grid.Column>
+      <Grid.Column width={3}>
         <Grid.Row>
           <Header as="h2" textAlign="center">
             <FormattedMessage
@@ -81,18 +94,6 @@ const MissionControl = ({ location }) => (
           </Header>
           <Segment style={{ margin: '10px' }}>
             <Console />
-          </Segment>
-        </Grid.Row>
-        <Divider />
-        <Grid.Row>
-          <Segment basic compact>
-            <CodeViewer>
-              <FormattedMessage
-                id="app.mission_control.show_code"
-                description="Button label for displaying user's code"
-                defaultMessage="Show Me The Code!"
-              />
-            </CodeViewer>
           </Segment>
         </Grid.Row>
       </Grid.Column>

--- a/src/containers/__tests__/__snapshots__/MissionControl.test.js.snap
+++ b/src/containers/__tests__/__snapshots__/MissionControl.test.js.snap
@@ -44,20 +44,9 @@ exports[`The MissionControl container renders on the page with no errors 1`] = `
     }
   }
 >
-  <Grid
-    style={
-      Object {
-        "height": "90vh",
-      }
-    }
-  >
+  <Grid>
     <div
       className="ui grid"
-      style={
-        Object {
-          "height": "90vh",
-        }
-      }
     >
       <GridRow>
         <div

--- a/src/containers/__tests__/__snapshots__/MissionControl.test.js.snap
+++ b/src/containers/__tests__/__snapshots__/MissionControl.test.js.snap
@@ -47,7 +47,7 @@ exports[`The MissionControl container renders on the page with no errors 1`] = `
   <Grid
     style={
       Object {
-        "height": "100vh",
+        "height": "90vh",
       }
     }
   >
@@ -55,7 +55,7 @@ exports[`The MissionControl container renders on the page with no errors 1`] = `
       className="ui grid"
       style={
         Object {
-          "height": "100vh",
+          "height": "90vh",
         }
       }
     >
@@ -63,25 +63,6 @@ exports[`The MissionControl container renders on the page with no errors 1`] = `
         <div
           className="row"
         >
-          <GridColumn
-            width={13}
-          >
-            <div
-              className="thirteen wide column"
-            >
-              <Component
-                location={
-                  Object {
-                    "state": Object {
-                      "readOnly": false,
-                    },
-                  }
-                }
-              >
-                <div />
-              </Component>
-            </div>
-          </GridColumn>
           <GridColumn
             width={3}
           >
@@ -417,6 +398,51 @@ exports[`The MissionControl container renders on the page with no errors 1`] = `
                 <div
                   className="row"
                 >
+                  <Segment
+                    basic={true}
+                    compact={true}
+                  >
+                    <div
+                      className="ui basic compact segment"
+                    >
+                      <Component>
+                        <div />
+                      </Component>
+                    </div>
+                  </Segment>
+                </div>
+              </GridRow>
+            </div>
+          </GridColumn>
+          <GridColumn
+            width={10}
+          >
+            <div
+              className="ten wide column"
+            >
+              <Component
+                location={
+                  Object {
+                    "state": Object {
+                      "readOnly": false,
+                    },
+                  }
+                }
+              >
+                <div />
+              </Component>
+            </div>
+          </GridColumn>
+          <GridColumn
+            width={3}
+          >
+            <div
+              className="three wide column"
+            >
+              <GridRow>
+                <div
+                  className="row"
+                >
                   <Header
                     as="h2"
                     textAlign="center"
@@ -613,29 +639,6 @@ exports[`The MissionControl container renders on the page with no errors 1`] = `
                           "margin": "10px",
                         }
                       }
-                    >
-                      <Component>
-                        <div />
-                      </Component>
-                    </div>
-                  </Segment>
-                </div>
-              </GridRow>
-              <Divider>
-                <div
-                  className="ui divider"
-                />
-              </Divider>
-              <GridRow>
-                <div
-                  className="row"
-                >
-                  <Segment
-                    basic={true}
-                    compact={true}
-                  >
-                    <div
-                      className="ui basic compact segment"
                     >
                       <Component>
                         <div />


### PR DESCRIPTION
Closes #69 

Adjusted the blockly area to fit on the screen without scrolling. In the process, found out that the resize calculation was doing nothing since it would go all the way up the parent nodes until hitting a `NaN` and end up equivalent to zero. Also, moved a few of the components to the left side of the workspace. This allows everything to fit neatly on the screen:
![image](https://user-images.githubusercontent.com/1184314/65374585-9c0fec00-dc59-11e9-98a5-4303de9727ae.png)
