### PR TITLE
Pause execution while sending

### DIFF
--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -188,7 +188,7 @@ class Workspace extends Component {
 
     this.updateSensorStateCache(sensor.left, sensor.right);
 
-    if (currentRover.isSending && !nextRover.isSending) {
+    if (currentRover && currentRover.isSending && nextRover && !nextRover.isSending) {
       this.runCode();
     }
 

--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -183,10 +183,14 @@ class Workspace extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { code: currentCode } = prevProps;
-    const { code: nextCode, sensor } = this.props;
+    const { code: currentCode, rover: currentRover } = prevProps;
+    const { code: nextCode, sensor, rover: nextRover } = this.props;
 
     this.updateSensorStateCache(sensor.left, sensor.right);
+
+    if (currentRover.isSending && !nextRover.isSending) {
+      this.runCode();
+    }
 
     // Ignore if execution state has not changed unless stepping
     if (nextCode.execution === currentCode.execution && nextCode.execution !== EXECUTION_STEP) {
@@ -341,15 +345,18 @@ class Workspace extends Component {
   }
 
   runCode = () => {
-    if (this.stepCode() && this.runningEnabled && !this.sleeping) {
+    const { rover } = this.props;
+
+    if (this.stepCode() && this.runningEnabled && !this.sleeping && !rover.isSending) {
       setTimeout(this.runCode, 10);
     }
   }
 
   stepCode = () => {
     const { interpreter, workspace } = this.state;
+    const { rover } = this.props;
 
-    if (this.sleeping) {
+    if (this.sleeping || rover.isSending) {
       return true;
     }
 
@@ -512,6 +519,7 @@ Workspace.propTypes = {
   }).isRequired,
   rover: PropTypes.shape({
     transmitChannel: PropTypes.object,
+    isSending: PropTypes.bool,
   }),
   updateJsCode: PropTypes.func.isRequired,
   updateXmlCode: PropTypes.func.isRequired,

--- a/src/components/__tests__/Workspace.test.js
+++ b/src/components/__tests__/Workspace.test.js
@@ -189,7 +189,7 @@ describe('The Workspace component', () => {
   });
 
   test('runs code when done sending Bluetooth message to rover', () => {
-    store.getState().rover.isSending = false;
+    store.getState().rover.isSending = true;
     const workspace = shallowWithIntl(
       <Workspace store={store}>
         <div />
@@ -203,7 +203,7 @@ describe('The Workspace component', () => {
     workspace.instance().runCode = jest.fn();
     workspace.setProps({
       rover: {
-        isSending: true,
+        isSending: false,
       },
     });
     workspace.update();
@@ -285,9 +285,6 @@ describe('The Workspace component', () => {
       sensor: {
         left: NOT_COVERED,
         right: NOT_COVERED,
-      },
-      rover: {
-        isSending: false,
       },
     });
     localStore.dispatch = jest.fn(() => Promise.resolve());
@@ -662,9 +659,6 @@ describe('The Workspace component', () => {
         left: NOT_COVERED,
         right: NOT_COVERED,
       },
-      rover: {
-        isSending: false,
-      },
     });
     localStore.dispatch = jest.fn(() => Promise.resolve());
     shallowWithIntl(
@@ -931,12 +925,6 @@ describe('The Workspace component', () => {
         left: NOT_COVERED,
         right: NOT_COVERED,
       },
-      rover: {
-        isSending: false,
-        transmitChannel: {
-          writeValue: jest.fn(),
-        },
-      },
     });
     localStore.dispatch = jest.fn(() => Promise.resolve());
     const wrapper = shallowWithIntl(
@@ -964,9 +952,6 @@ describe('The Workspace component', () => {
       sensor: {
         left: NOT_COVERED,
         right: NOT_COVERED,
-      },
-      rover: {
-        isSending: false,
       },
     });
     localStore.dispatch = jest.fn(() => Promise.resolve());

--- a/src/components/__tests__/Workspace.test.js
+++ b/src/components/__tests__/Workspace.test.js
@@ -188,6 +188,29 @@ describe('The Workspace component', () => {
     expect(workspace.instance().resetCode).toHaveBeenCalled();
   });
 
+  test('runs code when done sending Bluetooth message to rover', () => {
+    store.getState().rover.isSending = false;
+    const workspace = shallowWithIntl(
+      <Workspace store={store}>
+        <div />
+      </Workspace>, { context },
+    ).dive().dive().dive()
+      .dive()
+      .dive()
+      .dive()
+      .dive();
+
+    workspace.instance().runCode = jest.fn();
+    workspace.setProps({
+      rover: {
+        isSending: true,
+      },
+    });
+    workspace.update();
+
+    expect(workspace.instance().runCode).toHaveBeenCalled();
+  });
+
   test('does nothing on invalid state change', () => {
     const workspace = shallowWithIntl(
       <Workspace store={store}>
@@ -263,6 +286,9 @@ describe('The Workspace component', () => {
         left: NOT_COVERED,
         right: NOT_COVERED,
       },
+      rover: {
+        isSending: false,
+      },
     });
     localStore.dispatch = jest.fn(() => Promise.resolve());
     const workspace = shallowWithIntl(
@@ -322,9 +348,10 @@ describe('The Workspace component', () => {
     expect(workspace.instance().runCode).not.toHaveBeenCalled();
   });
 
-  test('runs code when not at end, running, and not sleeping', () => {
+  test('runs code when not at end, running, and not sleeping or sending to rover', () => {
     jest.useFakeTimers();
 
+    store.getState().rover.isSending = false;
     const workspace = shallowWithIntl(
       <Workspace store={store}>
         <div />
@@ -343,6 +370,30 @@ describe('The Workspace component', () => {
 
     expect(setTimeout).toHaveBeenCalled();
   });
+
+  test('doesn\'t run code when sending to rover', () => {
+    jest.useFakeTimers();
+
+    store.getState().rover.isSending = true;
+    const workspace = shallowWithIntl(
+      <Workspace store={store}>
+        <div />
+      </Workspace>, { context },
+    ).dive().dive().dive()
+      .dive()
+      .dive()
+      .dive()
+      .dive();
+
+    workspace.instance().stepCode = jest.fn(() => true);
+    workspace.instance().runningEnabled = true;
+    workspace.instance().sleeping = false;
+    workspace.update();
+    workspace.instance().runCode();
+
+    expect(setTimeout).not.toHaveBeenCalled();
+  });
+
 
   test('doesn\'t run code when at the end', () => {
     jest.useFakeTimers();
@@ -611,6 +662,9 @@ describe('The Workspace component', () => {
         left: NOT_COVERED,
         right: NOT_COVERED,
       },
+      rover: {
+        isSending: false,
+      },
     });
     localStore.dispatch = jest.fn(() => Promise.resolve());
     shallowWithIntl(
@@ -877,6 +931,12 @@ describe('The Workspace component', () => {
         left: NOT_COVERED,
         right: NOT_COVERED,
       },
+      rover: {
+        isSending: false,
+        transmitChannel: {
+          writeValue: jest.fn(),
+        },
+      },
     });
     localStore.dispatch = jest.fn(() => Promise.resolve());
     const wrapper = shallowWithIntl(
@@ -904,6 +964,9 @@ describe('The Workspace component', () => {
       sensor: {
         left: NOT_COVERED,
         right: NOT_COVERED,
+      },
+      rover: {
+        isSending: false,
       },
     });
     localStore.dispatch = jest.fn(() => Promise.resolve());

--- a/src/utils/__tests__/blockly-api.test.js
+++ b/src/utils/__tests__/blockly-api.test.js
@@ -100,9 +100,8 @@ describe('Blockly API', () => {
     const result = stopMotorHandler({ data: 'RIGHT' });
 
     expect(result).toBe(false);
-    expect(sendToRover).toHaveBeenCalledTimes(2);
+    expect(sendToRover).toHaveBeenCalledTimes(1);
     expect(sendToRover.mock.calls[0][0]).toBe('right-motor:0\n');
-    expect(sendToRover.mock.calls[1][0]).toBe('right-motor:0\n');
   });
 
   test('handles getSensorCovered', () => {

--- a/src/utils/blockly-api.js
+++ b/src/utils/blockly-api.js
@@ -69,9 +69,7 @@ class BlocklyApi {
 
     // Add stop motor API function
     wrapper = (motor) => {
-      /* Stop both forward and backward pins, just to be safe */
       this.sendMotorCommand(motor.data, 'FORWARD', 0);
-      this.sendMotorCommand(motor.data, 'BACKWARD', 0);
       return false;
     };
     interpreter.setProperty(scope, 'stopMotor',


### PR DESCRIPTION
This makes the Blockly program not progress execution while the Bluetooth channel is sending a message. Before this change, the second of two consecutive motor commands would fail because the GATT channel was busy.

You can test the change with my `timing-debug` program in the alpha environment.
![image](https://user-images.githubusercontent.com/976857/79059318-732b6480-7c46-11ea-80fb-56482f7f016b.png)


