### PR TITLE
Integrate sumo logger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,13 @@ before_deploy:
   - |
     if [ "$TRAVIS_BRANCH" = "alpha" ]; then
       eval export FRONTEND_SENTRY_DSN=https://88d114444d43458398b75b825909c30e@sentry.io/1406271
+      eval export FRONTEND_LOGGER_ENDPOINT=https://endpoint5.collection.us2.sumologic.com/receiver/v1/http/ZaVnC4dhaV0uI8K0CiECmYVRYAVau-_Lo8TjrkWC9OwPEut5y_AaDOVGto4SGwr4wiQEVWzdtH6keVnhWSiST0GvGBNUjjO0YEaUq1HwpFjV7HsqaVWYhQ==
     elif [ "$TRAVIS_BRANCH" = "beta" ]; then
       eval export FRONTEND_SENTRY_DSN=https://a82f31ed5aa14c6f835de8e5ba8ef3fa@sentry.io/1406272
+      eval export FRONTEND_LOGGER_ENDPOINT=https://endpoint5.collection.us2.sumologic.com/receiver/v1/http/ZaVnC4dhaV2YCwsKwtRRXcpk3bflt-bogF8u0T76IrkGlskmBrA2jfp2gcvfXGfy4NjKZUtSaSNz_OSUTfNL1NPTfcYWFsIWWNxrVWRJD6gFUkBgkt7fxg==
     else
       eval export FRONTEND_SENTRY_DSN=https://8ccf4910438348d494a8592312a4afdf@sentry.io/1406255
+      eval export FRONTEND_LOGGER_ENDPOINT=https://endpoint5.collection.us2.sumologic.com/receiver/v1/http/ZaVnC4dhaV2oB8AnxMbQANacTvKDVkwB20H-dae3lHDkY_kgPmF0dOzVQNabDUt1Btd6c7L-RF_kwk9wR-9JZYDJdOeXQh78cWVu_CsHw6VbVrpq2hepVg==
     fi
     yarn build
 

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "redux-thunk": "^2.3.0",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^0.85.0",
+    "sumo-logger": "^2.5.5",
     "url-parse": "^1.4.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "lint:fix": "eslint webpack.* src --fix --color --format stylish"
   },
   "jest": {
+    "globals": {
+      "LOGGER_ENDPOINT": ""
+    },
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
     ],

--- a/src/utils/__tests__/logger.test.js
+++ b/src/utils/__tests__/logger.test.js
@@ -1,0 +1,12 @@
+import SumoLogger from 'sumo-logger';
+import logger from '../logger';
+
+jest.mock('sumo-logger');
+
+describe('Logger', () => {
+  test('sends message to logger', () => {
+    logger.log('test message');
+    expect(SumoLogger).toHaveBeenCalled();
+    expect(SumoLogger.mock.instances[0].log).toHaveBeenCalledWith('test message');
+  });
+});

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,16 @@
+import SumoLogger from 'sumo-logger';
+
+const opts = {
+  endpoint: LOGGER_ENDPOINT, // eslint-disable-line no-undef
+  returnPromise: true,
+};
+
+class Logger {
+  constructor() {
+    this.logger = new SumoLogger(opts);
+  }
+
+  log = message => this.logger.log(message)
+}
+
+export default new Logger();

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -59,6 +59,7 @@ module.exports = {
   plugins: [
     new webpack.DefinePlugin({
       SENTRY_DSN: JSON.stringify(process.env.FRONTEND_SENTRY_DSN),
+      LOGGER_ENDPOINT: JSON.stringify(process.env.FRONTEND_LOGGER_ENDPOINT),
     }),
     new HtmlWebPackPlugin({
       template: './src/index.html',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2568,7 +2568,7 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
-component-emitter@^1.2.1:
+component-emitter@^1.2.1, component-emitter@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
@@ -2668,6 +2668,11 @@ cookie@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
   integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
+
+cookiejar@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
+  integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -3794,6 +3799,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.4:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-safe-stringify@^2.0.6:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
+  integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
+
 favicons@5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/favicons/-/favicons-5.3.0.tgz#ba4f826f147718ccf7e312f6f7ae23881ad1dfa6"
@@ -4008,6 +4018,15 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
+form-data@^2.3.3:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
+  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
 form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
@@ -4016,6 +4035,11 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+formidable@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
+  integrity sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -5983,7 +6007,7 @@ merge-stream@^1.0.1:
   dependencies:
     readable-stream "^2.0.1"
 
-methods@~1.1.2:
+methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
@@ -6032,7 +6056,7 @@ mime@1.6.0, mime@^1.3.4:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^2.4.2:
+mime@^2.4.2, mime@^2.4.4:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
   integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
@@ -7268,6 +7292,11 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+qs@^6.7.0:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.0.tgz#d1297e2a049c53119cb49cca366adbbacc80b409"
+  integrity sha512-27RP4UotQORTpmNQDX8BHPukOnBP3p1uUJY5UnDhaJB+rMt9iMsok724XL+UHU23bEFOHRMQ2ZhI99qOWUMGFA==
+
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
@@ -7566,7 +7595,7 @@ read-pkg@^3.0.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-"readable-stream@2 || 3", readable-stream@^3.0.6, readable-stream@^3.1.1:
+"readable-stream@2 || 3", readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
   integrity sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
@@ -8549,6 +8578,30 @@ style-loader@^0.23.1:
   dependencies:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
+
+sumo-logger@^2.5.5:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/sumo-logger/-/sumo-logger-2.5.5.tgz#0c64ebbeb65c6197139dbb6c0da295a07116427e"
+  integrity sha512-unZwb5dFRLNLupUuwaTexkEhV0EjqwRIxjPvaXGEO+ROYUTeCUK00on05j+Yv84kfo9JRoCD9Owd2oPVbHu/0g==
+  dependencies:
+    superagent "^5.0.5"
+
+superagent@^5.0.5:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-5.1.0.tgz#9ce4f38bee64d65a56166423b573222fa1b8f041"
+  integrity sha512-7V6JVx5N+eTL1MMqRBX0v0bG04UjrjAvvZJTF/VDH/SH2GjSLqlrcYepFlpTrXpm37aSY6h3GGVWGxXl/98TKA==
+  dependencies:
+    component-emitter "^1.3.0"
+    cookiejar "^2.1.2"
+    debug "^4.1.1"
+    fast-safe-stringify "^2.0.6"
+    form-data "^2.3.3"
+    formidable "^1.2.1"
+    methods "^1.1.2"
+    mime "^2.4.4"
+    qs "^6.7.0"
+    readable-stream "^3.4.0"
+    semver "^6.1.1"
 
 supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"


### PR DESCRIPTION
This creates an abstract interface for logging. Logging can be added anywhere in the application by doing the following:
```
import logger from '@/utils/logger';
logger.log('<insert message>');
```
Status can be checked via the returned `Promise`.
Endpoints are added to all the deployed instances. For local testing, define `FRONTEND_LOGGER_ENDPOINT`:
```
FRONTEND_LOGGER_ENDPOINT=<endpoint url> yarn start:local
```