### PR TITLE
Set the first rover active if no rover has been set

### DIFF
--- a/src/components/RoverConnectionList.js
+++ b/src/components/RoverConnectionList.js
@@ -27,15 +27,17 @@ class RoverConnectionList extends Component {
     let activeRoverObject = null;
     let inactiveRovers = null;
 
-    if (rovers) {
-      const activeRoverIndex = rovers.results.findIndex(rover => rover.client_id === activeRover);
-
-      if (activeRoverIndex > -1) {
-        ({ [activeRoverIndex]: activeRoverObject, ...inactiveRovers } = rovers.results);
-        inactiveRovers = Object.values(inactiveRovers);
-      } else {
-        inactiveRovers = rovers.results;
+    if (rovers && rovers.results.length) {
+      let activeRoverIndex = rovers.results.findIndex(rover => rover.client_id === activeRover);
+      if (activeRoverIndex < 0) {
+        changeActiveRover(rovers.results[0].client_id);
+        activeRoverIndex = 0;
       }
+
+      ({ [activeRoverIndex]: activeRoverObject, ...inactiveRovers } = rovers.results);
+      inactiveRovers = Object.values(inactiveRovers);
+    } else if (!isFetching) {
+      inactiveRovers = [];
     }
 
     return (
@@ -101,6 +103,7 @@ RoverConnectionList.propTypes = {
       PropTypes.shape({
         id: PropTypes.number.isRequired,
         name: PropTypes.string.isRequired,
+        client_id: PropTypes.string.isRequired,
       }),
     ),
   }),

--- a/src/components/__tests__/RoverConnectionList.test.js
+++ b/src/components/__tests__/RoverConnectionList.test.js
@@ -32,6 +32,7 @@ describe('The RoverConnectionList component', () => {
         fetchRovers={fetchRovers}
         commands={commands}
         rovers={null}
+        isFetching
       />,
     );
     expect(wrapper).toMatchSnapshot();
@@ -102,5 +103,41 @@ describe('The RoverConnectionList component', () => {
     expect(wrapper.find(RoverConnection).length).toBe(2);
     expect(wrapper.find(RoverConnection).first().prop('name')).toBe('Marvin');
     expect(wrapper.find(RoverConnection).last().prop('name')).toBe('Sparky');
+    expect(changeActiveRover).not.toHaveBeenCalled();
+  });
+
+  test('sets the active rover if not set', async () => {
+    const rovers = {
+      next: null,
+      previous: null,
+      results: [{
+        id: 1,
+        name: 'Sparky',
+        client_id: '1234',
+      }, {
+        id: 2,
+        name: 'Marvin',
+        client_id: '5678',
+      }],
+    };
+    const wrapper = shallow(
+      <RoverConnectionList
+        changeActiveRover={changeActiveRover}
+        changeLeftSensorState={changeLeftSensorState}
+        changeRightSensorState={changeRightSensorState}
+        popCommand={popCommand}
+        fetchRovers={fetchRovers}
+        rovers={rovers}
+        commands={commands}
+      />,
+    );
+    await wrapper.instance().componentDidMount();
+    wrapper.update();
+
+    expect(wrapper.find(Loader).exists()).toBe(false);
+    expect(wrapper.find(RoverConnection).length).toBe(2);
+    expect(wrapper.find(RoverConnection).first().prop('name')).toBe('Sparky');
+    expect(wrapper.find(RoverConnection).last().prop('name')).toBe('Marvin');
+    expect(changeActiveRover).toHaveBeenCalledWith('1234');
   });
 });


### PR DESCRIPTION
This makes sure that a rover is always active in mission control