### PR TITLE
Debounce program save

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "jest": {
     "globals": {
-      "LOGGER_ENDPOINT": ""
+      "LOGGER_ENDPOINT": "",
+      "SAVE_DEBOUNCE_TIME": "1000"
     },
     "snapshotSerializers": [
       "enzyme-to-json/serializer"

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^0.88.0",
     "sumo-logger": "^2.5.5",
+    "throttle-debounce": "^2.1.0",
     "url-parse": "^1.4.4"
   }
 }

--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -12,6 +12,7 @@ import PropTypes from 'prop-types';
 import { hot } from 'react-hot-loader';
 import { withCookies } from 'react-cookie';
 import Interpreter from 'js-interpreter';
+import { debounce } from 'throttle-debounce';
 
 import { checkAuthError, authHeader } from '@/actions/auth';
 import {
@@ -276,7 +277,11 @@ class Workspace extends Component {
       scrollbars: true,
     });
 
-    workspace.addChangeListener(this.updateCode);
+    workspace.addChangeListener(
+      debounce(
+        parseInt(SAVE_DEBOUNCE_TIME, 10) || 5000, this.updateCode, // eslint-disable-line no-undef
+      ),
+    );
 
     this.updateSensorStateCache(sensor.left, sensor.right);
 

--- a/src/components/__tests__/__snapshots__/Workspace.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Workspace.test.js.snap
@@ -9,24 +9,6 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
         "calls": Array [
           Array [
             Object {
-              "payload": "test-code",
-              "type": "UPDATE_JSCODE",
-            },
-          ],
-          Array [
-            Object {
-              "payload": "test-dom-text",
-              "type": "UPDATE_XMLCODE",
-            },
-          ],
-          Array [
-            Object {
-              "payload": Promise {},
-              "type": "SAVE_PROGRAM",
-            },
-          ],
-          Array [
-            Object {
               "type": "CLEAR",
             },
           ],
@@ -44,18 +26,6 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
           ],
         ],
         "results": Array [
-          Object {
-            "type": "return",
-            "value": Promise {},
-          },
-          Object {
-            "type": "return",
-            "value": Promise {},
-          },
-          Object {
-            "type": "return",
-            "value": Promise {},
-          },
           Object {
             "type": "return",
             "value": Promise {},
@@ -95,24 +65,6 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
           "calls": Array [
             Array [
               Object {
-                "payload": "test-code",
-                "type": "UPDATE_JSCODE",
-              },
-            ],
-            Array [
-              Object {
-                "payload": "test-dom-text",
-                "type": "UPDATE_XMLCODE",
-              },
-            ],
-            Array [
-              Object {
-                "payload": Promise {},
-                "type": "SAVE_PROGRAM",
-              },
-            ],
-            Array [
-              Object {
                 "type": "CLEAR",
               },
             ],
@@ -130,18 +82,6 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
             ],
           ],
           "results": Array [
-            Object {
-              "type": "return",
-              "value": Promise {},
-            },
-            Object {
-              "type": "return",
-              "value": Promise {},
-            },
-            Object {
-              "type": "return",
-              "value": Promise {},
-            },
             Object {
               "type": "return",
               "value": Promise {},
@@ -181,24 +121,6 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
             "calls": Array [
               Array [
                 Object {
-                  "payload": "test-code",
-                  "type": "UPDATE_JSCODE",
-                },
-              ],
-              Array [
-                Object {
-                  "payload": "test-dom-text",
-                  "type": "UPDATE_XMLCODE",
-                },
-              ],
-              Array [
-                Object {
-                  "payload": Promise {},
-                  "type": "SAVE_PROGRAM",
-                },
-              ],
-              Array [
-                Object {
                   "type": "CLEAR",
                 },
               ],
@@ -216,18 +138,6 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
               ],
             ],
             "results": Array [
-              Object {
-                "type": "return",
-                "value": Promise {},
-              },
-              Object {
-                "type": "return",
-                "value": Promise {},
-              },
-              Object {
-                "type": "return",
-                "value": Promise {},
-              },
               Object {
                 "type": "return",
                 "value": Promise {},
@@ -300,24 +210,6 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
               "calls": Array [
                 Array [
                   Object {
-                    "payload": "test-code",
-                    "type": "UPDATE_JSCODE",
-                  },
-                ],
-                Array [
-                  Object {
-                    "payload": "test-dom-text",
-                    "type": "UPDATE_XMLCODE",
-                  },
-                ],
-                Array [
-                  Object {
-                    "payload": Promise {},
-                    "type": "SAVE_PROGRAM",
-                  },
-                ],
-                Array [
-                  Object {
                     "type": "CLEAR",
                   },
                 ],
@@ -335,18 +227,6 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
                 ],
               ],
               "results": Array [
-                Object {
-                  "type": "return",
-                  "value": Promise {},
-                },
-                Object {
-                  "type": "return",
-                  "value": Promise {},
-                },
-                Object {
-                  "type": "return",
-                  "value": Promise {},
-                },
                 Object {
                   "type": "return",
                   "value": Promise {},
@@ -450,24 +330,6 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
                 "calls": Array [
                   Array [
                     Object {
-                      "payload": "test-code",
-                      "type": "UPDATE_JSCODE",
-                    },
-                  ],
-                  Array [
-                    Object {
-                      "payload": "test-dom-text",
-                      "type": "UPDATE_XMLCODE",
-                    },
-                  ],
-                  Array [
-                    Object {
-                      "payload": Promise {},
-                      "type": "SAVE_PROGRAM",
-                    },
-                  ],
-                  Array [
-                    Object {
                       "type": "CLEAR",
                     },
                   ],
@@ -485,18 +347,6 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
                   ],
                 ],
                 "results": Array [
-                  Object {
-                    "type": "return",
-                    "value": Promise {},
-                  },
-                  Object {
-                    "type": "return",
-                    "value": Promise {},
-                  },
-                  Object {
-                    "type": "return",
-                    "value": Promise {},
-                  },
                   Object {
                     "type": "return",
                     "value": Promise {},

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -60,6 +60,7 @@ module.exports = {
     new webpack.DefinePlugin({
       SENTRY_DSN: JSON.stringify(process.env.FRONTEND_SENTRY_DSN),
       LOGGER_ENDPOINT: JSON.stringify(process.env.FRONTEND_LOGGER_ENDPOINT),
+      SAVE_DEBOUNCE_TIME: JSON.stringify(process.env.SAVE_DEBOUNCE_TIME),
     }),
     new HtmlWebPackPlugin({
       template: './src/index.html',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2931,7 +2931,7 @@ clone@^2.1.1, clone@^2.1.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
-"clone@github:aminmarashi/clone#d97b4f":
+clone@aminmarashi/clone#d97b4f:
   version "2.1.1"
   resolved "https://codeload.github.com/aminmarashi/clone/tar.gz/d97b4f0ff3d3afebcaaf4a2ecc9c50fbce914900"
 
@@ -9514,6 +9514,11 @@ throat@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
+
+throttle-debounce@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.1.0.tgz#257e648f0a56bd9e54fe0f132c4ab8611df4e1d5"
+  integrity sha512-AOvyNahXQuU7NN+VVvOOX+uW6FPaWdAOdRP5HfwYxAfCzXTFKRMoIMk+n+po318+ktcChx+F1Dd91G3YHeMKyg==
 
 through2@^2.0.0:
   version "2.0.5"


### PR DESCRIPTION
Currently, every change in the workspace is immediately saved via the API. This will cause a significant performance impact on the backend during heavy usage times. This change significantly reduces the amount of saves to the API. The program won't save until `SAVE_DEBOUNCE_TIME` milliseconds have passed since the last call. The default is set to 5 seconds but can be adjusted.