### PR TITLE
Material UI - NotFound

### DIFF
--- a/src/containers/Global/NotFound.js
+++ b/src/containers/Global/NotFound.js
@@ -1,23 +1,23 @@
 import React from 'react';
-import { Grid, Header, Image } from 'semantic-ui-react';
+import { Grid, Typography } from '@material-ui/core';
 import { FormattedMessage } from 'react-intl';
 
 import notFoundImage from '@/assets/images/404.png';
 
 const NotFound = () => (
-  <Grid centered>
-    <Grid.Row>
-      <Image src={notFoundImage} />
-    </Grid.Row>
-    <Grid.Row>
-      <Header size="huge">
+  <Grid container direction="column" justify="center" alignItems="center" spacing={4}>
+    <Grid item>
+      <img alt="Not Found" src={notFoundImage} />
+    </Grid>
+    <Grid item>
+      <Typography variant="h4">
         <FormattedMessage
           id="app.global.not_exist"
           description="Notifies the user that the page does not exist"
           defaultMessage="Sorry, the page you're looking for doesn't exist."
         />
-      </Header>
-    </Grid.Row>
+      </Typography>
+    </Grid>
   </Grid>
 );
 

--- a/src/containers/Global/__tests__/__snapshots__/NotFound.test.js.snap
+++ b/src/containers/Global/__tests__/__snapshots__/NotFound.test.js.snap
@@ -1,26 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NotFound renders on the page with no errors 1`] = `
-<Grid
-  centered={true}
+<WithStyles(ForwardRef(Grid))
+  alignItems="center"
+  container={true}
+  direction="column"
+  justify="center"
+  spacing={4}
 >
-  <GridRow>
-    <Image
-      as="img"
+  <WithStyles(ForwardRef(Grid))
+    item={true}
+  >
+    <img
+      alt="Not Found"
       src={Object {}}
-      ui={true}
     />
-  </GridRow>
-  <GridRow>
-    <Header
-      size="huge"
+  </WithStyles(ForwardRef(Grid))>
+  <WithStyles(ForwardRef(Grid))
+    item={true}
+  >
+    <WithStyles(ForwardRef(Typography))
+      variant="h4"
     >
       <FormattedMessage
         defaultMessage="Sorry, the page you're looking for doesn't exist."
         id="app.global.not_exist"
         values={Object {}}
       />
-    </Header>
-  </GridRow>
-</Grid>
+    </WithStyles(ForwardRef(Typography))>
+  </WithStyles(ForwardRef(Grid))>
+</WithStyles(ForwardRef(Grid))>
 `;


### PR DESCRIPTION
Converts the `404` page to Material UI. The image can be updated when there is a graphic that better matches this application.