### PR TITLE
Upgrade to supported versions of node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "8"
+  - "10"
+  - "12"
 install:
   - yarn install --pure-lockfile
 script:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains the [react](https://reactjs.org/) application frontend 
 Requirements
 ============
 
-[nodejs](https://nodejs.org) LTS version v8.x is required. Newer versions may have issues.
+[nodejs](https://nodejs.org) LTS version v10.x or v12.x is required
 
 [yarn](https://yarnpkg.com/) is required for installing dependencies. Instructions for installing `yarn` can be found [here](https://yarnpkg.com/lang/en/docs/install/).
 


### PR DESCRIPTION
Node v8.x went EOL Dec 2019: https://github.com/nodejs/Release
This runs the tests with supported versions v10.x and v12.x.