### PR TITLE
Material UI - Control

### DIFF
--- a/src/components/Control.js
+++ b/src/components/Control.js
@@ -7,7 +7,6 @@ import {
   SkipNext,
   Stop,
 } from '@material-ui/icons';
-import { red } from '@material-ui/core/colors';
 import { withStyles } from '@material-ui/core/styles';
 import { hot } from 'react-hot-loader';
 import { injectIntl } from 'react-intl';
@@ -56,12 +55,12 @@ const Control = ({
     defaultMessage: 'Reset',
   });
 
-  const RunButton = withStyles(() => ({
+  const RunButton = withStyles((theme) => ({
     root: {
       color: '#FFFFFF',
-      backgroundColor: '#114BFD',
+      backgroundColor: theme.palette.primary.main,
       '&:hover': {
-        backgroundColor: '#114BFD',
+        backgroundColor: theme.palette.primary.main,
       },
       width: '42px',
       height: '42px',
@@ -72,12 +71,12 @@ const Control = ({
     },
   }))(Button);
 
-  const StepButton = withStyles(() => ({
+  const StepButton = withStyles((theme) => ({
     root: {
       color: '#FFFFFF',
-      backgroundColor: '#FFAD11',
+      backgroundColor: theme.palette.warning.main,
       '&:hover': {
-        backgroundColor: '#FFAD11',
+        backgroundColor: theme.palette.warning.main,
       },
       width: '24px',
       height: '24px',
@@ -88,12 +87,12 @@ const Control = ({
     },
   }))(Button);
 
-  const ResetButton = withStyles(() => ({
+  const ResetButton = withStyles((theme) => ({
     root: {
       color: '#FFFFFF',
-      backgroundColor: '#FF0459',
+      backgroundColor: theme.palette.secondary.main,
       '&:hover': {
-        backgroundColor: '#FF0459',
+        backgroundColor: theme.palette.secondary.main,
       },
       width: '24px',
       height: '24px',
@@ -104,12 +103,12 @@ const Control = ({
     },
   }))(Button);
 
-  const StopButton = withStyles(() => ({
+  const StopButton = withStyles((theme) => ({
     root: {
       color: '#FFFFFF',
-      backgroundColor: red[500],
+      backgroundColor: theme.palette.error.main,
       '&:hover': {
-        backgroundColor: red[500],
+        backgroundColor: theme.palette.error.main,
       },
       width: '42px',
       height: '42px',

--- a/src/components/Control.js
+++ b/src/components/Control.js
@@ -142,7 +142,6 @@ const Control = ({
                 <ResetButton
                   variant="contained"
                   onClick={() => changeExecutionState(EXECUTION_RESET)}
-                  style={{ verticalAlign: 'bottom' }}
                   disabled={!isConnected}
                 >
                   <Replay />
@@ -165,7 +164,6 @@ const Control = ({
                 <StepButton
                   variant="contained"
                   onClick={() => changeExecutionState(EXECUTION_STEP)}
-                  style={{ verticalAlign: 'bottom' }}
                   disabled={!isConnected}
                 >
                   <SkipNext />

--- a/src/components/Control.js
+++ b/src/components/Control.js
@@ -1,8 +1,16 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { Button, Icon } from 'semantic-ui-react';
+import { Button, Grid, Tooltip } from '@material-ui/core';
+import {
+  PlayArrow,
+  Replay,
+  SkipNext,
+  Stop,
+} from '@material-ui/icons';
+import { red } from '@material-ui/core/colors';
+import { withStyles } from '@material-ui/core/styles';
 import { hot } from 'react-hot-loader';
-import { FormattedMessage } from 'react-intl';
+import { injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 
 import {
@@ -18,65 +26,159 @@ const mapDispatchToProps = (dispatch) => ({
   changeExecutionState: (state) => dispatch(actionChangeExecutionState(state)),
 });
 
-const Control = ({ code, changeExecutionState, isConnected }) => (
-  <>
-    {
-      code.execution === EXECUTION_RUN ? (
-        <Button color="red" onMouseDown={(e) => e.preventDefault()} onClick={() => changeExecutionState(EXECUTION_STOP)} animated="vertical">
-          <Button.Content hidden>
-            <FormattedMessage
-              id="app.control.stop"
-              description="Button label to stop execution of the code"
-              defaultMessage="Stop"
-            />
-          </Button.Content>
-          <Button.Content visible>
-            <Icon name="stop" />
-          </Button.Content>
-        </Button>
-      ) : (
-        <>
-          <Button color="green" size="huge" onMouseDown={(e) => e.preventDefault()} onClick={() => changeExecutionState(EXECUTION_RUN)} animated="vertical" disabled={!isConnected}>
-            <Button.Content hidden>
-              <FormattedMessage
-                id="app.control.run"
-                description="Button label to start execution of the code"
-                defaultMessage="Run"
-              />
-            </Button.Content>
-            <Button.Content visible>
-              <Icon name="play" />
-            </Button.Content>
-          </Button>
-          <Button color="yellow" onMouseDown={(e) => e.preventDefault()} onClick={() => changeExecutionState(EXECUTION_STEP)} animated="vertical" style={{ verticalAlign: 'bottom' }} disabled={!isConnected}>
-            <Button.Content hidden>
-              <FormattedMessage
-                id="app.control.step"
-                description="Button label to step one place forward in the code"
-                defaultMessage="Step"
-              />
-            </Button.Content>
-            <Button.Content visible>
-              <Icon name="step forward" />
-            </Button.Content>
-          </Button>
-          <Button color="blue" onMouseDown={(e) => e.preventDefault()} onClick={() => changeExecutionState(EXECUTION_RESET)} animated="vertical" style={{ verticalAlign: 'bottom' }} disabled={!isConnected}>
-            <Button.Content hidden>
-              <FormattedMessage
-                id="app.control.reset"
-                description="Button label to reset to the beginning of the code"
-                defaultMessage="Reset"
-              />
-            </Button.Content>
-            <Button.Content visible>
-              <Icon name="repeat" />
-            </Button.Content>
-          </Button>
-        </>
-      )
-    }
-  </>
-);
+const Control = ({
+  code,
+  changeExecutionState,
+  isConnected,
+  intl,
+}) => {
+  const stopTitle = intl.formatMessage({
+    id: 'app.control.stop',
+    description: 'Button label to stop execution of the code',
+    defaultMessage: 'Stop',
+  });
+
+  const runTitle = intl.formatMessage({
+    id: 'app.control.run',
+    description: 'Button label to start execution of the code',
+    defaultMessage: 'Run',
+  });
+
+  const stepTitle = intl.formatMessage({
+    id: 'app.control.step',
+    description: 'Button label to step one place forward in the code',
+    defaultMessage: 'Step',
+  });
+
+  const resetTitle = intl.formatMessage({
+    id: 'app.control.reset',
+    description: 'Button label to reset to the beginning of the code',
+    defaultMessage: 'Reset',
+  });
+
+  const RunButton = withStyles(() => ({
+    root: {
+      color: '#FFFFFF',
+      backgroundColor: '#114BFD',
+      '&:hover': {
+        backgroundColor: '#114BFD',
+      },
+      width: '42px',
+      height: '42px',
+      minWidth: '0px',
+      boxShadow: '0px 3px 3px #00000029',
+      borderRadius: '4px',
+      opacity: 1,
+    },
+  }))(Button);
+
+  const StepButton = withStyles(() => ({
+    root: {
+      color: '#FFFFFF',
+      backgroundColor: '#FFAD11',
+      '&:hover': {
+        backgroundColor: '#FFAD11',
+      },
+      width: '24px',
+      height: '24px',
+      minWidth: '0px',
+      boxShadow: '0px 1px 3px #00000057',
+      borderRadius: '4px',
+      opacity: 1,
+    },
+  }))(Button);
+
+  const ResetButton = withStyles(() => ({
+    root: {
+      color: '#FFFFFF',
+      backgroundColor: '#FF0459',
+      '&:hover': {
+        backgroundColor: '#FF0459',
+      },
+      width: '24px',
+      height: '24px',
+      minWidth: '0px',
+      boxShadow: '0px 1px 3px #00000057',
+      borderRadius: '4px',
+      opacity: 1,
+    },
+  }))(Button);
+
+  const StopButton = withStyles(() => ({
+    root: {
+      color: '#FFFFFF',
+      backgroundColor: red[500],
+      '&:hover': {
+        backgroundColor: red[500],
+      },
+      width: '42px',
+      height: '42px',
+      minWidth: '0px',
+      boxShadow: '0px 3px 3px #00000029',
+      borderRadius: '4px',
+      opacity: 1,
+    },
+  }))(Button);
+
+  return (
+    <>
+      <Grid container direction="row" justify="center" alignItems="center" spacing={1} style={{ minWidth: '150px' }}>
+        {
+        code.execution === EXECUTION_RUN ? (
+          <Grid item>
+            <Tooltip title={stopTitle}>
+              <StopButton
+                variant="contained"
+                onClick={() => changeExecutionState(EXECUTION_STOP)}
+              >
+                <Stop />
+              </StopButton>
+            </Tooltip>
+          </Grid>
+        ) : (
+          <>
+            <Grid item>
+              <Tooltip title={resetTitle}>
+                <ResetButton
+                  variant="contained"
+                  onClick={() => changeExecutionState(EXECUTION_RESET)}
+                  style={{ verticalAlign: 'bottom' }}
+                  disabled={!isConnected}
+                >
+                  <Replay />
+                </ResetButton>
+              </Tooltip>
+            </Grid>
+            <Grid item>
+              <Tooltip title={runTitle}>
+                <RunButton
+                  variant="contained"
+                  onClick={() => changeExecutionState(EXECUTION_RUN)}
+                  disabled={!isConnected}
+                >
+                  <PlayArrow />
+                </RunButton>
+              </Tooltip>
+            </Grid>
+            <Grid item>
+              <Tooltip title={stepTitle}>
+                <StepButton
+                  variant="contained"
+                  onClick={() => changeExecutionState(EXECUTION_STEP)}
+                  style={{ verticalAlign: 'bottom' }}
+                  disabled={!isConnected}
+                >
+                  <SkipNext />
+                </StepButton>
+              </Tooltip>
+            </Grid>
+          </>
+        )
+      }
+      </Grid>
+    </>
+  );
+};
 
 Control.defaultProps = {
   isConnected: false,
@@ -88,6 +190,9 @@ Control.propTypes = {
   }).isRequired,
   isConnected: PropTypes.bool,
   changeExecutionState: PropTypes.func.isRequired,
+  intl: PropTypes.shape({
+    formatMessage: PropTypes.func.isRequired,
+  }).isRequired,
 };
 
-export default hot(module)(connect(mapStateToProps, mapDispatchToProps)(Control));
+export default hot(module)(injectIntl(connect(mapStateToProps, mapDispatchToProps)(Control)));

--- a/src/components/Control.js
+++ b/src/components/Control.js
@@ -55,13 +55,9 @@ const Control = ({
     defaultMessage: 'Reset',
   });
 
-  const RunButton = withStyles((theme) => ({
+  const RunButton = withStyles(() => ({
     root: {
       color: '#FFFFFF',
-      backgroundColor: theme.palette.primary.main,
-      '&:hover': {
-        backgroundColor: theme.palette.primary.main,
-      },
       width: '42px',
       height: '42px',
       minWidth: '0px',
@@ -76,7 +72,7 @@ const Control = ({
       color: '#FFFFFF',
       backgroundColor: theme.palette.warning.main,
       '&:hover': {
-        backgroundColor: theme.palette.warning.main,
+        backgroundColor: theme.palette.warning.dark,
       },
       width: '24px',
       height: '24px',
@@ -87,13 +83,9 @@ const Control = ({
     },
   }))(Button);
 
-  const ResetButton = withStyles((theme) => ({
+  const ResetButton = withStyles(() => ({
     root: {
       color: '#FFFFFF',
-      backgroundColor: theme.palette.secondary.main,
-      '&:hover': {
-        backgroundColor: theme.palette.secondary.main,
-      },
       width: '24px',
       height: '24px',
       minWidth: '0px',
@@ -108,7 +100,7 @@ const Control = ({
       color: '#FFFFFF',
       backgroundColor: theme.palette.error.main,
       '&:hover': {
-        backgroundColor: theme.palette.error.main,
+        backgroundColor: theme.palette.error.dark,
       },
       width: '42px',
       height: '42px',
@@ -140,6 +132,7 @@ const Control = ({
               <Tooltip title={resetTitle}>
                 <ResetButton
                   variant="contained"
+                  color="secondary"
                   onClick={() => changeExecutionState(EXECUTION_RESET)}
                   disabled={!isConnected}
                 >
@@ -151,6 +144,7 @@ const Control = ({
               <Tooltip title={runTitle}>
                 <RunButton
                   variant="contained"
+                  color="primary"
                   onClick={() => changeExecutionState(EXECUTION_RUN)}
                   disabled={!isConnected}
                 >

--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -497,7 +497,7 @@ class Workspace extends Component {
           ) : (null)
         }
         <div ref={(editorDiv) => { this.editorDiv = editorDiv; }} id="blocklyDiv">
-          <div style={{ position: 'absolute', bottom: 30, right: 100 }}>
+          <div style={{ position: 'absolute', bottom: 0, right: 0 }}>
             { React.cloneElement(children, { isConnected: !!rover.rover }) }
           </div>
         </div>

--- a/src/components/__tests__/Control.test.js
+++ b/src/components/__tests__/Control.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Button } from 'semantic-ui-react';
-import { shallow } from 'enzyme';
+import { Button } from '@material-ui/core';
 import toJson from 'enzyme-to-json';
 import configureStore from 'redux-mock-store';
 
@@ -26,13 +25,23 @@ describe('The Control component', () => {
     store.dispatch = jest.fn();
   });
 
-  test('renders on the page with no errors', () => {
+  test('renders on the page with no errors in stop state', () => {
     const wrapper = mountWithIntl(<Control store={store} isConnected />);
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
+  test('renders on the page with no errors in run state', () => {
+    const runStore = mockStore({
+      code: {
+        execution: EXECUTION_RUN,
+      },
+    });
+    const wrapper = mountWithIntl(<Control store={runStore} isConnected />);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
   test('dispatches an action to change execution state', () => {
-    const wrapper = shallow(<Control store={store} />).dive();
+    const wrapper = shallowWithIntl(<Control store={store} />).dive().dive().dive();
 
     wrapper.props().changeExecutionState(EXECUTION_RUN);
 
@@ -40,57 +49,50 @@ describe('The Control component', () => {
   });
 
   test('changes to run state on button press', () => {
-    const mockPreventDefault = jest.fn();
-    const wrapper = shallow(<Control store={store} />).dive();
+    const wrapper = shallowWithIntl(<Control store={store} />).dive().dive().dive()
+      .dive();
 
-    wrapper.dive().find(Button).at(0).simulate('click');
-    wrapper.dive().find(Button).at(0).simulate('mousedown', { preventDefault: mockPreventDefault });
+    wrapper.find('WithStyles(WithStyles(ForwardRef(Button)))').at(1).simulate('click');
 
     expect(store.dispatch).toHaveBeenCalledWith(changeExecutionState(EXECUTION_RUN));
-    expect(mockPreventDefault).toHaveBeenCalled();
   });
 
   test('changes to step state on button press', () => {
-    const mockPreventDefault = jest.fn();
-    const wrapper = shallow(<Control store={store} />).dive();
+    const wrapper = shallowWithIntl(<Control store={store} />).dive().dive().dive()
+      .dive();
 
-    wrapper.dive().find(Button).at(1).simulate('click');
-    wrapper.dive().find(Button).at(1).simulate('mousedown', { preventDefault: mockPreventDefault });
+    wrapper.find('WithStyles(WithStyles(ForwardRef(Button)))').at(2).simulate('click');
 
     expect(store.dispatch).toHaveBeenCalledWith(changeExecutionState(EXECUTION_STEP));
-    expect(mockPreventDefault).toHaveBeenCalled();
   });
 
   test('changes to reset state on button press', () => {
-    const mockPreventDefault = jest.fn();
-    const wrapper = shallow(<Control store={store} />).dive();
+    const wrapper = shallowWithIntl(<Control store={store} />).dive().dive().dive()
+      .dive();
 
-    wrapper.dive().find(Button).at(2).simulate('click');
-    wrapper.dive().find(Button).at(2).simulate('mousedown', { preventDefault: mockPreventDefault });
+    wrapper.find('WithStyles(WithStyles(ForwardRef(Button)))').at(0).simulate('click');
 
     expect(store.dispatch).toHaveBeenCalledWith(changeExecutionState(EXECUTION_RESET));
-    expect(mockPreventDefault).toHaveBeenCalled();
   });
 
   test('changes to stop state on button press', () => {
-    const mockPreventDefault = jest.fn();
     const runStore = mockStore({
       code: {
         execution: EXECUTION_RUN,
       },
     });
     runStore.dispatch = jest.fn();
-    const wrapper = shallow(<Control store={runStore} />).dive().dive();
+    const wrapper = shallowWithIntl(<Control store={runStore} />).dive().dive().dive()
+      .dive();
 
-    wrapper.find(Button).at(0).simulate('click');
-    wrapper.find(Button).at(0).simulate('mousedown', { preventDefault: mockPreventDefault });
+    wrapper.find('WithStyles(WithStyles(ForwardRef(Button)))').at(0).simulate('click');
 
     expect(runStore.dispatch).toHaveBeenCalledWith(changeExecutionState(EXECUTION_STOP));
-    expect(mockPreventDefault).toHaveBeenCalled();
   });
 
   test('disables buttons when not connected', () => {
-    const wrapper = shallow(<Control store={store} />).dive().dive();
+    const wrapper = shallowWithIntl(<Control store={store} />).dive().dive().dive()
+      .dive();
 
     wrapper.find(Button).forEach((btn) => {
       expect(btn.prop('disabled')).toBe(true);

--- a/src/components/__tests__/__snapshots__/Control.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Control.test.js.snap
@@ -1042,6 +1042,7 @@ exports[`The Control component renders on the page with no errors in stop state 
                       <WithStyles(WithStyles(ForwardRef(Button)))
                         aria-describedby={null}
                         className=""
+                        color="secondary"
                         disabled={false}
                         onBlur={[Function]}
                         onClick={[Function]}
@@ -1061,6 +1062,7 @@ exports[`The Control component renders on the page with no errors in stop state 
                               "root": "WithStyles(ForwardRef(Button))-root-115",
                             }
                           }
+                          color="secondary"
                           disabled={false}
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -1108,6 +1110,7 @@ exports[`The Control component renders on the page with no errors in stop state 
                                 "textSizeSmall": "MuiButton-textSizeSmall",
                               }
                             }
+                            color="secondary"
                             disabled={false}
                             onBlur={[Function]}
                             onClick={[Function]}
@@ -1121,7 +1124,7 @@ exports[`The Control component renders on the page with no errors in stop state 
                           >
                             <WithStyles(ForwardRef(ButtonBase))
                               aria-describedby={null}
-                              className="MuiButton-root WithStyles(ForwardRef(Button))-root-115 MuiButton-contained"
+                              className="MuiButton-root WithStyles(ForwardRef(Button))-root-115 MuiButton-contained MuiButton-containedSecondary"
                               component="button"
                               disabled={false}
                               focusRipple={true}
@@ -1138,7 +1141,7 @@ exports[`The Control component renders on the page with no errors in stop state 
                             >
                               <ForwardRef(ButtonBase)
                                 aria-describedby={null}
-                                className="MuiButton-root WithStyles(ForwardRef(Button))-root-115 MuiButton-contained"
+                                className="MuiButton-root WithStyles(ForwardRef(Button))-root-115 MuiButton-contained MuiButton-containedSecondary"
                                 classes={
                                   Object {
                                     "disabled": "Mui-disabled",
@@ -1162,7 +1165,7 @@ exports[`The Control component renders on the page with no errors in stop state 
                               >
                                 <button
                                   aria-describedby={null}
-                                  className="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-115 MuiButton-contained"
+                                  className="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-115 MuiButton-contained MuiButton-containedSecondary"
                                   disabled={false}
                                   onBlur={[Function]}
                                   onClick={[Function]}
@@ -1252,7 +1255,7 @@ exports[`The Control component renders on the page with no errors in stop state 
                       <ForwardRef(Popper)
                         anchorEl={
                           <button
-                            class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-115 MuiButton-contained"
+                            class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-115 MuiButton-contained MuiButton-containedSecondary"
                             tabindex="0"
                             title="Reset"
                             type="button"
@@ -1437,6 +1440,7 @@ exports[`The Control component renders on the page with no errors in stop state 
                       <WithStyles(WithStyles(ForwardRef(Button)))
                         aria-describedby={null}
                         className=""
+                        color="primary"
                         disabled={false}
                         onBlur={[Function]}
                         onClick={[Function]}
@@ -1456,6 +1460,7 @@ exports[`The Control component renders on the page with no errors in stop state 
                               "root": "WithStyles(ForwardRef(Button))-root-157",
                             }
                           }
+                          color="primary"
                           disabled={false}
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -1503,6 +1508,7 @@ exports[`The Control component renders on the page with no errors in stop state 
                                 "textSizeSmall": "MuiButton-textSizeSmall",
                               }
                             }
+                            color="primary"
                             disabled={false}
                             onBlur={[Function]}
                             onClick={[Function]}
@@ -1516,7 +1522,7 @@ exports[`The Control component renders on the page with no errors in stop state 
                           >
                             <WithStyles(ForwardRef(ButtonBase))
                               aria-describedby={null}
-                              className="MuiButton-root WithStyles(ForwardRef(Button))-root-157 MuiButton-contained"
+                              className="MuiButton-root WithStyles(ForwardRef(Button))-root-157 MuiButton-contained MuiButton-containedPrimary"
                               component="button"
                               disabled={false}
                               focusRipple={true}
@@ -1533,7 +1539,7 @@ exports[`The Control component renders on the page with no errors in stop state 
                             >
                               <ForwardRef(ButtonBase)
                                 aria-describedby={null}
-                                className="MuiButton-root WithStyles(ForwardRef(Button))-root-157 MuiButton-contained"
+                                className="MuiButton-root WithStyles(ForwardRef(Button))-root-157 MuiButton-contained MuiButton-containedPrimary"
                                 classes={
                                   Object {
                                     "disabled": "Mui-disabled",
@@ -1557,7 +1563,7 @@ exports[`The Control component renders on the page with no errors in stop state 
                               >
                                 <button
                                   aria-describedby={null}
-                                  className="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-157 MuiButton-contained"
+                                  className="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-157 MuiButton-contained MuiButton-containedPrimary"
                                   disabled={false}
                                   onBlur={[Function]}
                                   onClick={[Function]}
@@ -1647,7 +1653,7 @@ exports[`The Control component renders on the page with no errors in stop state 
                       <ForwardRef(Popper)
                         anchorEl={
                           <button
-                            class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-157 MuiButton-contained"
+                            class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-157 MuiButton-contained MuiButton-containedPrimary"
                             tabindex="0"
                             title="Run"
                             type="button"

--- a/src/components/__tests__/__snapshots__/Control.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Control.test.js.snap
@@ -1050,11 +1050,6 @@ exports[`The Control component renders on the page with no errors in stop state 
                         onMouseOver={[Function]}
                         onTouchEnd={[Function]}
                         onTouchStart={[Function]}
-                        style={
-                          Object {
-                            "verticalAlign": "bottom",
-                          }
-                        }
                         title="Reset"
                         variant="contained"
                       >
@@ -1074,11 +1069,6 @@ exports[`The Control component renders on the page with no errors in stop state 
                           onMouseOver={[Function]}
                           onTouchEnd={[Function]}
                           onTouchStart={[Function]}
-                          style={
-                            Object {
-                              "verticalAlign": "bottom",
-                            }
-                          }
                           title="Reset"
                           variant="contained"
                         >
@@ -1126,11 +1116,6 @@ exports[`The Control component renders on the page with no errors in stop state 
                             onMouseOver={[Function]}
                             onTouchEnd={[Function]}
                             onTouchStart={[Function]}
-                            style={
-                              Object {
-                                "verticalAlign": "bottom",
-                              }
-                            }
                             title="Reset"
                             variant="contained"
                           >
@@ -1148,11 +1133,6 @@ exports[`The Control component renders on the page with no errors in stop state 
                               onMouseOver={[Function]}
                               onTouchEnd={[Function]}
                               onTouchStart={[Function]}
-                              style={
-                                Object {
-                                  "verticalAlign": "bottom",
-                                }
-                              }
                               title="Reset"
                               type="button"
                             >
@@ -1177,11 +1157,6 @@ exports[`The Control component renders on the page with no errors in stop state 
                                 onMouseOver={[Function]}
                                 onTouchEnd={[Function]}
                                 onTouchStart={[Function]}
-                                style={
-                                  Object {
-                                    "verticalAlign": "bottom",
-                                  }
-                                }
                                 title="Reset"
                                 type="button"
                               >
@@ -1202,11 +1177,6 @@ exports[`The Control component renders on the page with no errors in stop state 
                                   onTouchEnd={[Function]}
                                   onTouchMove={[Function]}
                                   onTouchStart={[Function]}
-                                  style={
-                                    Object {
-                                      "verticalAlign": "bottom",
-                                    }
-                                  }
                                   tabIndex={0}
                                   title="Reset"
                                   type="button"
@@ -1283,7 +1253,6 @@ exports[`The Control component renders on the page with no errors in stop state 
                         anchorEl={
                           <button
                             class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-115 MuiButton-contained"
-                            style="vertical-align: bottom;"
                             tabindex="0"
                             title="Reset"
                             type="button"
@@ -1871,11 +1840,6 @@ exports[`The Control component renders on the page with no errors in stop state 
                         onMouseOver={[Function]}
                         onTouchEnd={[Function]}
                         onTouchStart={[Function]}
-                        style={
-                          Object {
-                            "verticalAlign": "bottom",
-                          }
-                        }
                         title="Step"
                         variant="contained"
                       >
@@ -1895,11 +1859,6 @@ exports[`The Control component renders on the page with no errors in stop state 
                           onMouseOver={[Function]}
                           onTouchEnd={[Function]}
                           onTouchStart={[Function]}
-                          style={
-                            Object {
-                              "verticalAlign": "bottom",
-                            }
-                          }
                           title="Step"
                           variant="contained"
                         >
@@ -1947,11 +1906,6 @@ exports[`The Control component renders on the page with no errors in stop state 
                             onMouseOver={[Function]}
                             onTouchEnd={[Function]}
                             onTouchStart={[Function]}
-                            style={
-                              Object {
-                                "verticalAlign": "bottom",
-                              }
-                            }
                             title="Step"
                             variant="contained"
                           >
@@ -1969,11 +1923,6 @@ exports[`The Control component renders on the page with no errors in stop state 
                               onMouseOver={[Function]}
                               onTouchEnd={[Function]}
                               onTouchStart={[Function]}
-                              style={
-                                Object {
-                                  "verticalAlign": "bottom",
-                                }
-                              }
                               title="Step"
                               type="button"
                             >
@@ -1998,11 +1947,6 @@ exports[`The Control component renders on the page with no errors in stop state 
                                 onMouseOver={[Function]}
                                 onTouchEnd={[Function]}
                                 onTouchStart={[Function]}
-                                style={
-                                  Object {
-                                    "verticalAlign": "bottom",
-                                  }
-                                }
                                 title="Step"
                                 type="button"
                               >
@@ -2023,11 +1967,6 @@ exports[`The Control component renders on the page with no errors in stop state 
                                   onTouchEnd={[Function]}
                                   onTouchMove={[Function]}
                                   onTouchStart={[Function]}
-                                  style={
-                                    Object {
-                                      "verticalAlign": "bottom",
-                                    }
-                                  }
                                   tabIndex={0}
                                   title="Step"
                                   type="button"
@@ -2104,7 +2043,6 @@ exports[`The Control component renders on the page with no errors in stop state 
                         anchorEl={
                           <button
                             class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-158 MuiButton-contained"
-                            style="vertical-align: bottom;"
                             tabindex="0"
                             title="Step"
                             type="button"

--- a/src/components/__tests__/__snapshots__/Control.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Control.test.js.snap
@@ -1,7 +1,658 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`The Control component renders on the page with no errors 1`] = `
-<Connect(Control)
+exports[`The Control component renders on the page with no errors in run state 1`] = `
+<injectIntl(Connect(Control))
+  isConnected={true}
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <Connect(Control)
+    intl={
+      Object {
+        "defaultFormats": Object {},
+        "defaultLocale": "en",
+        "formatDate": [Function],
+        "formatDateToParts": [Function],
+        "formatDisplayName": [Function],
+        "formatHTMLMessage": [Function],
+        "formatList": [Function],
+        "formatMessage": [Function],
+        "formatNumber": [Function],
+        "formatNumberToParts": [Function],
+        "formatPlural": [Function],
+        "formatRelativeTime": [Function],
+        "formatTime": [Function],
+        "formatTimeToParts": [Function],
+        "formats": Object {},
+        "formatters": Object {
+          "getDateTimeFormat": [Function],
+          "getDisplayNames": [Function],
+          "getListFormat": [Function],
+          "getMessageFormat": [Function],
+          "getNumberFormat": [Function],
+          "getPluralRules": [Function],
+          "getRelativeTimeFormat": [Function],
+        },
+        "locale": "en",
+        "messages": Object {},
+        "onError": [Function],
+        "textComponent": Symbol(react.fragment),
+        "timeZone": undefined,
+      }
+    }
+    isConnected={true}
+    store={
+      Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      }
+    }
+  >
+    <Control
+      changeExecutionState={[Function]}
+      code={
+        Object {
+          "execution": 1,
+        }
+      }
+      intl={
+        Object {
+          "defaultFormats": Object {},
+          "defaultLocale": "en",
+          "formatDate": [Function],
+          "formatDateToParts": [Function],
+          "formatDisplayName": [Function],
+          "formatHTMLMessage": [Function],
+          "formatList": [Function],
+          "formatMessage": [Function],
+          "formatNumber": [Function],
+          "formatNumberToParts": [Function],
+          "formatPlural": [Function],
+          "formatRelativeTime": [Function],
+          "formatTime": [Function],
+          "formatTimeToParts": [Function],
+          "formats": Object {},
+          "formatters": Object {
+            "getDateTimeFormat": [Function],
+            "getDisplayNames": [Function],
+            "getListFormat": [Function],
+            "getMessageFormat": [Function],
+            "getNumberFormat": [Function],
+            "getPluralRules": [Function],
+            "getRelativeTimeFormat": [Function],
+          },
+          "locale": "en",
+          "messages": Object {},
+          "onError": [Function],
+          "textComponent": Symbol(react.fragment),
+          "timeZone": undefined,
+        }
+      }
+      isConnected={true}
+      store={
+        Object {
+          "clearActions": [Function],
+          "dispatch": [Function],
+          "getActions": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+        }
+      }
+    >
+      <WithStyles(ForwardRef(Grid))
+        alignItems="center"
+        container={true}
+        direction="row"
+        justify="center"
+        spacing={1}
+        style={
+          Object {
+            "minWidth": "150px",
+          }
+        }
+      >
+        <ForwardRef(Grid)
+          alignItems="center"
+          classes={
+            Object {
+              "align-content-xs-center": "MuiGrid-align-content-xs-center",
+              "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
+              "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
+              "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
+              "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
+              "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
+              "align-items-xs-center": "MuiGrid-align-items-xs-center",
+              "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
+              "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
+              "container": "MuiGrid-container",
+              "direction-xs-column": "MuiGrid-direction-xs-column",
+              "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
+              "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
+              "grid-lg-1": "MuiGrid-grid-lg-1",
+              "grid-lg-10": "MuiGrid-grid-lg-10",
+              "grid-lg-11": "MuiGrid-grid-lg-11",
+              "grid-lg-12": "MuiGrid-grid-lg-12",
+              "grid-lg-2": "MuiGrid-grid-lg-2",
+              "grid-lg-3": "MuiGrid-grid-lg-3",
+              "grid-lg-4": "MuiGrid-grid-lg-4",
+              "grid-lg-5": "MuiGrid-grid-lg-5",
+              "grid-lg-6": "MuiGrid-grid-lg-6",
+              "grid-lg-7": "MuiGrid-grid-lg-7",
+              "grid-lg-8": "MuiGrid-grid-lg-8",
+              "grid-lg-9": "MuiGrid-grid-lg-9",
+              "grid-lg-auto": "MuiGrid-grid-lg-auto",
+              "grid-lg-true": "MuiGrid-grid-lg-true",
+              "grid-md-1": "MuiGrid-grid-md-1",
+              "grid-md-10": "MuiGrid-grid-md-10",
+              "grid-md-11": "MuiGrid-grid-md-11",
+              "grid-md-12": "MuiGrid-grid-md-12",
+              "grid-md-2": "MuiGrid-grid-md-2",
+              "grid-md-3": "MuiGrid-grid-md-3",
+              "grid-md-4": "MuiGrid-grid-md-4",
+              "grid-md-5": "MuiGrid-grid-md-5",
+              "grid-md-6": "MuiGrid-grid-md-6",
+              "grid-md-7": "MuiGrid-grid-md-7",
+              "grid-md-8": "MuiGrid-grid-md-8",
+              "grid-md-9": "MuiGrid-grid-md-9",
+              "grid-md-auto": "MuiGrid-grid-md-auto",
+              "grid-md-true": "MuiGrid-grid-md-true",
+              "grid-sm-1": "MuiGrid-grid-sm-1",
+              "grid-sm-10": "MuiGrid-grid-sm-10",
+              "grid-sm-11": "MuiGrid-grid-sm-11",
+              "grid-sm-12": "MuiGrid-grid-sm-12",
+              "grid-sm-2": "MuiGrid-grid-sm-2",
+              "grid-sm-3": "MuiGrid-grid-sm-3",
+              "grid-sm-4": "MuiGrid-grid-sm-4",
+              "grid-sm-5": "MuiGrid-grid-sm-5",
+              "grid-sm-6": "MuiGrid-grid-sm-6",
+              "grid-sm-7": "MuiGrid-grid-sm-7",
+              "grid-sm-8": "MuiGrid-grid-sm-8",
+              "grid-sm-9": "MuiGrid-grid-sm-9",
+              "grid-sm-auto": "MuiGrid-grid-sm-auto",
+              "grid-sm-true": "MuiGrid-grid-sm-true",
+              "grid-xl-1": "MuiGrid-grid-xl-1",
+              "grid-xl-10": "MuiGrid-grid-xl-10",
+              "grid-xl-11": "MuiGrid-grid-xl-11",
+              "grid-xl-12": "MuiGrid-grid-xl-12",
+              "grid-xl-2": "MuiGrid-grid-xl-2",
+              "grid-xl-3": "MuiGrid-grid-xl-3",
+              "grid-xl-4": "MuiGrid-grid-xl-4",
+              "grid-xl-5": "MuiGrid-grid-xl-5",
+              "grid-xl-6": "MuiGrid-grid-xl-6",
+              "grid-xl-7": "MuiGrid-grid-xl-7",
+              "grid-xl-8": "MuiGrid-grid-xl-8",
+              "grid-xl-9": "MuiGrid-grid-xl-9",
+              "grid-xl-auto": "MuiGrid-grid-xl-auto",
+              "grid-xl-true": "MuiGrid-grid-xl-true",
+              "grid-xs-1": "MuiGrid-grid-xs-1",
+              "grid-xs-10": "MuiGrid-grid-xs-10",
+              "grid-xs-11": "MuiGrid-grid-xs-11",
+              "grid-xs-12": "MuiGrid-grid-xs-12",
+              "grid-xs-2": "MuiGrid-grid-xs-2",
+              "grid-xs-3": "MuiGrid-grid-xs-3",
+              "grid-xs-4": "MuiGrid-grid-xs-4",
+              "grid-xs-5": "MuiGrid-grid-xs-5",
+              "grid-xs-6": "MuiGrid-grid-xs-6",
+              "grid-xs-7": "MuiGrid-grid-xs-7",
+              "grid-xs-8": "MuiGrid-grid-xs-8",
+              "grid-xs-9": "MuiGrid-grid-xs-9",
+              "grid-xs-auto": "MuiGrid-grid-xs-auto",
+              "grid-xs-true": "MuiGrid-grid-xs-true",
+              "item": "MuiGrid-item",
+              "justify-xs-center": "MuiGrid-justify-xs-center",
+              "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
+              "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
+              "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
+              "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
+              "root": "MuiGrid-root",
+              "spacing-xs-1": "MuiGrid-spacing-xs-1",
+              "spacing-xs-10": "MuiGrid-spacing-xs-10",
+              "spacing-xs-2": "MuiGrid-spacing-xs-2",
+              "spacing-xs-3": "MuiGrid-spacing-xs-3",
+              "spacing-xs-4": "MuiGrid-spacing-xs-4",
+              "spacing-xs-5": "MuiGrid-spacing-xs-5",
+              "spacing-xs-6": "MuiGrid-spacing-xs-6",
+              "spacing-xs-7": "MuiGrid-spacing-xs-7",
+              "spacing-xs-8": "MuiGrid-spacing-xs-8",
+              "spacing-xs-9": "MuiGrid-spacing-xs-9",
+              "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
+              "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
+              "zeroMinWidth": "MuiGrid-zeroMinWidth",
+            }
+          }
+          container={true}
+          direction="row"
+          justify="center"
+          spacing={1}
+          style={
+            Object {
+              "minWidth": "150px",
+            }
+          }
+        >
+          <div
+            className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"
+            style={
+              Object {
+                "minWidth": "150px",
+              }
+            }
+          >
+            <WithStyles(ForwardRef(Grid))
+              item={true}
+            >
+              <ForwardRef(Grid)
+                classes={
+                  Object {
+                    "align-content-xs-center": "MuiGrid-align-content-xs-center",
+                    "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
+                    "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
+                    "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
+                    "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
+                    "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
+                    "align-items-xs-center": "MuiGrid-align-items-xs-center",
+                    "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
+                    "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
+                    "container": "MuiGrid-container",
+                    "direction-xs-column": "MuiGrid-direction-xs-column",
+                    "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
+                    "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
+                    "grid-lg-1": "MuiGrid-grid-lg-1",
+                    "grid-lg-10": "MuiGrid-grid-lg-10",
+                    "grid-lg-11": "MuiGrid-grid-lg-11",
+                    "grid-lg-12": "MuiGrid-grid-lg-12",
+                    "grid-lg-2": "MuiGrid-grid-lg-2",
+                    "grid-lg-3": "MuiGrid-grid-lg-3",
+                    "grid-lg-4": "MuiGrid-grid-lg-4",
+                    "grid-lg-5": "MuiGrid-grid-lg-5",
+                    "grid-lg-6": "MuiGrid-grid-lg-6",
+                    "grid-lg-7": "MuiGrid-grid-lg-7",
+                    "grid-lg-8": "MuiGrid-grid-lg-8",
+                    "grid-lg-9": "MuiGrid-grid-lg-9",
+                    "grid-lg-auto": "MuiGrid-grid-lg-auto",
+                    "grid-lg-true": "MuiGrid-grid-lg-true",
+                    "grid-md-1": "MuiGrid-grid-md-1",
+                    "grid-md-10": "MuiGrid-grid-md-10",
+                    "grid-md-11": "MuiGrid-grid-md-11",
+                    "grid-md-12": "MuiGrid-grid-md-12",
+                    "grid-md-2": "MuiGrid-grid-md-2",
+                    "grid-md-3": "MuiGrid-grid-md-3",
+                    "grid-md-4": "MuiGrid-grid-md-4",
+                    "grid-md-5": "MuiGrid-grid-md-5",
+                    "grid-md-6": "MuiGrid-grid-md-6",
+                    "grid-md-7": "MuiGrid-grid-md-7",
+                    "grid-md-8": "MuiGrid-grid-md-8",
+                    "grid-md-9": "MuiGrid-grid-md-9",
+                    "grid-md-auto": "MuiGrid-grid-md-auto",
+                    "grid-md-true": "MuiGrid-grid-md-true",
+                    "grid-sm-1": "MuiGrid-grid-sm-1",
+                    "grid-sm-10": "MuiGrid-grid-sm-10",
+                    "grid-sm-11": "MuiGrid-grid-sm-11",
+                    "grid-sm-12": "MuiGrid-grid-sm-12",
+                    "grid-sm-2": "MuiGrid-grid-sm-2",
+                    "grid-sm-3": "MuiGrid-grid-sm-3",
+                    "grid-sm-4": "MuiGrid-grid-sm-4",
+                    "grid-sm-5": "MuiGrid-grid-sm-5",
+                    "grid-sm-6": "MuiGrid-grid-sm-6",
+                    "grid-sm-7": "MuiGrid-grid-sm-7",
+                    "grid-sm-8": "MuiGrid-grid-sm-8",
+                    "grid-sm-9": "MuiGrid-grid-sm-9",
+                    "grid-sm-auto": "MuiGrid-grid-sm-auto",
+                    "grid-sm-true": "MuiGrid-grid-sm-true",
+                    "grid-xl-1": "MuiGrid-grid-xl-1",
+                    "grid-xl-10": "MuiGrid-grid-xl-10",
+                    "grid-xl-11": "MuiGrid-grid-xl-11",
+                    "grid-xl-12": "MuiGrid-grid-xl-12",
+                    "grid-xl-2": "MuiGrid-grid-xl-2",
+                    "grid-xl-3": "MuiGrid-grid-xl-3",
+                    "grid-xl-4": "MuiGrid-grid-xl-4",
+                    "grid-xl-5": "MuiGrid-grid-xl-5",
+                    "grid-xl-6": "MuiGrid-grid-xl-6",
+                    "grid-xl-7": "MuiGrid-grid-xl-7",
+                    "grid-xl-8": "MuiGrid-grid-xl-8",
+                    "grid-xl-9": "MuiGrid-grid-xl-9",
+                    "grid-xl-auto": "MuiGrid-grid-xl-auto",
+                    "grid-xl-true": "MuiGrid-grid-xl-true",
+                    "grid-xs-1": "MuiGrid-grid-xs-1",
+                    "grid-xs-10": "MuiGrid-grid-xs-10",
+                    "grid-xs-11": "MuiGrid-grid-xs-11",
+                    "grid-xs-12": "MuiGrid-grid-xs-12",
+                    "grid-xs-2": "MuiGrid-grid-xs-2",
+                    "grid-xs-3": "MuiGrid-grid-xs-3",
+                    "grid-xs-4": "MuiGrid-grid-xs-4",
+                    "grid-xs-5": "MuiGrid-grid-xs-5",
+                    "grid-xs-6": "MuiGrid-grid-xs-6",
+                    "grid-xs-7": "MuiGrid-grid-xs-7",
+                    "grid-xs-8": "MuiGrid-grid-xs-8",
+                    "grid-xs-9": "MuiGrid-grid-xs-9",
+                    "grid-xs-auto": "MuiGrid-grid-xs-auto",
+                    "grid-xs-true": "MuiGrid-grid-xs-true",
+                    "item": "MuiGrid-item",
+                    "justify-xs-center": "MuiGrid-justify-xs-center",
+                    "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
+                    "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
+                    "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
+                    "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
+                    "root": "MuiGrid-root",
+                    "spacing-xs-1": "MuiGrid-spacing-xs-1",
+                    "spacing-xs-10": "MuiGrid-spacing-xs-10",
+                    "spacing-xs-2": "MuiGrid-spacing-xs-2",
+                    "spacing-xs-3": "MuiGrid-spacing-xs-3",
+                    "spacing-xs-4": "MuiGrid-spacing-xs-4",
+                    "spacing-xs-5": "MuiGrid-spacing-xs-5",
+                    "spacing-xs-6": "MuiGrid-spacing-xs-6",
+                    "spacing-xs-7": "MuiGrid-spacing-xs-7",
+                    "spacing-xs-8": "MuiGrid-spacing-xs-8",
+                    "spacing-xs-9": "MuiGrid-spacing-xs-9",
+                    "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
+                    "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
+                    "zeroMinWidth": "MuiGrid-zeroMinWidth",
+                  }
+                }
+                item={true}
+              >
+                <div
+                  className="MuiGrid-root MuiGrid-item"
+                >
+                  <WithStyles(ForwardRef(Tooltip))
+                    title="Stop"
+                  >
+                    <ForwardRef(Tooltip)
+                      classes={
+                        Object {
+                          "arrow": "MuiTooltip-arrow",
+                          "popper": "MuiTooltip-popper",
+                          "popperArrow": "MuiTooltip-popperArrow",
+                          "popperInteractive": "MuiTooltip-popperInteractive",
+                          "tooltip": "MuiTooltip-tooltip",
+                          "tooltipArrow": "MuiTooltip-tooltipArrow",
+                          "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom",
+                          "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft",
+                          "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight",
+                          "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop",
+                          "touch": "MuiTooltip-touch",
+                        }
+                      }
+                      title="Stop"
+                    >
+                      <WithStyles(WithStyles(ForwardRef(Button)))
+                        aria-describedby={null}
+                        className=""
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        title="Stop"
+                        variant="contained"
+                      >
+                        <WithStyles(ForwardRef(Button))
+                          aria-describedby={null}
+                          className=""
+                          classes={
+                            Object {
+                              "root": "WithStyles(ForwardRef(Button))-root-169",
+                            }
+                          }
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchStart={[Function]}
+                          title="Stop"
+                          variant="contained"
+                        >
+                          <ForwardRef(Button)
+                            aria-describedby={null}
+                            className=""
+                            classes={
+                              Object {
+                                "colorInherit": "MuiButton-colorInherit",
+                                "contained": "MuiButton-contained",
+                                "containedPrimary": "MuiButton-containedPrimary",
+                                "containedSecondary": "MuiButton-containedSecondary",
+                                "containedSizeLarge": "MuiButton-containedSizeLarge",
+                                "containedSizeSmall": "MuiButton-containedSizeSmall",
+                                "disableElevation": "MuiButton-disableElevation",
+                                "disabled": "Mui-disabled",
+                                "endIcon": "MuiButton-endIcon",
+                                "focusVisible": "Mui-focusVisible",
+                                "fullWidth": "MuiButton-fullWidth",
+                                "iconSizeLarge": "MuiButton-iconSizeLarge",
+                                "iconSizeMedium": "MuiButton-iconSizeMedium",
+                                "iconSizeSmall": "MuiButton-iconSizeSmall",
+                                "label": "MuiButton-label",
+                                "outlined": "MuiButton-outlined",
+                                "outlinedPrimary": "MuiButton-outlinedPrimary",
+                                "outlinedSecondary": "MuiButton-outlinedSecondary",
+                                "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                                "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                                "root": "MuiButton-root WithStyles(ForwardRef(Button))-root-169",
+                                "sizeLarge": "MuiButton-sizeLarge",
+                                "sizeSmall": "MuiButton-sizeSmall",
+                                "startIcon": "MuiButton-startIcon",
+                                "text": "MuiButton-text",
+                                "textPrimary": "MuiButton-textPrimary",
+                                "textSecondary": "MuiButton-textSecondary",
+                                "textSizeLarge": "MuiButton-textSizeLarge",
+                                "textSizeSmall": "MuiButton-textSizeSmall",
+                              }
+                            }
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseOver={[Function]}
+                            onTouchEnd={[Function]}
+                            onTouchStart={[Function]}
+                            title="Stop"
+                            variant="contained"
+                          >
+                            <WithStyles(ForwardRef(ButtonBase))
+                              aria-describedby={null}
+                              className="MuiButton-root WithStyles(ForwardRef(Button))-root-169 MuiButton-contained"
+                              component="button"
+                              disabled={false}
+                              focusRipple={true}
+                              focusVisibleClassName="Mui-focusVisible"
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onMouseLeave={[Function]}
+                              onMouseOver={[Function]}
+                              onTouchEnd={[Function]}
+                              onTouchStart={[Function]}
+                              title="Stop"
+                              type="button"
+                            >
+                              <ForwardRef(ButtonBase)
+                                aria-describedby={null}
+                                className="MuiButton-root WithStyles(ForwardRef(Button))-root-169 MuiButton-contained"
+                                classes={
+                                  Object {
+                                    "disabled": "Mui-disabled",
+                                    "focusVisible": "Mui-focusVisible",
+                                    "root": "MuiButtonBase-root",
+                                  }
+                                }
+                                component="button"
+                                disabled={false}
+                                focusRipple={true}
+                                focusVisibleClassName="Mui-focusVisible"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseLeave={[Function]}
+                                onMouseOver={[Function]}
+                                onTouchEnd={[Function]}
+                                onTouchStart={[Function]}
+                                title="Stop"
+                                type="button"
+                              >
+                                <button
+                                  aria-describedby={null}
+                                  className="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-169 MuiButton-contained"
+                                  disabled={false}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onDragLeave={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onKeyUp={[Function]}
+                                  onMouseDown={[Function]}
+                                  onMouseLeave={[Function]}
+                                  onMouseOver={[Function]}
+                                  onMouseUp={[Function]}
+                                  onTouchEnd={[Function]}
+                                  onTouchMove={[Function]}
+                                  onTouchStart={[Function]}
+                                  tabIndex={0}
+                                  title="Stop"
+                                  type="button"
+                                >
+                                  <span
+                                    className="MuiButton-label"
+                                  >
+                                    <ForwardRef>
+                                      <WithStyles(ForwardRef(SvgIcon))>
+                                        <ForwardRef(SvgIcon)
+                                          classes={
+                                            Object {
+                                              "colorAction": "MuiSvgIcon-colorAction",
+                                              "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                              "colorError": "MuiSvgIcon-colorError",
+                                              "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                              "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                              "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                              "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                              "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                              "root": "MuiSvgIcon-root",
+                                            }
+                                          }
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            className="MuiSvgIcon-root"
+                                            focusable="false"
+                                            viewBox="0 0 24 24"
+                                          >
+                                            <path
+                                              d="M6 6h12v12H6z"
+                                            />
+                                          </svg>
+                                        </ForwardRef(SvgIcon)>
+                                      </WithStyles(ForwardRef(SvgIcon))>
+                                    </ForwardRef>
+                                  </span>
+                                  <WithStyles(memo)
+                                    center={false}
+                                  >
+                                    <ForwardRef(TouchRipple)
+                                      center={false}
+                                      classes={
+                                        Object {
+                                          "child": "MuiTouchRipple-child",
+                                          "childLeaving": "MuiTouchRipple-childLeaving",
+                                          "childPulsate": "MuiTouchRipple-childPulsate",
+                                          "ripple": "MuiTouchRipple-ripple",
+                                          "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                          "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                          "root": "MuiTouchRipple-root",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="MuiTouchRipple-root"
+                                      >
+                                        <TransitionGroup
+                                          childFactory={[Function]}
+                                          component={null}
+                                          exit={true}
+                                        />
+                                      </span>
+                                    </ForwardRef(TouchRipple)>
+                                  </WithStyles(memo)>
+                                </button>
+                              </ForwardRef(ButtonBase)>
+                            </WithStyles(ForwardRef(ButtonBase))>
+                          </ForwardRef(Button)>
+                        </WithStyles(ForwardRef(Button))>
+                      </WithStyles(WithStyles(ForwardRef(Button)))>
+                      <ForwardRef(Popper)
+                        anchorEl={
+                          <button
+                            class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-169 MuiButton-contained"
+                            tabindex="0"
+                            title="Stop"
+                            type="button"
+                          >
+                            <span
+                              class="MuiButton-label"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M6 6h12v12H6z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiTouchRipple-root"
+                            />
+                          </button>
+                        }
+                        className="MuiTooltip-popper"
+                        id={null}
+                        open={false}
+                        placement="bottom"
+                        popperOptions={
+                          Object {
+                            "modifiers": Object {
+                              "arrow": Object {
+                                "element": null,
+                                "enabled": false,
+                              },
+                            },
+                          }
+                        }
+                        transition={true}
+                      />
+                    </ForwardRef(Tooltip)>
+                  </WithStyles(ForwardRef(Tooltip))>
+                </div>
+              </ForwardRef(Grid)>
+            </WithStyles(ForwardRef(Grid))>
+          </div>
+        </ForwardRef(Grid)>
+      </WithStyles(ForwardRef(Grid))>
+    </Control>
+  </Connect(Control)>
+</injectIntl(Connect(Control))>
+`;
+
+exports[`The Control component renders on the page with no errors in stop state 1`] = `
+<injectIntl(Connect(Control))
   isConnected={true}
   store={
     Object {
@@ -14,11 +665,38 @@ exports[`The Control component renders on the page with no errors 1`] = `
     }
   }
 >
-  <Control
-    changeExecutionState={[Function]}
-    code={
+  <Connect(Control)
+    intl={
       Object {
-        "execution": 3,
+        "defaultFormats": Object {},
+        "defaultLocale": "en",
+        "formatDate": [Function],
+        "formatDateToParts": [Function],
+        "formatDisplayName": [Function],
+        "formatHTMLMessage": [Function],
+        "formatList": [Function],
+        "formatMessage": [Function],
+        "formatNumber": [Function],
+        "formatNumberToParts": [Function],
+        "formatPlural": [Function],
+        "formatRelativeTime": [Function],
+        "formatTime": [Function],
+        "formatTimeToParts": [Function],
+        "formats": Object {},
+        "formatters": Object {
+          "getDateTimeFormat": [Function],
+          "getDisplayNames": [Function],
+          "getListFormat": [Function],
+          "getMessageFormat": [Function],
+          "getNumberFormat": [Function],
+          "getPluralRules": [Function],
+          "getRelativeTimeFormat": [Function],
+        },
+        "locale": "en",
+        "messages": Object {},
+        "onError": [Function],
+        "textComponent": Symbol(react.fragment),
+        "timeZone": undefined,
       }
     }
     isConnected={true}
@@ -33,319 +711,1448 @@ exports[`The Control component renders on the page with no errors 1`] = `
       }
     }
   >
-    <Button
-      animated="vertical"
-      as="button"
-      color="green"
-      disabled={false}
-      onClick={[Function]}
-      onMouseDown={[Function]}
-      size="huge"
-    >
-      <Ref
-        innerRef={
-          Object {
-            "current": <button
-              class="ui green huge vertical animated button"
-            >
-              <div
-                class="hidden content"
-              >
-                Run
-              </div>
-              <div
-                class="visible content"
-              >
-                <i
-                  aria-hidden="true"
-                  class="play icon"
-                />
-              </div>
-            </button>,
-          }
-        }
-      >
-        <RefFindNode
-          innerRef={
-            Object {
-              "current": <button
-                class="ui green huge vertical animated button"
-              >
-                <div
-                  class="hidden content"
-                >
-                  Run
-                </div>
-                <div
-                  class="visible content"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="play icon"
-                  />
-                </div>
-              </button>,
-            }
-          }
-        >
-          <button
-            className="ui green huge vertical animated button"
-            onClick={[Function]}
-            onMouseDown={[Function]}
-          >
-            <ButtonContent
-              hidden={true}
-            >
-              <div
-                className="hidden content"
-              >
-                <FormattedMessage
-                  defaultMessage="Run"
-                  id="app.control.run"
-                  values={Object {}}
-                >
-                  Run
-                </FormattedMessage>
-              </div>
-            </ButtonContent>
-            <ButtonContent
-              visible={true}
-            >
-              <div
-                className="visible content"
-              >
-                <Icon
-                  as="i"
-                  name="play"
-                >
-                  <i
-                    aria-hidden="true"
-                    className="play icon"
-                    onClick={[Function]}
-                  />
-                </Icon>
-              </div>
-            </ButtonContent>
-          </button>
-        </RefFindNode>
-      </Ref>
-    </Button>
-    <Button
-      animated="vertical"
-      as="button"
-      color="yellow"
-      disabled={false}
-      onClick={[Function]}
-      onMouseDown={[Function]}
-      style={
+    <Control
+      changeExecutionState={[Function]}
+      code={
         Object {
-          "verticalAlign": "bottom",
+          "execution": 3,
+        }
+      }
+      intl={
+        Object {
+          "defaultFormats": Object {},
+          "defaultLocale": "en",
+          "formatDate": [Function],
+          "formatDateToParts": [Function],
+          "formatDisplayName": [Function],
+          "formatHTMLMessage": [Function],
+          "formatList": [Function],
+          "formatMessage": [Function],
+          "formatNumber": [Function],
+          "formatNumberToParts": [Function],
+          "formatPlural": [Function],
+          "formatRelativeTime": [Function],
+          "formatTime": [Function],
+          "formatTimeToParts": [Function],
+          "formats": Object {},
+          "formatters": Object {
+            "getDateTimeFormat": [Function],
+            "getDisplayNames": [Function],
+            "getListFormat": [Function],
+            "getMessageFormat": [Function],
+            "getNumberFormat": [Function],
+            "getPluralRules": [Function],
+            "getRelativeTimeFormat": [Function],
+          },
+          "locale": "en",
+          "messages": Object {},
+          "onError": [Function],
+          "textComponent": Symbol(react.fragment),
+          "timeZone": undefined,
+        }
+      }
+      isConnected={true}
+      store={
+        Object {
+          "clearActions": [Function],
+          "dispatch": [MockFunction],
+          "getActions": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
         }
       }
     >
-      <Ref
-        innerRef={
+      <WithStyles(ForwardRef(Grid))
+        alignItems="center"
+        container={true}
+        direction="row"
+        justify="center"
+        spacing={1}
+        style={
           Object {
-            "current": <button
-              class="ui yellow vertical animated button"
-              style="vertical-align: bottom;"
-            >
-              <div
-                class="hidden content"
-              >
-                Step
-              </div>
-              <div
-                class="visible content"
-              >
-                <i
-                  aria-hidden="true"
-                  class="step forward icon"
-                />
-              </div>
-            </button>,
+            "minWidth": "150px",
           }
         }
       >
-        <RefFindNode
-          innerRef={
+        <ForwardRef(Grid)
+          alignItems="center"
+          classes={
             Object {
-              "current": <button
-                class="ui yellow vertical animated button"
-                style="vertical-align: bottom;"
-              >
-                <div
-                  class="hidden content"
-                >
-                  Step
-                </div>
-                <div
-                  class="visible content"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="step forward icon"
-                  />
-                </div>
-              </button>,
+              "align-content-xs-center": "MuiGrid-align-content-xs-center",
+              "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
+              "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
+              "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
+              "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
+              "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
+              "align-items-xs-center": "MuiGrid-align-items-xs-center",
+              "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
+              "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
+              "container": "MuiGrid-container",
+              "direction-xs-column": "MuiGrid-direction-xs-column",
+              "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
+              "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
+              "grid-lg-1": "MuiGrid-grid-lg-1",
+              "grid-lg-10": "MuiGrid-grid-lg-10",
+              "grid-lg-11": "MuiGrid-grid-lg-11",
+              "grid-lg-12": "MuiGrid-grid-lg-12",
+              "grid-lg-2": "MuiGrid-grid-lg-2",
+              "grid-lg-3": "MuiGrid-grid-lg-3",
+              "grid-lg-4": "MuiGrid-grid-lg-4",
+              "grid-lg-5": "MuiGrid-grid-lg-5",
+              "grid-lg-6": "MuiGrid-grid-lg-6",
+              "grid-lg-7": "MuiGrid-grid-lg-7",
+              "grid-lg-8": "MuiGrid-grid-lg-8",
+              "grid-lg-9": "MuiGrid-grid-lg-9",
+              "grid-lg-auto": "MuiGrid-grid-lg-auto",
+              "grid-lg-true": "MuiGrid-grid-lg-true",
+              "grid-md-1": "MuiGrid-grid-md-1",
+              "grid-md-10": "MuiGrid-grid-md-10",
+              "grid-md-11": "MuiGrid-grid-md-11",
+              "grid-md-12": "MuiGrid-grid-md-12",
+              "grid-md-2": "MuiGrid-grid-md-2",
+              "grid-md-3": "MuiGrid-grid-md-3",
+              "grid-md-4": "MuiGrid-grid-md-4",
+              "grid-md-5": "MuiGrid-grid-md-5",
+              "grid-md-6": "MuiGrid-grid-md-6",
+              "grid-md-7": "MuiGrid-grid-md-7",
+              "grid-md-8": "MuiGrid-grid-md-8",
+              "grid-md-9": "MuiGrid-grid-md-9",
+              "grid-md-auto": "MuiGrid-grid-md-auto",
+              "grid-md-true": "MuiGrid-grid-md-true",
+              "grid-sm-1": "MuiGrid-grid-sm-1",
+              "grid-sm-10": "MuiGrid-grid-sm-10",
+              "grid-sm-11": "MuiGrid-grid-sm-11",
+              "grid-sm-12": "MuiGrid-grid-sm-12",
+              "grid-sm-2": "MuiGrid-grid-sm-2",
+              "grid-sm-3": "MuiGrid-grid-sm-3",
+              "grid-sm-4": "MuiGrid-grid-sm-4",
+              "grid-sm-5": "MuiGrid-grid-sm-5",
+              "grid-sm-6": "MuiGrid-grid-sm-6",
+              "grid-sm-7": "MuiGrid-grid-sm-7",
+              "grid-sm-8": "MuiGrid-grid-sm-8",
+              "grid-sm-9": "MuiGrid-grid-sm-9",
+              "grid-sm-auto": "MuiGrid-grid-sm-auto",
+              "grid-sm-true": "MuiGrid-grid-sm-true",
+              "grid-xl-1": "MuiGrid-grid-xl-1",
+              "grid-xl-10": "MuiGrid-grid-xl-10",
+              "grid-xl-11": "MuiGrid-grid-xl-11",
+              "grid-xl-12": "MuiGrid-grid-xl-12",
+              "grid-xl-2": "MuiGrid-grid-xl-2",
+              "grid-xl-3": "MuiGrid-grid-xl-3",
+              "grid-xl-4": "MuiGrid-grid-xl-4",
+              "grid-xl-5": "MuiGrid-grid-xl-5",
+              "grid-xl-6": "MuiGrid-grid-xl-6",
+              "grid-xl-7": "MuiGrid-grid-xl-7",
+              "grid-xl-8": "MuiGrid-grid-xl-8",
+              "grid-xl-9": "MuiGrid-grid-xl-9",
+              "grid-xl-auto": "MuiGrid-grid-xl-auto",
+              "grid-xl-true": "MuiGrid-grid-xl-true",
+              "grid-xs-1": "MuiGrid-grid-xs-1",
+              "grid-xs-10": "MuiGrid-grid-xs-10",
+              "grid-xs-11": "MuiGrid-grid-xs-11",
+              "grid-xs-12": "MuiGrid-grid-xs-12",
+              "grid-xs-2": "MuiGrid-grid-xs-2",
+              "grid-xs-3": "MuiGrid-grid-xs-3",
+              "grid-xs-4": "MuiGrid-grid-xs-4",
+              "grid-xs-5": "MuiGrid-grid-xs-5",
+              "grid-xs-6": "MuiGrid-grid-xs-6",
+              "grid-xs-7": "MuiGrid-grid-xs-7",
+              "grid-xs-8": "MuiGrid-grid-xs-8",
+              "grid-xs-9": "MuiGrid-grid-xs-9",
+              "grid-xs-auto": "MuiGrid-grid-xs-auto",
+              "grid-xs-true": "MuiGrid-grid-xs-true",
+              "item": "MuiGrid-item",
+              "justify-xs-center": "MuiGrid-justify-xs-center",
+              "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
+              "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
+              "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
+              "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
+              "root": "MuiGrid-root",
+              "spacing-xs-1": "MuiGrid-spacing-xs-1",
+              "spacing-xs-10": "MuiGrid-spacing-xs-10",
+              "spacing-xs-2": "MuiGrid-spacing-xs-2",
+              "spacing-xs-3": "MuiGrid-spacing-xs-3",
+              "spacing-xs-4": "MuiGrid-spacing-xs-4",
+              "spacing-xs-5": "MuiGrid-spacing-xs-5",
+              "spacing-xs-6": "MuiGrid-spacing-xs-6",
+              "spacing-xs-7": "MuiGrid-spacing-xs-7",
+              "spacing-xs-8": "MuiGrid-spacing-xs-8",
+              "spacing-xs-9": "MuiGrid-spacing-xs-9",
+              "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
+              "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
+              "zeroMinWidth": "MuiGrid-zeroMinWidth",
+            }
+          }
+          container={true}
+          direction="row"
+          justify="center"
+          spacing={1}
+          style={
+            Object {
+              "minWidth": "150px",
             }
           }
         >
-          <button
-            className="ui yellow vertical animated button"
-            onClick={[Function]}
-            onMouseDown={[Function]}
+          <div
+            className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"
             style={
               Object {
-                "verticalAlign": "bottom",
+                "minWidth": "150px",
               }
             }
           >
-            <ButtonContent
-              hidden={true}
+            <WithStyles(ForwardRef(Grid))
+              item={true}
             >
-              <div
-                className="hidden content"
-              >
-                <FormattedMessage
-                  defaultMessage="Step"
-                  id="app.control.step"
-                  values={Object {}}
-                >
-                  Step
-                </FormattedMessage>
-              </div>
-            </ButtonContent>
-            <ButtonContent
-              visible={true}
-            >
-              <div
-                className="visible content"
-              >
-                <Icon
-                  as="i"
-                  name="step forward"
-                >
-                  <i
-                    aria-hidden="true"
-                    className="step forward icon"
-                    onClick={[Function]}
-                  />
-                </Icon>
-              </div>
-            </ButtonContent>
-          </button>
-        </RefFindNode>
-      </Ref>
-    </Button>
-    <Button
-      animated="vertical"
-      as="button"
-      color="blue"
-      disabled={false}
-      onClick={[Function]}
-      onMouseDown={[Function]}
-      style={
-        Object {
-          "verticalAlign": "bottom",
-        }
-      }
-    >
-      <Ref
-        innerRef={
-          Object {
-            "current": <button
-              class="ui blue vertical animated button"
-              style="vertical-align: bottom;"
-            >
-              <div
-                class="hidden content"
-              >
-                Reset
-              </div>
-              <div
-                class="visible content"
-              >
-                <i
-                  aria-hidden="true"
-                  class="repeat icon"
-                />
-              </div>
-            </button>,
-          }
-        }
-      >
-        <RefFindNode
-          innerRef={
-            Object {
-              "current": <button
-                class="ui blue vertical animated button"
-                style="vertical-align: bottom;"
+              <ForwardRef(Grid)
+                classes={
+                  Object {
+                    "align-content-xs-center": "MuiGrid-align-content-xs-center",
+                    "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
+                    "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
+                    "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
+                    "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
+                    "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
+                    "align-items-xs-center": "MuiGrid-align-items-xs-center",
+                    "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
+                    "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
+                    "container": "MuiGrid-container",
+                    "direction-xs-column": "MuiGrid-direction-xs-column",
+                    "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
+                    "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
+                    "grid-lg-1": "MuiGrid-grid-lg-1",
+                    "grid-lg-10": "MuiGrid-grid-lg-10",
+                    "grid-lg-11": "MuiGrid-grid-lg-11",
+                    "grid-lg-12": "MuiGrid-grid-lg-12",
+                    "grid-lg-2": "MuiGrid-grid-lg-2",
+                    "grid-lg-3": "MuiGrid-grid-lg-3",
+                    "grid-lg-4": "MuiGrid-grid-lg-4",
+                    "grid-lg-5": "MuiGrid-grid-lg-5",
+                    "grid-lg-6": "MuiGrid-grid-lg-6",
+                    "grid-lg-7": "MuiGrid-grid-lg-7",
+                    "grid-lg-8": "MuiGrid-grid-lg-8",
+                    "grid-lg-9": "MuiGrid-grid-lg-9",
+                    "grid-lg-auto": "MuiGrid-grid-lg-auto",
+                    "grid-lg-true": "MuiGrid-grid-lg-true",
+                    "grid-md-1": "MuiGrid-grid-md-1",
+                    "grid-md-10": "MuiGrid-grid-md-10",
+                    "grid-md-11": "MuiGrid-grid-md-11",
+                    "grid-md-12": "MuiGrid-grid-md-12",
+                    "grid-md-2": "MuiGrid-grid-md-2",
+                    "grid-md-3": "MuiGrid-grid-md-3",
+                    "grid-md-4": "MuiGrid-grid-md-4",
+                    "grid-md-5": "MuiGrid-grid-md-5",
+                    "grid-md-6": "MuiGrid-grid-md-6",
+                    "grid-md-7": "MuiGrid-grid-md-7",
+                    "grid-md-8": "MuiGrid-grid-md-8",
+                    "grid-md-9": "MuiGrid-grid-md-9",
+                    "grid-md-auto": "MuiGrid-grid-md-auto",
+                    "grid-md-true": "MuiGrid-grid-md-true",
+                    "grid-sm-1": "MuiGrid-grid-sm-1",
+                    "grid-sm-10": "MuiGrid-grid-sm-10",
+                    "grid-sm-11": "MuiGrid-grid-sm-11",
+                    "grid-sm-12": "MuiGrid-grid-sm-12",
+                    "grid-sm-2": "MuiGrid-grid-sm-2",
+                    "grid-sm-3": "MuiGrid-grid-sm-3",
+                    "grid-sm-4": "MuiGrid-grid-sm-4",
+                    "grid-sm-5": "MuiGrid-grid-sm-5",
+                    "grid-sm-6": "MuiGrid-grid-sm-6",
+                    "grid-sm-7": "MuiGrid-grid-sm-7",
+                    "grid-sm-8": "MuiGrid-grid-sm-8",
+                    "grid-sm-9": "MuiGrid-grid-sm-9",
+                    "grid-sm-auto": "MuiGrid-grid-sm-auto",
+                    "grid-sm-true": "MuiGrid-grid-sm-true",
+                    "grid-xl-1": "MuiGrid-grid-xl-1",
+                    "grid-xl-10": "MuiGrid-grid-xl-10",
+                    "grid-xl-11": "MuiGrid-grid-xl-11",
+                    "grid-xl-12": "MuiGrid-grid-xl-12",
+                    "grid-xl-2": "MuiGrid-grid-xl-2",
+                    "grid-xl-3": "MuiGrid-grid-xl-3",
+                    "grid-xl-4": "MuiGrid-grid-xl-4",
+                    "grid-xl-5": "MuiGrid-grid-xl-5",
+                    "grid-xl-6": "MuiGrid-grid-xl-6",
+                    "grid-xl-7": "MuiGrid-grid-xl-7",
+                    "grid-xl-8": "MuiGrid-grid-xl-8",
+                    "grid-xl-9": "MuiGrid-grid-xl-9",
+                    "grid-xl-auto": "MuiGrid-grid-xl-auto",
+                    "grid-xl-true": "MuiGrid-grid-xl-true",
+                    "grid-xs-1": "MuiGrid-grid-xs-1",
+                    "grid-xs-10": "MuiGrid-grid-xs-10",
+                    "grid-xs-11": "MuiGrid-grid-xs-11",
+                    "grid-xs-12": "MuiGrid-grid-xs-12",
+                    "grid-xs-2": "MuiGrid-grid-xs-2",
+                    "grid-xs-3": "MuiGrid-grid-xs-3",
+                    "grid-xs-4": "MuiGrid-grid-xs-4",
+                    "grid-xs-5": "MuiGrid-grid-xs-5",
+                    "grid-xs-6": "MuiGrid-grid-xs-6",
+                    "grid-xs-7": "MuiGrid-grid-xs-7",
+                    "grid-xs-8": "MuiGrid-grid-xs-8",
+                    "grid-xs-9": "MuiGrid-grid-xs-9",
+                    "grid-xs-auto": "MuiGrid-grid-xs-auto",
+                    "grid-xs-true": "MuiGrid-grid-xs-true",
+                    "item": "MuiGrid-item",
+                    "justify-xs-center": "MuiGrid-justify-xs-center",
+                    "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
+                    "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
+                    "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
+                    "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
+                    "root": "MuiGrid-root",
+                    "spacing-xs-1": "MuiGrid-spacing-xs-1",
+                    "spacing-xs-10": "MuiGrid-spacing-xs-10",
+                    "spacing-xs-2": "MuiGrid-spacing-xs-2",
+                    "spacing-xs-3": "MuiGrid-spacing-xs-3",
+                    "spacing-xs-4": "MuiGrid-spacing-xs-4",
+                    "spacing-xs-5": "MuiGrid-spacing-xs-5",
+                    "spacing-xs-6": "MuiGrid-spacing-xs-6",
+                    "spacing-xs-7": "MuiGrid-spacing-xs-7",
+                    "spacing-xs-8": "MuiGrid-spacing-xs-8",
+                    "spacing-xs-9": "MuiGrid-spacing-xs-9",
+                    "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
+                    "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
+                    "zeroMinWidth": "MuiGrid-zeroMinWidth",
+                  }
+                }
+                item={true}
               >
                 <div
-                  class="hidden content"
+                  className="MuiGrid-root MuiGrid-item"
                 >
-                  Reset
+                  <WithStyles(ForwardRef(Tooltip))
+                    title="Reset"
+                  >
+                    <ForwardRef(Tooltip)
+                      classes={
+                        Object {
+                          "arrow": "MuiTooltip-arrow",
+                          "popper": "MuiTooltip-popper",
+                          "popperArrow": "MuiTooltip-popperArrow",
+                          "popperInteractive": "MuiTooltip-popperInteractive",
+                          "tooltip": "MuiTooltip-tooltip",
+                          "tooltipArrow": "MuiTooltip-tooltipArrow",
+                          "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom",
+                          "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft",
+                          "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight",
+                          "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop",
+                          "touch": "MuiTooltip-touch",
+                        }
+                      }
+                      title="Reset"
+                    >
+                      <WithStyles(WithStyles(ForwardRef(Button)))
+                        aria-describedby={null}
+                        className=""
+                        disabled={false}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "verticalAlign": "bottom",
+                          }
+                        }
+                        title="Reset"
+                        variant="contained"
+                      >
+                        <WithStyles(ForwardRef(Button))
+                          aria-describedby={null}
+                          className=""
+                          classes={
+                            Object {
+                              "root": "WithStyles(ForwardRef(Button))-root-115",
+                            }
+                          }
+                          disabled={false}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchStart={[Function]}
+                          style={
+                            Object {
+                              "verticalAlign": "bottom",
+                            }
+                          }
+                          title="Reset"
+                          variant="contained"
+                        >
+                          <ForwardRef(Button)
+                            aria-describedby={null}
+                            className=""
+                            classes={
+                              Object {
+                                "colorInherit": "MuiButton-colorInherit",
+                                "contained": "MuiButton-contained",
+                                "containedPrimary": "MuiButton-containedPrimary",
+                                "containedSecondary": "MuiButton-containedSecondary",
+                                "containedSizeLarge": "MuiButton-containedSizeLarge",
+                                "containedSizeSmall": "MuiButton-containedSizeSmall",
+                                "disableElevation": "MuiButton-disableElevation",
+                                "disabled": "Mui-disabled",
+                                "endIcon": "MuiButton-endIcon",
+                                "focusVisible": "Mui-focusVisible",
+                                "fullWidth": "MuiButton-fullWidth",
+                                "iconSizeLarge": "MuiButton-iconSizeLarge",
+                                "iconSizeMedium": "MuiButton-iconSizeMedium",
+                                "iconSizeSmall": "MuiButton-iconSizeSmall",
+                                "label": "MuiButton-label",
+                                "outlined": "MuiButton-outlined",
+                                "outlinedPrimary": "MuiButton-outlinedPrimary",
+                                "outlinedSecondary": "MuiButton-outlinedSecondary",
+                                "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                                "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                                "root": "MuiButton-root WithStyles(ForwardRef(Button))-root-115",
+                                "sizeLarge": "MuiButton-sizeLarge",
+                                "sizeSmall": "MuiButton-sizeSmall",
+                                "startIcon": "MuiButton-startIcon",
+                                "text": "MuiButton-text",
+                                "textPrimary": "MuiButton-textPrimary",
+                                "textSecondary": "MuiButton-textSecondary",
+                                "textSizeLarge": "MuiButton-textSizeLarge",
+                                "textSizeSmall": "MuiButton-textSizeSmall",
+                              }
+                            }
+                            disabled={false}
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseOver={[Function]}
+                            onTouchEnd={[Function]}
+                            onTouchStart={[Function]}
+                            style={
+                              Object {
+                                "verticalAlign": "bottom",
+                              }
+                            }
+                            title="Reset"
+                            variant="contained"
+                          >
+                            <WithStyles(ForwardRef(ButtonBase))
+                              aria-describedby={null}
+                              className="MuiButton-root WithStyles(ForwardRef(Button))-root-115 MuiButton-contained"
+                              component="button"
+                              disabled={false}
+                              focusRipple={true}
+                              focusVisibleClassName="Mui-focusVisible"
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onMouseLeave={[Function]}
+                              onMouseOver={[Function]}
+                              onTouchEnd={[Function]}
+                              onTouchStart={[Function]}
+                              style={
+                                Object {
+                                  "verticalAlign": "bottom",
+                                }
+                              }
+                              title="Reset"
+                              type="button"
+                            >
+                              <ForwardRef(ButtonBase)
+                                aria-describedby={null}
+                                className="MuiButton-root WithStyles(ForwardRef(Button))-root-115 MuiButton-contained"
+                                classes={
+                                  Object {
+                                    "disabled": "Mui-disabled",
+                                    "focusVisible": "Mui-focusVisible",
+                                    "root": "MuiButtonBase-root",
+                                  }
+                                }
+                                component="button"
+                                disabled={false}
+                                focusRipple={true}
+                                focusVisibleClassName="Mui-focusVisible"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseLeave={[Function]}
+                                onMouseOver={[Function]}
+                                onTouchEnd={[Function]}
+                                onTouchStart={[Function]}
+                                style={
+                                  Object {
+                                    "verticalAlign": "bottom",
+                                  }
+                                }
+                                title="Reset"
+                                type="button"
+                              >
+                                <button
+                                  aria-describedby={null}
+                                  className="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-115 MuiButton-contained"
+                                  disabled={false}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onDragLeave={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onKeyUp={[Function]}
+                                  onMouseDown={[Function]}
+                                  onMouseLeave={[Function]}
+                                  onMouseOver={[Function]}
+                                  onMouseUp={[Function]}
+                                  onTouchEnd={[Function]}
+                                  onTouchMove={[Function]}
+                                  onTouchStart={[Function]}
+                                  style={
+                                    Object {
+                                      "verticalAlign": "bottom",
+                                    }
+                                  }
+                                  tabIndex={0}
+                                  title="Reset"
+                                  type="button"
+                                >
+                                  <span
+                                    className="MuiButton-label"
+                                  >
+                                    <ForwardRef>
+                                      <WithStyles(ForwardRef(SvgIcon))>
+                                        <ForwardRef(SvgIcon)
+                                          classes={
+                                            Object {
+                                              "colorAction": "MuiSvgIcon-colorAction",
+                                              "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                              "colorError": "MuiSvgIcon-colorError",
+                                              "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                              "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                              "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                              "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                              "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                              "root": "MuiSvgIcon-root",
+                                            }
+                                          }
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            className="MuiSvgIcon-root"
+                                            focusable="false"
+                                            viewBox="0 0 24 24"
+                                          >
+                                            <path
+                                              d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"
+                                            />
+                                          </svg>
+                                        </ForwardRef(SvgIcon)>
+                                      </WithStyles(ForwardRef(SvgIcon))>
+                                    </ForwardRef>
+                                  </span>
+                                  <WithStyles(memo)
+                                    center={false}
+                                  >
+                                    <ForwardRef(TouchRipple)
+                                      center={false}
+                                      classes={
+                                        Object {
+                                          "child": "MuiTouchRipple-child",
+                                          "childLeaving": "MuiTouchRipple-childLeaving",
+                                          "childPulsate": "MuiTouchRipple-childPulsate",
+                                          "ripple": "MuiTouchRipple-ripple",
+                                          "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                          "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                          "root": "MuiTouchRipple-root",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="MuiTouchRipple-root"
+                                      >
+                                        <TransitionGroup
+                                          childFactory={[Function]}
+                                          component={null}
+                                          exit={true}
+                                        />
+                                      </span>
+                                    </ForwardRef(TouchRipple)>
+                                  </WithStyles(memo)>
+                                </button>
+                              </ForwardRef(ButtonBase)>
+                            </WithStyles(ForwardRef(ButtonBase))>
+                          </ForwardRef(Button)>
+                        </WithStyles(ForwardRef(Button))>
+                      </WithStyles(WithStyles(ForwardRef(Button)))>
+                      <ForwardRef(Popper)
+                        anchorEl={
+                          <button
+                            class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-115 MuiButton-contained"
+                            style="vertical-align: bottom;"
+                            tabindex="0"
+                            title="Reset"
+                            type="button"
+                          >
+                            <span
+                              class="MuiButton-label"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiTouchRipple-root"
+                            />
+                          </button>
+                        }
+                        className="MuiTooltip-popper"
+                        id={null}
+                        open={false}
+                        placement="bottom"
+                        popperOptions={
+                          Object {
+                            "modifiers": Object {
+                              "arrow": Object {
+                                "element": null,
+                                "enabled": false,
+                              },
+                            },
+                          }
+                        }
+                        transition={true}
+                      />
+                    </ForwardRef(Tooltip)>
+                  </WithStyles(ForwardRef(Tooltip))>
                 </div>
+              </ForwardRef(Grid)>
+            </WithStyles(ForwardRef(Grid))>
+            <WithStyles(ForwardRef(Grid))
+              item={true}
+            >
+              <ForwardRef(Grid)
+                classes={
+                  Object {
+                    "align-content-xs-center": "MuiGrid-align-content-xs-center",
+                    "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
+                    "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
+                    "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
+                    "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
+                    "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
+                    "align-items-xs-center": "MuiGrid-align-items-xs-center",
+                    "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
+                    "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
+                    "container": "MuiGrid-container",
+                    "direction-xs-column": "MuiGrid-direction-xs-column",
+                    "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
+                    "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
+                    "grid-lg-1": "MuiGrid-grid-lg-1",
+                    "grid-lg-10": "MuiGrid-grid-lg-10",
+                    "grid-lg-11": "MuiGrid-grid-lg-11",
+                    "grid-lg-12": "MuiGrid-grid-lg-12",
+                    "grid-lg-2": "MuiGrid-grid-lg-2",
+                    "grid-lg-3": "MuiGrid-grid-lg-3",
+                    "grid-lg-4": "MuiGrid-grid-lg-4",
+                    "grid-lg-5": "MuiGrid-grid-lg-5",
+                    "grid-lg-6": "MuiGrid-grid-lg-6",
+                    "grid-lg-7": "MuiGrid-grid-lg-7",
+                    "grid-lg-8": "MuiGrid-grid-lg-8",
+                    "grid-lg-9": "MuiGrid-grid-lg-9",
+                    "grid-lg-auto": "MuiGrid-grid-lg-auto",
+                    "grid-lg-true": "MuiGrid-grid-lg-true",
+                    "grid-md-1": "MuiGrid-grid-md-1",
+                    "grid-md-10": "MuiGrid-grid-md-10",
+                    "grid-md-11": "MuiGrid-grid-md-11",
+                    "grid-md-12": "MuiGrid-grid-md-12",
+                    "grid-md-2": "MuiGrid-grid-md-2",
+                    "grid-md-3": "MuiGrid-grid-md-3",
+                    "grid-md-4": "MuiGrid-grid-md-4",
+                    "grid-md-5": "MuiGrid-grid-md-5",
+                    "grid-md-6": "MuiGrid-grid-md-6",
+                    "grid-md-7": "MuiGrid-grid-md-7",
+                    "grid-md-8": "MuiGrid-grid-md-8",
+                    "grid-md-9": "MuiGrid-grid-md-9",
+                    "grid-md-auto": "MuiGrid-grid-md-auto",
+                    "grid-md-true": "MuiGrid-grid-md-true",
+                    "grid-sm-1": "MuiGrid-grid-sm-1",
+                    "grid-sm-10": "MuiGrid-grid-sm-10",
+                    "grid-sm-11": "MuiGrid-grid-sm-11",
+                    "grid-sm-12": "MuiGrid-grid-sm-12",
+                    "grid-sm-2": "MuiGrid-grid-sm-2",
+                    "grid-sm-3": "MuiGrid-grid-sm-3",
+                    "grid-sm-4": "MuiGrid-grid-sm-4",
+                    "grid-sm-5": "MuiGrid-grid-sm-5",
+                    "grid-sm-6": "MuiGrid-grid-sm-6",
+                    "grid-sm-7": "MuiGrid-grid-sm-7",
+                    "grid-sm-8": "MuiGrid-grid-sm-8",
+                    "grid-sm-9": "MuiGrid-grid-sm-9",
+                    "grid-sm-auto": "MuiGrid-grid-sm-auto",
+                    "grid-sm-true": "MuiGrid-grid-sm-true",
+                    "grid-xl-1": "MuiGrid-grid-xl-1",
+                    "grid-xl-10": "MuiGrid-grid-xl-10",
+                    "grid-xl-11": "MuiGrid-grid-xl-11",
+                    "grid-xl-12": "MuiGrid-grid-xl-12",
+                    "grid-xl-2": "MuiGrid-grid-xl-2",
+                    "grid-xl-3": "MuiGrid-grid-xl-3",
+                    "grid-xl-4": "MuiGrid-grid-xl-4",
+                    "grid-xl-5": "MuiGrid-grid-xl-5",
+                    "grid-xl-6": "MuiGrid-grid-xl-6",
+                    "grid-xl-7": "MuiGrid-grid-xl-7",
+                    "grid-xl-8": "MuiGrid-grid-xl-8",
+                    "grid-xl-9": "MuiGrid-grid-xl-9",
+                    "grid-xl-auto": "MuiGrid-grid-xl-auto",
+                    "grid-xl-true": "MuiGrid-grid-xl-true",
+                    "grid-xs-1": "MuiGrid-grid-xs-1",
+                    "grid-xs-10": "MuiGrid-grid-xs-10",
+                    "grid-xs-11": "MuiGrid-grid-xs-11",
+                    "grid-xs-12": "MuiGrid-grid-xs-12",
+                    "grid-xs-2": "MuiGrid-grid-xs-2",
+                    "grid-xs-3": "MuiGrid-grid-xs-3",
+                    "grid-xs-4": "MuiGrid-grid-xs-4",
+                    "grid-xs-5": "MuiGrid-grid-xs-5",
+                    "grid-xs-6": "MuiGrid-grid-xs-6",
+                    "grid-xs-7": "MuiGrid-grid-xs-7",
+                    "grid-xs-8": "MuiGrid-grid-xs-8",
+                    "grid-xs-9": "MuiGrid-grid-xs-9",
+                    "grid-xs-auto": "MuiGrid-grid-xs-auto",
+                    "grid-xs-true": "MuiGrid-grid-xs-true",
+                    "item": "MuiGrid-item",
+                    "justify-xs-center": "MuiGrid-justify-xs-center",
+                    "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
+                    "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
+                    "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
+                    "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
+                    "root": "MuiGrid-root",
+                    "spacing-xs-1": "MuiGrid-spacing-xs-1",
+                    "spacing-xs-10": "MuiGrid-spacing-xs-10",
+                    "spacing-xs-2": "MuiGrid-spacing-xs-2",
+                    "spacing-xs-3": "MuiGrid-spacing-xs-3",
+                    "spacing-xs-4": "MuiGrid-spacing-xs-4",
+                    "spacing-xs-5": "MuiGrid-spacing-xs-5",
+                    "spacing-xs-6": "MuiGrid-spacing-xs-6",
+                    "spacing-xs-7": "MuiGrid-spacing-xs-7",
+                    "spacing-xs-8": "MuiGrid-spacing-xs-8",
+                    "spacing-xs-9": "MuiGrid-spacing-xs-9",
+                    "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
+                    "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
+                    "zeroMinWidth": "MuiGrid-zeroMinWidth",
+                  }
+                }
+                item={true}
+              >
                 <div
-                  class="visible content"
+                  className="MuiGrid-root MuiGrid-item"
                 >
-                  <i
-                    aria-hidden="true"
-                    class="repeat icon"
-                  />
+                  <WithStyles(ForwardRef(Tooltip))
+                    title="Run"
+                  >
+                    <ForwardRef(Tooltip)
+                      classes={
+                        Object {
+                          "arrow": "MuiTooltip-arrow",
+                          "popper": "MuiTooltip-popper",
+                          "popperArrow": "MuiTooltip-popperArrow",
+                          "popperInteractive": "MuiTooltip-popperInteractive",
+                          "tooltip": "MuiTooltip-tooltip",
+                          "tooltipArrow": "MuiTooltip-tooltipArrow",
+                          "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom",
+                          "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft",
+                          "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight",
+                          "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop",
+                          "touch": "MuiTooltip-touch",
+                        }
+                      }
+                      title="Run"
+                    >
+                      <WithStyles(WithStyles(ForwardRef(Button)))
+                        aria-describedby={null}
+                        className=""
+                        disabled={false}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        title="Run"
+                        variant="contained"
+                      >
+                        <WithStyles(ForwardRef(Button))
+                          aria-describedby={null}
+                          className=""
+                          classes={
+                            Object {
+                              "root": "WithStyles(ForwardRef(Button))-root-157",
+                            }
+                          }
+                          disabled={false}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchStart={[Function]}
+                          title="Run"
+                          variant="contained"
+                        >
+                          <ForwardRef(Button)
+                            aria-describedby={null}
+                            className=""
+                            classes={
+                              Object {
+                                "colorInherit": "MuiButton-colorInherit",
+                                "contained": "MuiButton-contained",
+                                "containedPrimary": "MuiButton-containedPrimary",
+                                "containedSecondary": "MuiButton-containedSecondary",
+                                "containedSizeLarge": "MuiButton-containedSizeLarge",
+                                "containedSizeSmall": "MuiButton-containedSizeSmall",
+                                "disableElevation": "MuiButton-disableElevation",
+                                "disabled": "Mui-disabled",
+                                "endIcon": "MuiButton-endIcon",
+                                "focusVisible": "Mui-focusVisible",
+                                "fullWidth": "MuiButton-fullWidth",
+                                "iconSizeLarge": "MuiButton-iconSizeLarge",
+                                "iconSizeMedium": "MuiButton-iconSizeMedium",
+                                "iconSizeSmall": "MuiButton-iconSizeSmall",
+                                "label": "MuiButton-label",
+                                "outlined": "MuiButton-outlined",
+                                "outlinedPrimary": "MuiButton-outlinedPrimary",
+                                "outlinedSecondary": "MuiButton-outlinedSecondary",
+                                "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                                "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                                "root": "MuiButton-root WithStyles(ForwardRef(Button))-root-157",
+                                "sizeLarge": "MuiButton-sizeLarge",
+                                "sizeSmall": "MuiButton-sizeSmall",
+                                "startIcon": "MuiButton-startIcon",
+                                "text": "MuiButton-text",
+                                "textPrimary": "MuiButton-textPrimary",
+                                "textSecondary": "MuiButton-textSecondary",
+                                "textSizeLarge": "MuiButton-textSizeLarge",
+                                "textSizeSmall": "MuiButton-textSizeSmall",
+                              }
+                            }
+                            disabled={false}
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseOver={[Function]}
+                            onTouchEnd={[Function]}
+                            onTouchStart={[Function]}
+                            title="Run"
+                            variant="contained"
+                          >
+                            <WithStyles(ForwardRef(ButtonBase))
+                              aria-describedby={null}
+                              className="MuiButton-root WithStyles(ForwardRef(Button))-root-157 MuiButton-contained"
+                              component="button"
+                              disabled={false}
+                              focusRipple={true}
+                              focusVisibleClassName="Mui-focusVisible"
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onMouseLeave={[Function]}
+                              onMouseOver={[Function]}
+                              onTouchEnd={[Function]}
+                              onTouchStart={[Function]}
+                              title="Run"
+                              type="button"
+                            >
+                              <ForwardRef(ButtonBase)
+                                aria-describedby={null}
+                                className="MuiButton-root WithStyles(ForwardRef(Button))-root-157 MuiButton-contained"
+                                classes={
+                                  Object {
+                                    "disabled": "Mui-disabled",
+                                    "focusVisible": "Mui-focusVisible",
+                                    "root": "MuiButtonBase-root",
+                                  }
+                                }
+                                component="button"
+                                disabled={false}
+                                focusRipple={true}
+                                focusVisibleClassName="Mui-focusVisible"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseLeave={[Function]}
+                                onMouseOver={[Function]}
+                                onTouchEnd={[Function]}
+                                onTouchStart={[Function]}
+                                title="Run"
+                                type="button"
+                              >
+                                <button
+                                  aria-describedby={null}
+                                  className="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-157 MuiButton-contained"
+                                  disabled={false}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onDragLeave={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onKeyUp={[Function]}
+                                  onMouseDown={[Function]}
+                                  onMouseLeave={[Function]}
+                                  onMouseOver={[Function]}
+                                  onMouseUp={[Function]}
+                                  onTouchEnd={[Function]}
+                                  onTouchMove={[Function]}
+                                  onTouchStart={[Function]}
+                                  tabIndex={0}
+                                  title="Run"
+                                  type="button"
+                                >
+                                  <span
+                                    className="MuiButton-label"
+                                  >
+                                    <ForwardRef>
+                                      <WithStyles(ForwardRef(SvgIcon))>
+                                        <ForwardRef(SvgIcon)
+                                          classes={
+                                            Object {
+                                              "colorAction": "MuiSvgIcon-colorAction",
+                                              "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                              "colorError": "MuiSvgIcon-colorError",
+                                              "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                              "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                              "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                              "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                              "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                              "root": "MuiSvgIcon-root",
+                                            }
+                                          }
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            className="MuiSvgIcon-root"
+                                            focusable="false"
+                                            viewBox="0 0 24 24"
+                                          >
+                                            <path
+                                              d="M8 5v14l11-7z"
+                                            />
+                                          </svg>
+                                        </ForwardRef(SvgIcon)>
+                                      </WithStyles(ForwardRef(SvgIcon))>
+                                    </ForwardRef>
+                                  </span>
+                                  <WithStyles(memo)
+                                    center={false}
+                                  >
+                                    <ForwardRef(TouchRipple)
+                                      center={false}
+                                      classes={
+                                        Object {
+                                          "child": "MuiTouchRipple-child",
+                                          "childLeaving": "MuiTouchRipple-childLeaving",
+                                          "childPulsate": "MuiTouchRipple-childPulsate",
+                                          "ripple": "MuiTouchRipple-ripple",
+                                          "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                          "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                          "root": "MuiTouchRipple-root",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="MuiTouchRipple-root"
+                                      >
+                                        <TransitionGroup
+                                          childFactory={[Function]}
+                                          component={null}
+                                          exit={true}
+                                        />
+                                      </span>
+                                    </ForwardRef(TouchRipple)>
+                                  </WithStyles(memo)>
+                                </button>
+                              </ForwardRef(ButtonBase)>
+                            </WithStyles(ForwardRef(ButtonBase))>
+                          </ForwardRef(Button)>
+                        </WithStyles(ForwardRef(Button))>
+                      </WithStyles(WithStyles(ForwardRef(Button)))>
+                      <ForwardRef(Popper)
+                        anchorEl={
+                          <button
+                            class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-157 MuiButton-contained"
+                            tabindex="0"
+                            title="Run"
+                            type="button"
+                          >
+                            <span
+                              class="MuiButton-label"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M8 5v14l11-7z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiTouchRipple-root"
+                            />
+                          </button>
+                        }
+                        className="MuiTooltip-popper"
+                        id={null}
+                        open={false}
+                        placement="bottom"
+                        popperOptions={
+                          Object {
+                            "modifiers": Object {
+                              "arrow": Object {
+                                "element": null,
+                                "enabled": false,
+                              },
+                            },
+                          }
+                        }
+                        transition={true}
+                      />
+                    </ForwardRef(Tooltip)>
+                  </WithStyles(ForwardRef(Tooltip))>
                 </div>
-              </button>,
-            }
-          }
-        >
-          <button
-            className="ui blue vertical animated button"
-            onClick={[Function]}
-            onMouseDown={[Function]}
-            style={
-              Object {
-                "verticalAlign": "bottom",
-              }
-            }
-          >
-            <ButtonContent
-              hidden={true}
+              </ForwardRef(Grid)>
+            </WithStyles(ForwardRef(Grid))>
+            <WithStyles(ForwardRef(Grid))
+              item={true}
             >
-              <div
-                className="hidden content"
+              <ForwardRef(Grid)
+                classes={
+                  Object {
+                    "align-content-xs-center": "MuiGrid-align-content-xs-center",
+                    "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
+                    "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
+                    "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
+                    "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
+                    "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
+                    "align-items-xs-center": "MuiGrid-align-items-xs-center",
+                    "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
+                    "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
+                    "container": "MuiGrid-container",
+                    "direction-xs-column": "MuiGrid-direction-xs-column",
+                    "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
+                    "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
+                    "grid-lg-1": "MuiGrid-grid-lg-1",
+                    "grid-lg-10": "MuiGrid-grid-lg-10",
+                    "grid-lg-11": "MuiGrid-grid-lg-11",
+                    "grid-lg-12": "MuiGrid-grid-lg-12",
+                    "grid-lg-2": "MuiGrid-grid-lg-2",
+                    "grid-lg-3": "MuiGrid-grid-lg-3",
+                    "grid-lg-4": "MuiGrid-grid-lg-4",
+                    "grid-lg-5": "MuiGrid-grid-lg-5",
+                    "grid-lg-6": "MuiGrid-grid-lg-6",
+                    "grid-lg-7": "MuiGrid-grid-lg-7",
+                    "grid-lg-8": "MuiGrid-grid-lg-8",
+                    "grid-lg-9": "MuiGrid-grid-lg-9",
+                    "grid-lg-auto": "MuiGrid-grid-lg-auto",
+                    "grid-lg-true": "MuiGrid-grid-lg-true",
+                    "grid-md-1": "MuiGrid-grid-md-1",
+                    "grid-md-10": "MuiGrid-grid-md-10",
+                    "grid-md-11": "MuiGrid-grid-md-11",
+                    "grid-md-12": "MuiGrid-grid-md-12",
+                    "grid-md-2": "MuiGrid-grid-md-2",
+                    "grid-md-3": "MuiGrid-grid-md-3",
+                    "grid-md-4": "MuiGrid-grid-md-4",
+                    "grid-md-5": "MuiGrid-grid-md-5",
+                    "grid-md-6": "MuiGrid-grid-md-6",
+                    "grid-md-7": "MuiGrid-grid-md-7",
+                    "grid-md-8": "MuiGrid-grid-md-8",
+                    "grid-md-9": "MuiGrid-grid-md-9",
+                    "grid-md-auto": "MuiGrid-grid-md-auto",
+                    "grid-md-true": "MuiGrid-grid-md-true",
+                    "grid-sm-1": "MuiGrid-grid-sm-1",
+                    "grid-sm-10": "MuiGrid-grid-sm-10",
+                    "grid-sm-11": "MuiGrid-grid-sm-11",
+                    "grid-sm-12": "MuiGrid-grid-sm-12",
+                    "grid-sm-2": "MuiGrid-grid-sm-2",
+                    "grid-sm-3": "MuiGrid-grid-sm-3",
+                    "grid-sm-4": "MuiGrid-grid-sm-4",
+                    "grid-sm-5": "MuiGrid-grid-sm-5",
+                    "grid-sm-6": "MuiGrid-grid-sm-6",
+                    "grid-sm-7": "MuiGrid-grid-sm-7",
+                    "grid-sm-8": "MuiGrid-grid-sm-8",
+                    "grid-sm-9": "MuiGrid-grid-sm-9",
+                    "grid-sm-auto": "MuiGrid-grid-sm-auto",
+                    "grid-sm-true": "MuiGrid-grid-sm-true",
+                    "grid-xl-1": "MuiGrid-grid-xl-1",
+                    "grid-xl-10": "MuiGrid-grid-xl-10",
+                    "grid-xl-11": "MuiGrid-grid-xl-11",
+                    "grid-xl-12": "MuiGrid-grid-xl-12",
+                    "grid-xl-2": "MuiGrid-grid-xl-2",
+                    "grid-xl-3": "MuiGrid-grid-xl-3",
+                    "grid-xl-4": "MuiGrid-grid-xl-4",
+                    "grid-xl-5": "MuiGrid-grid-xl-5",
+                    "grid-xl-6": "MuiGrid-grid-xl-6",
+                    "grid-xl-7": "MuiGrid-grid-xl-7",
+                    "grid-xl-8": "MuiGrid-grid-xl-8",
+                    "grid-xl-9": "MuiGrid-grid-xl-9",
+                    "grid-xl-auto": "MuiGrid-grid-xl-auto",
+                    "grid-xl-true": "MuiGrid-grid-xl-true",
+                    "grid-xs-1": "MuiGrid-grid-xs-1",
+                    "grid-xs-10": "MuiGrid-grid-xs-10",
+                    "grid-xs-11": "MuiGrid-grid-xs-11",
+                    "grid-xs-12": "MuiGrid-grid-xs-12",
+                    "grid-xs-2": "MuiGrid-grid-xs-2",
+                    "grid-xs-3": "MuiGrid-grid-xs-3",
+                    "grid-xs-4": "MuiGrid-grid-xs-4",
+                    "grid-xs-5": "MuiGrid-grid-xs-5",
+                    "grid-xs-6": "MuiGrid-grid-xs-6",
+                    "grid-xs-7": "MuiGrid-grid-xs-7",
+                    "grid-xs-8": "MuiGrid-grid-xs-8",
+                    "grid-xs-9": "MuiGrid-grid-xs-9",
+                    "grid-xs-auto": "MuiGrid-grid-xs-auto",
+                    "grid-xs-true": "MuiGrid-grid-xs-true",
+                    "item": "MuiGrid-item",
+                    "justify-xs-center": "MuiGrid-justify-xs-center",
+                    "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
+                    "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
+                    "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
+                    "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
+                    "root": "MuiGrid-root",
+                    "spacing-xs-1": "MuiGrid-spacing-xs-1",
+                    "spacing-xs-10": "MuiGrid-spacing-xs-10",
+                    "spacing-xs-2": "MuiGrid-spacing-xs-2",
+                    "spacing-xs-3": "MuiGrid-spacing-xs-3",
+                    "spacing-xs-4": "MuiGrid-spacing-xs-4",
+                    "spacing-xs-5": "MuiGrid-spacing-xs-5",
+                    "spacing-xs-6": "MuiGrid-spacing-xs-6",
+                    "spacing-xs-7": "MuiGrid-spacing-xs-7",
+                    "spacing-xs-8": "MuiGrid-spacing-xs-8",
+                    "spacing-xs-9": "MuiGrid-spacing-xs-9",
+                    "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
+                    "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
+                    "zeroMinWidth": "MuiGrid-zeroMinWidth",
+                  }
+                }
+                item={true}
               >
-                <FormattedMessage
-                  defaultMessage="Reset"
-                  id="app.control.reset"
-                  values={Object {}}
+                <div
+                  className="MuiGrid-root MuiGrid-item"
                 >
-                  Reset
-                </FormattedMessage>
-              </div>
-            </ButtonContent>
-            <ButtonContent
-              visible={true}
-            >
-              <div
-                className="visible content"
-              >
-                <Icon
-                  as="i"
-                  name="repeat"
-                >
-                  <i
-                    aria-hidden="true"
-                    className="repeat icon"
-                    onClick={[Function]}
-                  />
-                </Icon>
-              </div>
-            </ButtonContent>
-          </button>
-        </RefFindNode>
-      </Ref>
-    </Button>
-  </Control>
-</Connect(Control)>
+                  <WithStyles(ForwardRef(Tooltip))
+                    title="Step"
+                  >
+                    <ForwardRef(Tooltip)
+                      classes={
+                        Object {
+                          "arrow": "MuiTooltip-arrow",
+                          "popper": "MuiTooltip-popper",
+                          "popperArrow": "MuiTooltip-popperArrow",
+                          "popperInteractive": "MuiTooltip-popperInteractive",
+                          "tooltip": "MuiTooltip-tooltip",
+                          "tooltipArrow": "MuiTooltip-tooltipArrow",
+                          "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom",
+                          "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft",
+                          "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight",
+                          "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop",
+                          "touch": "MuiTooltip-touch",
+                        }
+                      }
+                      title="Step"
+                    >
+                      <WithStyles(WithStyles(ForwardRef(Button)))
+                        aria-describedby={null}
+                        className=""
+                        disabled={false}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "verticalAlign": "bottom",
+                          }
+                        }
+                        title="Step"
+                        variant="contained"
+                      >
+                        <WithStyles(ForwardRef(Button))
+                          aria-describedby={null}
+                          className=""
+                          classes={
+                            Object {
+                              "root": "WithStyles(ForwardRef(Button))-root-158",
+                            }
+                          }
+                          disabled={false}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchStart={[Function]}
+                          style={
+                            Object {
+                              "verticalAlign": "bottom",
+                            }
+                          }
+                          title="Step"
+                          variant="contained"
+                        >
+                          <ForwardRef(Button)
+                            aria-describedby={null}
+                            className=""
+                            classes={
+                              Object {
+                                "colorInherit": "MuiButton-colorInherit",
+                                "contained": "MuiButton-contained",
+                                "containedPrimary": "MuiButton-containedPrimary",
+                                "containedSecondary": "MuiButton-containedSecondary",
+                                "containedSizeLarge": "MuiButton-containedSizeLarge",
+                                "containedSizeSmall": "MuiButton-containedSizeSmall",
+                                "disableElevation": "MuiButton-disableElevation",
+                                "disabled": "Mui-disabled",
+                                "endIcon": "MuiButton-endIcon",
+                                "focusVisible": "Mui-focusVisible",
+                                "fullWidth": "MuiButton-fullWidth",
+                                "iconSizeLarge": "MuiButton-iconSizeLarge",
+                                "iconSizeMedium": "MuiButton-iconSizeMedium",
+                                "iconSizeSmall": "MuiButton-iconSizeSmall",
+                                "label": "MuiButton-label",
+                                "outlined": "MuiButton-outlined",
+                                "outlinedPrimary": "MuiButton-outlinedPrimary",
+                                "outlinedSecondary": "MuiButton-outlinedSecondary",
+                                "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                                "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                                "root": "MuiButton-root WithStyles(ForwardRef(Button))-root-158",
+                                "sizeLarge": "MuiButton-sizeLarge",
+                                "sizeSmall": "MuiButton-sizeSmall",
+                                "startIcon": "MuiButton-startIcon",
+                                "text": "MuiButton-text",
+                                "textPrimary": "MuiButton-textPrimary",
+                                "textSecondary": "MuiButton-textSecondary",
+                                "textSizeLarge": "MuiButton-textSizeLarge",
+                                "textSizeSmall": "MuiButton-textSizeSmall",
+                              }
+                            }
+                            disabled={false}
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseOver={[Function]}
+                            onTouchEnd={[Function]}
+                            onTouchStart={[Function]}
+                            style={
+                              Object {
+                                "verticalAlign": "bottom",
+                              }
+                            }
+                            title="Step"
+                            variant="contained"
+                          >
+                            <WithStyles(ForwardRef(ButtonBase))
+                              aria-describedby={null}
+                              className="MuiButton-root WithStyles(ForwardRef(Button))-root-158 MuiButton-contained"
+                              component="button"
+                              disabled={false}
+                              focusRipple={true}
+                              focusVisibleClassName="Mui-focusVisible"
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onMouseLeave={[Function]}
+                              onMouseOver={[Function]}
+                              onTouchEnd={[Function]}
+                              onTouchStart={[Function]}
+                              style={
+                                Object {
+                                  "verticalAlign": "bottom",
+                                }
+                              }
+                              title="Step"
+                              type="button"
+                            >
+                              <ForwardRef(ButtonBase)
+                                aria-describedby={null}
+                                className="MuiButton-root WithStyles(ForwardRef(Button))-root-158 MuiButton-contained"
+                                classes={
+                                  Object {
+                                    "disabled": "Mui-disabled",
+                                    "focusVisible": "Mui-focusVisible",
+                                    "root": "MuiButtonBase-root",
+                                  }
+                                }
+                                component="button"
+                                disabled={false}
+                                focusRipple={true}
+                                focusVisibleClassName="Mui-focusVisible"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseLeave={[Function]}
+                                onMouseOver={[Function]}
+                                onTouchEnd={[Function]}
+                                onTouchStart={[Function]}
+                                style={
+                                  Object {
+                                    "verticalAlign": "bottom",
+                                  }
+                                }
+                                title="Step"
+                                type="button"
+                              >
+                                <button
+                                  aria-describedby={null}
+                                  className="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-158 MuiButton-contained"
+                                  disabled={false}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onDragLeave={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onKeyUp={[Function]}
+                                  onMouseDown={[Function]}
+                                  onMouseLeave={[Function]}
+                                  onMouseOver={[Function]}
+                                  onMouseUp={[Function]}
+                                  onTouchEnd={[Function]}
+                                  onTouchMove={[Function]}
+                                  onTouchStart={[Function]}
+                                  style={
+                                    Object {
+                                      "verticalAlign": "bottom",
+                                    }
+                                  }
+                                  tabIndex={0}
+                                  title="Step"
+                                  type="button"
+                                >
+                                  <span
+                                    className="MuiButton-label"
+                                  >
+                                    <ForwardRef>
+                                      <WithStyles(ForwardRef(SvgIcon))>
+                                        <ForwardRef(SvgIcon)
+                                          classes={
+                                            Object {
+                                              "colorAction": "MuiSvgIcon-colorAction",
+                                              "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                              "colorError": "MuiSvgIcon-colorError",
+                                              "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                              "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                              "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                              "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                              "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                              "root": "MuiSvgIcon-root",
+                                            }
+                                          }
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            className="MuiSvgIcon-root"
+                                            focusable="false"
+                                            viewBox="0 0 24 24"
+                                          >
+                                            <path
+                                              d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z"
+                                            />
+                                          </svg>
+                                        </ForwardRef(SvgIcon)>
+                                      </WithStyles(ForwardRef(SvgIcon))>
+                                    </ForwardRef>
+                                  </span>
+                                  <WithStyles(memo)
+                                    center={false}
+                                  >
+                                    <ForwardRef(TouchRipple)
+                                      center={false}
+                                      classes={
+                                        Object {
+                                          "child": "MuiTouchRipple-child",
+                                          "childLeaving": "MuiTouchRipple-childLeaving",
+                                          "childPulsate": "MuiTouchRipple-childPulsate",
+                                          "ripple": "MuiTouchRipple-ripple",
+                                          "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                          "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                          "root": "MuiTouchRipple-root",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="MuiTouchRipple-root"
+                                      >
+                                        <TransitionGroup
+                                          childFactory={[Function]}
+                                          component={null}
+                                          exit={true}
+                                        />
+                                      </span>
+                                    </ForwardRef(TouchRipple)>
+                                  </WithStyles(memo)>
+                                </button>
+                              </ForwardRef(ButtonBase)>
+                            </WithStyles(ForwardRef(ButtonBase))>
+                          </ForwardRef(Button)>
+                        </WithStyles(ForwardRef(Button))>
+                      </WithStyles(WithStyles(ForwardRef(Button)))>
+                      <ForwardRef(Popper)
+                        anchorEl={
+                          <button
+                            class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-158 MuiButton-contained"
+                            style="vertical-align: bottom;"
+                            tabindex="0"
+                            title="Step"
+                            type="button"
+                          >
+                            <span
+                              class="MuiButton-label"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiTouchRipple-root"
+                            />
+                          </button>
+                        }
+                        className="MuiTooltip-popper"
+                        id={null}
+                        open={false}
+                        placement="bottom"
+                        popperOptions={
+                          Object {
+                            "modifiers": Object {
+                              "arrow": Object {
+                                "element": null,
+                                "enabled": false,
+                              },
+                            },
+                          }
+                        }
+                        transition={true}
+                      />
+                    </ForwardRef(Tooltip)>
+                  </WithStyles(ForwardRef(Tooltip))>
+                </div>
+              </ForwardRef(Grid)>
+            </WithStyles(ForwardRef(Grid))>
+          </div>
+        </ForwardRef(Grid)>
+      </WithStyles(ForwardRef(Grid))>
+    </Control>
+  </Connect(Control)>
+</injectIntl(Connect(Control))>
 `;

--- a/src/components/__tests__/__snapshots__/Workspace.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Workspace.test.js.snap
@@ -392,9 +392,9 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
                 <div
                   style={
                     Object {
-                      "bottom": 30,
+                      "bottom": 0,
                       "position": "absolute",
-                      "right": 100,
+                      "right": 0,
                     }
                   }
                 >


### PR DESCRIPTION
Convert control to Material UI. Placed the `stop` button at the same location as `run` to make it easier to use. The component renders behind `Workspace` for some reason. This should be addressed when `Workspace` is converted to Material UI since that could be the cause. It is temporarily placed outside of `Workspace`.
![image](https://user-images.githubusercontent.com/1184314/81360098-f787d080-90a8-11ea-97ab-903994d491e6.png)
