### PR TITLE
Append _PENDING on bluetooth actions in reducer

### DIFF
--- a/src/actions/rover.js
+++ b/src/actions/rover.js
@@ -2,12 +2,15 @@
 // async actions https://redux.js.org/advanced/asyncactions
 
 export const SCAN = 'SCAN';
+export const SCAN_PENDING = `${SCAN}_PENDING`;
 export const SCAN_FULFILLED = `${SCAN}_FULFILLED`;
 export const SCAN_REJECTED = `${SCAN}_REJECTED`;
 export const CONNECT_ROVER = 'CONNECT_ROVER';
+export const CONNECT_ROVER_PENDING = `${CONNECT_ROVER}_PENDING`;
 export const CONNECT_ROVER_FULFILLED = `${CONNECT_ROVER}_FULFILLED`;
 export const CONNECT_ROVER_REJECTED = `${CONNECT_ROVER}_REJECTED`;
 export const SEND_ROVER = 'SEND_ROVER';
+export const SEND_ROVER_PENDING = `${SEND_ROVER}_PENDING`;
 export const SEND_ROVER_FULFILLED = `${SEND_ROVER}_FULFILLED`;
 export const SEND_ROVER_REJECTED = `${SEND_ROVER}_REJECTED`;
 export const DISCONNECT_ROVER = 'DISCONNECT_ROVER';

--- a/src/reducers/__tests__/rover.test.js
+++ b/src/reducers/__tests__/rover.test.js
@@ -1,22 +1,22 @@
 import reducer from '../rover';
 import {
-  SCAN,
+  SCAN_PENDING,
   SCAN_FULFILLED,
   SCAN_REJECTED,
-  CONNECT_ROVER,
+  CONNECT_ROVER_PENDING,
   CONNECT_ROVER_FULFILLED,
   CONNECT_ROVER_REJECTED,
-  SEND_ROVER,
+  SEND_ROVER_PENDING,
   SEND_ROVER_FULFILLED,
   SEND_ROVER_REJECTED,
   DISCONNECT_ROVER,
 } from '../../actions/rover';
 
 describe('The rover reducer', () => {
-  test('should handle SCAN', () => {
+  test('should handle SCAN_PENDING', () => {
     expect(
       reducer(undefined, {
-        type: SCAN,
+        type: SCAN_PENDING,
       }),
     ).toEqual({
       isConnecting: false,
@@ -54,10 +54,10 @@ describe('The rover reducer', () => {
     });
   });
 
-  test('should handle CONNECT_ROVER', () => {
+  test('should handle CONNECT_ROVER_PENDING', () => {
     expect(
       reducer(undefined, {
-        type: CONNECT_ROVER,
+        type: CONNECT_ROVER_PENDING,
       }),
     ).toEqual({
       isConnecting: true,
@@ -96,10 +96,10 @@ describe('The rover reducer', () => {
     });
   });
 
-  test('should handle SEND_ROVER', () => {
+  test('should handle SEND_ROVER_PENDING', () => {
     expect(
       reducer(undefined, {
-        type: SEND_ROVER,
+        type: SEND_ROVER_PENDING,
       }),
     ).toEqual({
       isConnecting: false,

--- a/src/reducers/rover.js
+++ b/src/reducers/rover.js
@@ -1,11 +1,11 @@
 import {
-  SCAN,
+  SCAN_PENDING,
   SCAN_FULFILLED,
   SCAN_REJECTED,
-  CONNECT_ROVER,
+  CONNECT_ROVER_PENDING,
   CONNECT_ROVER_FULFILLED,
   CONNECT_ROVER_REJECTED,
-  SEND_ROVER,
+  SEND_ROVER_PENDING,
   SEND_ROVER_FULFILLED,
   SEND_ROVER_REJECTED,
   DISCONNECT_ROVER,
@@ -24,7 +24,7 @@ export default function rovers(
   action,
 ) {
   switch (action.type) {
-    case SCAN:
+    case SCAN_PENDING:
       return {
         ...state,
         isScanning: true,
@@ -42,7 +42,7 @@ export default function rovers(
         isScanning: false,
         error: action.payload,
       };
-    case CONNECT_ROVER:
+    case CONNECT_ROVER_PENDING:
       return {
         ...state,
         isConnecting: true,
@@ -61,7 +61,7 @@ export default function rovers(
         isConnecting: false,
         error: action.payload,
       };
-    case SEND_ROVER:
+    case SEND_ROVER_PENDING:
       return {
         ...state,
         isSending: true,


### PR DESCRIPTION
The `SCAN`, `ROVER_CONNECT`, and `ROVER_SEND` actions somehow get a `_PENDING` suffix by the time they make it to the reducer. We came across this once before with something else, didn't we?

Now `isScanning`, `isConnecting`, and `isSending` get set to `true` at the right times.