### PR TITLE
Use container to set height

### DIFF
--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -1,5 +1,10 @@
-import React, { Component, Fragment } from 'react';
-import { Button, Grid, Message } from 'semantic-ui-react';
+import React, { Component } from 'react';
+import {
+  Button,
+  Container,
+  Grid,
+  Message,
+} from 'semantic-ui-react';
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import { connect } from 'react-redux';
 import Blockly from 'node-blockly/browser';
@@ -436,7 +441,7 @@ class Workspace extends Component {
     const { children, code } = this.props;
 
     return (
-      <Fragment>
+      <Container style={{ height: code.isReadOnly ? '70vh' : '80vh' }}>
         {
           code.isReadOnly ? (
             <Grid verticalAlign="middle">
@@ -468,12 +473,12 @@ class Workspace extends Component {
             </Grid>
           ) : (null)
         }
-        <div ref={(editorDiv) => { this.editorDiv = editorDiv; }} style={{ height: code.isReadOnly ? '80vh' : '90vh' }} id="blocklyDiv">
+        <div ref={(editorDiv) => { this.editorDiv = editorDiv; }} id="blocklyDiv">
           <div style={{ position: 'absolute', bottom: 30, right: 100 }}>
             { children }
           </div>
         </div>
-      </Fragment>
+      </Container>
     );
   }
 }

--- a/src/components/__tests__/__snapshots__/Workspace.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Workspace.test.js.snap
@@ -555,26 +555,38 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
         updateXmlCode={[Function]}
         writeToConsole={[Function]}
       >
-        <div
-          id="blocklyDiv"
+        <Container
           style={
             Object {
-              "height": "90vh",
+              "height": "80vh",
             }
           }
         >
           <div
+            className="ui container"
             style={
               Object {
-                "bottom": 30,
-                "position": "absolute",
-                "right": 100,
+                "height": "80vh",
               }
             }
           >
-            <div />
+            <div
+              id="blocklyDiv"
+            >
+              <div
+                style={
+                  Object {
+                    "bottom": 30,
+                    "position": "absolute",
+                    "right": 100,
+                  }
+                }
+              >
+                <div />
+              </div>
+            </div>
           </div>
-        </div>
+        </Container>
       </Workspace>
     </Connect(Workspace)>
   </InjectIntl(Connect(Workspace))>


### PR DESCRIPTION
Adding the footer caused mission control to scroll again. Adding a container will allow for setting the height of the workspace area with or without the message being displayed.

![image](https://user-images.githubusercontent.com/1184314/65650911-bf7cc300-dfda-11e9-955b-493111c124ea.png)
