### PR TITLE
Handle case where error does not have a response

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -16,7 +16,7 @@ export const logout = () => ({
 
 // helper functions
 export const checkAuthError = dispatch => (error) => {
-  if (error.response.status === 401) {
+  if (error.response && error.response.status === 401) {
     // Authentication is no longer valid
     dispatch(updateValidAuth(false));
   } else {


### PR DESCRIPTION
Checks for a response object before trying to access `status`.
Original error:
![image](https://user-images.githubusercontent.com/1184314/68093371-f314fd80-fe62-11e9-83c2-fb7db7612383.png)
