### PR TITLE
Get rid of scrollbars in mission-control

### DIFF
--- a/src/components/Control.js
+++ b/src/components/Control.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { Button, Grid, Tooltip } from '@material-ui/core';
+import { IconButton, Button, Grid, Tooltip } from '@material-ui/core';
 import {
   PlayArrow,
   Replay,
@@ -75,7 +75,7 @@ const Control = ({
         backgroundColor: theme.palette.warning.dark,
       },
       width: '24px',
-      height: '24px',
+      height: '34px',
       minWidth: '0px',
       boxShadow: '0px 1px 3px #00000057',
       borderRadius: '4px',
@@ -83,11 +83,11 @@ const Control = ({
     },
   }))(Button);
 
-  const ResetButton = withStyles(() => ({
+  const ResetButton = withStyles((theme) => ({
     root: {
       color: '#FFFFFF',
       width: '24px',
-      height: '24px',
+      height: '34px',
       minWidth: '0px',
       boxShadow: '0px 1px 3px #00000057',
       borderRadius: '4px',

--- a/src/components/Control.js
+++ b/src/components/Control.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { IconButton, Button, Grid, Tooltip } from '@material-ui/core';
+import { Button, Grid, Tooltip } from '@material-ui/core';
 import {
   PlayArrow,
   Replay,
@@ -83,7 +83,7 @@ const Control = ({
     },
   }))(Button);
 
-  const ResetButton = withStyles((theme) => ({
+  const ResetButton = withStyles(() => ({
     root: {
       color: '#FFFFFF',
       width: '24px',

--- a/src/components/ProgramList.js
+++ b/src/components/ProgramList.js
@@ -3,12 +3,14 @@ import {
   Box,
   CircularProgress,
   Grid,
+  Divider,
 } from '@material-ui/core';
 import { injectIntl } from 'react-intl';
 import { Redirect } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 import ConfirmDialog from './ConfirmDialog';
+import Footer from './Footer';
 import ProgramCollection from './ProgramCollection';
 
 const defaultState = {
@@ -200,6 +202,8 @@ class ProgramList extends Component {
         >
           {dialogContent}
         </ConfirmDialog>
+        <Divider />
+        <Footer />
       </>
     );
   }

--- a/src/components/ProtectedRoute.js
+++ b/src/components/ProtectedRoute.js
@@ -3,9 +3,7 @@ import { Route, Redirect } from 'react-router-dom';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import { Divider } from '@material-ui/core';
 import { logout as actionLogout } from '@/actions/auth';
-import Footer from './Footer';
 import TopNav from './TopNav';
 
 const mapStateToProps = ({ auth, user }) => ({ auth, user });
@@ -48,8 +46,6 @@ class ProtectedRoute extends Component {
             )
           )}
         />
-        <Divider />
-        <Footer />
       </>
     );
   }

--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -466,7 +466,7 @@ class Workspace extends Component {
 
     return (
       <Box m={1}>
-        <Grid container direction="column" justify="center" alignItems="center" spacing={1}>
+        <Grid container direction="column" justify="center" alignItems="center" spacing={0}>
           {
           code.isReadOnly ? (
             <Grid item>
@@ -499,7 +499,7 @@ class Workspace extends Component {
           ) : (null)
         }
           <Grid item container direction="column" alignItems="stretch">
-            <Grid item style={{ minHeight: code.isReadOnly ? '70vh' : '80vh', maxHeight: '1080px' }}>
+            <Grid item style={{ minHeight: code.isReadOnly ? '65vh' : '75vh', maxHeight: '1080px' }}>
               <div ref={(editorDiv) => { this.editorDiv = editorDiv; }} id="blocklyDiv">
                 <Box zIndex="modal" style={{ position: 'absolute', bottom: '15%', left: '10%' }}>
                   { React.cloneElement(children, { isConnected: !!rover.rover }) }

--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -466,7 +466,7 @@ class Workspace extends Component {
 
     return (
       <Box m={1}>
-        <Grid container direction="column" justify="center" alignItems="center" spacing={0}>
+        <Grid container direction="column" justify="center" alignItems="center">
           {
           code.isReadOnly ? (
             <Grid item>

--- a/src/components/__tests__/CodeViewer.test.js
+++ b/src/components/__tests__/CodeViewer.test.js
@@ -16,7 +16,7 @@ describe('The CodeViewer component', () => {
     });
     const wrapper = shallow(
       <CodeViewer store={store}>
-        Show Me The Code!
+        View JavaScript
       </CodeViewer>,
     ).dive().dive();
     expect(wrapper).toMatchSnapshot();
@@ -30,7 +30,7 @@ describe('The CodeViewer component', () => {
     });
     const wrapper = shallow(
       <CodeViewer store={store}>
-        Show Me The Code!
+        View JavaScript
       </CodeViewer>,
     ).dive().dive();
 

--- a/src/components/__tests__/__snapshots__/CodeViewer.test.js.snap
+++ b/src/components/__tests__/__snapshots__/CodeViewer.test.js.snap
@@ -7,7 +7,7 @@ exports[`The CodeViewer component renders on the page with no errors 1`] = `
     onClick={[Function]}
     variant="contained"
   >
-    Show Me The Code!
+    View JavaScript
   </WithStyles(ForwardRef(Button))>
   <WithStyles(ForwardRef(Dialog))
     maxWidth="md"

--- a/src/components/__tests__/__snapshots__/ProgramList.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ProgramList.test.js.snap
@@ -52,5 +52,7 @@ exports[`The ProgramList component renders on the page with no errors 1`] = `
   >
     Are you sure you want to remove Test Program?
   </ConfirmDialog>
+  <WithStyles(ForwardRef(Divider)) />
+  <Footer />
 </Fragment>
 `;

--- a/src/components/__tests__/__snapshots__/Workspace.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Workspace.test.js.snap
@@ -383,7 +383,7 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
                 container={true}
                 direction="column"
                 justify="center"
-                spacing={1}
+                spacing={0}
               >
                 <ForwardRef(Grid)
                   alignItems="center"
@@ -497,10 +497,10 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
                   container={true}
                   direction="column"
                   justify="center"
-                  spacing={1}
+                  spacing={0}
                 >
                   <div
-                    className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 MuiGrid-direction-xs-column MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"
+                    className="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"
                   >
                     <WithStyles(ForwardRef(Grid))
                       alignItems="stretch"
@@ -629,7 +629,7 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
                             style={
                               Object {
                                 "maxHeight": "1080px",
-                                "minHeight": "80vh",
+                                "minHeight": "75vh",
                               }
                             }
                           >
@@ -745,7 +745,7 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
                               style={
                                 Object {
                                   "maxHeight": "1080px",
-                                  "minHeight": "80vh",
+                                  "minHeight": "75vh",
                                 }
                               }
                             >
@@ -754,7 +754,7 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
                                 style={
                                   Object {
                                     "maxHeight": "1080px",
-                                    "minHeight": "80vh",
+                                    "minHeight": "75vh",
                                   }
                                 }
                               >

--- a/src/components/__tests__/__snapshots__/Workspace.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Workspace.test.js.snap
@@ -383,7 +383,6 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
                 container={true}
                 direction="column"
                 justify="center"
-                spacing={0}
               >
                 <ForwardRef(Grid)
                   alignItems="center"
@@ -497,7 +496,6 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
                   container={true}
                   direction="column"
                   justify="center"
-                  spacing={0}
                 >
                   <div
                     className="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"

--- a/src/containers/MissionControl.js
+++ b/src/containers/MissionControl.js
@@ -32,7 +32,6 @@ import Workspace from '@/components/Workspace';
 const mapStateToProps = ({ code }) => ({ code });
 
 const MissionControl = ({ location, code }) => {
-
   const [state, setState] = React.useState({
     open: false,
   });
@@ -162,9 +161,6 @@ MissionControl.defaultProps = {
       readOnly: false,
     },
   },
-  code: {
-    name: "",
-  }
 };
 
 MissionControl.propTypes = {

--- a/src/containers/MissionControl.js
+++ b/src/containers/MissionControl.js
@@ -17,6 +17,7 @@ import {
 import { withStyles } from '@material-ui/core/styles';
 import { ExpandMore, Close } from '@material-ui/icons';
 import { FormattedMessage } from 'react-intl';
+import { connect } from 'react-redux';
 import { hot } from 'react-hot-loader';
 import PropTypes from 'prop-types';
 
@@ -28,7 +29,10 @@ import ProgramName from '@/components/ProgramName';
 import ProgramTags from '@/components/ProgramTags';
 import Workspace from '@/components/Workspace';
 
-const MissionControl = ({ location }) => {
+const mapStateToProps = ({ code }) => ({ code });
+
+const MissionControl = ({ location, code }) => {
+
   const [state, setState] = React.useState({
     open: false,
   });
@@ -76,9 +80,16 @@ const MissionControl = ({ location }) => {
         </List>
       </Drawer>
 
-      <Grid container direction="row" justify="space-evenly" alignItems="flex-start" spacing={2}>
-        <Grid item container xs={10} direction="column" justify="center" alignItems="stretch">
-          <Grid item container direction="row" justify="flex-end">
+      <Grid container direction="row" justify="space-evenly" alignItems="flex-start" spacing={0}>
+        <Grid item container xs={10} direction="column" justify="center" alignItems="stretch" spacing={2}>
+          <Grid item container direction="row" justify="space-between">
+            <Grid item>
+              <Box m={1}>
+                <Typography variant="h6">
+                  {code.name}
+                </Typography>
+              </Box>
+            </Grid>
             <Grid item>
               <Button color="default" onClick={() => setState({ ...state, open: true })}>
                 <FormattedMessage
@@ -135,7 +146,7 @@ const MissionControl = ({ location }) => {
               <FormattedMessage
                 id="app.mission_control.show_code"
                 description="Button label for displaying user's code"
-                defaultMessage="Show Me The Code!"
+                defaultMessage="View JavaScript"
               />
             </CodeViewer>
           </Grid>
@@ -151,6 +162,9 @@ MissionControl.defaultProps = {
       readOnly: false,
     },
   },
+  code: {
+    name: "",
+  }
 };
 
 MissionControl.propTypes = {
@@ -159,6 +173,9 @@ MissionControl.propTypes = {
       readOnly: PropTypes.bool,
     }),
   }),
+  code: PropTypes.shape({
+    name: PropTypes.string,
+  }).isRequired,
 };
 
-export default hot(module)(MissionControl);
+export default hot(module)(connect(mapStateToProps)(MissionControl));

--- a/src/containers/__tests__/MissionControl.test.js
+++ b/src/containers/__tests__/MissionControl.test.js
@@ -70,6 +70,8 @@ describe('The MissionControl container', () => {
       },
     ).dive().dive().dive()
       .dive()
+      .dive()
+      .dive()
       .dive();
 
     expect(wrapper.find(Drawer).prop('open')).toBe(false);

--- a/src/containers/__tests__/__snapshots__/MissionControl.test.js.snap
+++ b/src/containers/__tests__/__snapshots__/MissionControl.test.js.snap
@@ -1,14 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`The MissionControl container renders on the page with no errors 1`] = `
-<MissionControl
-  location={
-    Object {
-      "state": Object {
-        "readOnly": false,
-      },
-    }
-  }
+<Connect(MissionControl)
   store={
     Object {
       "dispatch": [MockFunction],
@@ -19,909 +12,1092 @@ exports[`The MissionControl container renders on the page with no errors 1`] = `
     }
   }
 >
-  <WithStyles(ForwardRef(Drawer))
-    anchor="left"
-    onClose={[Function]}
-    open={false}
-  >
-    <ForwardRef(Drawer)
-      anchor="left"
-      classes={
-        Object {
-          "docked": "MuiDrawer-docked",
-          "modal": "MuiDrawer-modal",
-          "paper": "MuiDrawer-paper",
-          "paperAnchorBottom": "MuiDrawer-paperAnchorBottom",
-          "paperAnchorDockedBottom": "MuiDrawer-paperAnchorDockedBottom",
-          "paperAnchorDockedLeft": "MuiDrawer-paperAnchorDockedLeft",
-          "paperAnchorDockedRight": "MuiDrawer-paperAnchorDockedRight",
-          "paperAnchorDockedTop": "MuiDrawer-paperAnchorDockedTop",
-          "paperAnchorLeft": "MuiDrawer-paperAnchorLeft",
-          "paperAnchorRight": "MuiDrawer-paperAnchorRight",
-          "paperAnchorTop": "MuiDrawer-paperAnchorTop",
-          "root": "MuiDrawer-root",
-        }
+  <MissionControl
+    code={
+      Object {
+        "jsCode": "testcode",
+        "tags": Array [],
       }
+    }
+    dispatch={[MockFunction]}
+    location={
+      Object {
+        "state": Object {
+          "readOnly": false,
+        },
+      }
+    }
+    store={
+      Object {
+        "dispatch": [MockFunction],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+        Symbol(observable): [Function],
+      }
+    }
+  >
+    <WithStyles(ForwardRef(Drawer))
+      anchor="left"
       onClose={[Function]}
       open={false}
     >
-      <ForwardRef(Modal)
-        BackdropComponent={
+      <ForwardRef(Drawer)
+        anchor="left"
+        classes={
           Object {
-            "$$typeof": Symbol(react.forward_ref),
-            "Naked": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "propTypes": Object {
-                "children": [Function],
-                "className": [Function],
-                "classes": [Function],
-                "invisible": [Function],
-                "open": [Function],
-                "transitionDuration": [Function],
-              },
-              "render": [Function],
-            },
-            "displayName": "WithStyles(ForwardRef(Backdrop))",
-            "options": Object {
-              "defaultTheme": Object {
-                "breakpoints": Object {
-                  "between": [Function],
-                  "down": [Function],
-                  "keys": Array [
-                    "xs",
-                    "sm",
-                    "md",
-                    "lg",
-                    "xl",
-                  ],
-                  "only": [Function],
-                  "up": [Function],
-                  "values": Object {
-                    "lg": 1280,
-                    "md": 960,
-                    "sm": 600,
-                    "xl": 1920,
-                    "xs": 0,
-                  },
-                  "width": [Function],
-                },
-                "direction": "ltr",
-                "mixins": Object {
-                  "gutters": [Function],
-                  "toolbar": Object {
-                    "@media (min-width:0px) and (orientation: landscape)": Object {
-                      "minHeight": 48,
-                    },
-                    "@media (min-width:600px)": Object {
-                      "minHeight": 64,
-                    },
-                    "minHeight": 56,
-                  },
-                },
-                "overrides": Object {},
-                "palette": Object {
-                  "action": Object {
-                    "activatedOpacity": 0.12,
-                    "active": "rgba(0, 0, 0, 0.54)",
-                    "disabled": "rgba(0, 0, 0, 0.26)",
-                    "disabledBackground": "rgba(0, 0, 0, 0.12)",
-                    "disabledOpacity": 0.38,
-                    "focus": "rgba(0, 0, 0, 0.12)",
-                    "focusOpacity": 0.12,
-                    "hover": "rgba(0, 0, 0, 0.04)",
-                    "hoverOpacity": 0.04,
-                    "selected": "rgba(0, 0, 0, 0.08)",
-                    "selectedOpacity": 0.08,
-                  },
-                  "augmentColor": [Function],
-                  "background": Object {
-                    "default": "#fafafa",
-                    "paper": "#fff",
-                  },
-                  "common": Object {
-                    "black": "#000",
-                    "white": "#fff",
-                  },
-                  "contrastThreshold": 3,
-                  "divider": "rgba(0, 0, 0, 0.12)",
-                  "error": Object {
-                    "contrastText": "#fff",
-                    "dark": "#d32f2f",
-                    "light": "#e57373",
-                    "main": "#f44336",
-                  },
-                  "getContrastText": [Function],
-                  "grey": Object {
-                    "100": "#f5f5f5",
-                    "200": "#eeeeee",
-                    "300": "#e0e0e0",
-                    "400": "#bdbdbd",
-                    "50": "#fafafa",
-                    "500": "#9e9e9e",
-                    "600": "#757575",
-                    "700": "#616161",
-                    "800": "#424242",
-                    "900": "#212121",
-                    "A100": "#d5d5d5",
-                    "A200": "#aaaaaa",
-                    "A400": "#303030",
-                    "A700": "#616161",
-                  },
-                  "info": Object {
-                    "contrastText": "#fff",
-                    "dark": "#1976d2",
-                    "light": "#64b5f6",
-                    "main": "#2196f3",
-                  },
-                  "primary": Object {
-                    "contrastText": "#fff",
-                    "dark": "#303f9f",
-                    "light": "#7986cb",
-                    "main": "#3f51b5",
-                  },
-                  "secondary": Object {
-                    "contrastText": "#fff",
-                    "dark": "#c51162",
-                    "light": "#ff4081",
-                    "main": "#f50057",
-                  },
-                  "success": Object {
-                    "contrastText": "rgba(0, 0, 0, 0.87)",
-                    "dark": "#388e3c",
-                    "light": "#81c784",
-                    "main": "#4caf50",
-                  },
-                  "text": Object {
-                    "disabled": "rgba(0, 0, 0, 0.38)",
-                    "hint": "rgba(0, 0, 0, 0.38)",
-                    "primary": "rgba(0, 0, 0, 0.87)",
-                    "secondary": "rgba(0, 0, 0, 0.54)",
-                  },
-                  "tonalOffset": 0.2,
-                  "type": "light",
-                  "warning": Object {
-                    "contrastText": "rgba(0, 0, 0, 0.87)",
-                    "dark": "#f57c00",
-                    "light": "#ffb74d",
-                    "main": "#ff9800",
-                  },
-                },
-                "props": Object {},
-                "shadows": Array [
-                  "none",
-                  "0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)",
-                  "0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)",
-                  "0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12)",
-                  "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
-                  "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
-                  "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
-                  "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
-                  "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
-                  "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
-                  "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
-                  "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
-                  "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
-                  "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
-                  "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
-                  "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
-                  "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
-                  "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
-                  "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
-                  "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
-                  "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
-                  "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
-                  "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
-                  "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
-                  "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
-                ],
-                "shape": Object {
-                  "borderRadius": 4,
-                },
-                "spacing": [Function],
-                "transitions": Object {
-                  "create": [Function],
-                  "duration": Object {
-                    "complex": 375,
-                    "enteringScreen": 225,
-                    "leavingScreen": 195,
-                    "short": 250,
-                    "shorter": 200,
-                    "shortest": 150,
-                    "standard": 300,
-                  },
-                  "easing": Object {
-                    "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
-                    "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
-                    "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
-                    "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
-                  },
-                  "getAutoHeightDuration": [Function],
-                },
-                "typography": Object {
-                  "body1": Object {
-                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-                    "fontSize": "1rem",
-                    "fontWeight": 400,
-                    "letterSpacing": "0.00938em",
-                    "lineHeight": 1.5,
-                  },
-                  "body2": Object {
-                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-                    "fontSize": "0.875rem",
-                    "fontWeight": 400,
-                    "letterSpacing": "0.01071em",
-                    "lineHeight": 1.43,
-                  },
-                  "button": Object {
-                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-                    "fontSize": "0.875rem",
-                    "fontWeight": 500,
-                    "letterSpacing": "0.02857em",
-                    "lineHeight": 1.75,
-                    "textTransform": "uppercase",
-                  },
-                  "caption": Object {
-                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                    "letterSpacing": "0.03333em",
-                    "lineHeight": 1.66,
-                  },
-                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-                  "fontSize": 14,
-                  "fontWeightBold": 700,
-                  "fontWeightLight": 300,
-                  "fontWeightMedium": 500,
-                  "fontWeightRegular": 400,
-                  "h1": Object {
-                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-                    "fontSize": "6rem",
-                    "fontWeight": 300,
-                    "letterSpacing": "-0.01562em",
-                    "lineHeight": 1.167,
-                  },
-                  "h2": Object {
-                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-                    "fontSize": "3.75rem",
-                    "fontWeight": 300,
-                    "letterSpacing": "-0.00833em",
-                    "lineHeight": 1.2,
-                  },
-                  "h3": Object {
-                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-                    "fontSize": "3rem",
-                    "fontWeight": 400,
-                    "letterSpacing": "0em",
-                    "lineHeight": 1.167,
-                  },
-                  "h4": Object {
-                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-                    "fontSize": "2.125rem",
-                    "fontWeight": 400,
-                    "letterSpacing": "0.00735em",
-                    "lineHeight": 1.235,
-                  },
-                  "h5": Object {
-                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-                    "fontSize": "1.5rem",
-                    "fontWeight": 400,
-                    "letterSpacing": "0em",
-                    "lineHeight": 1.334,
-                  },
-                  "h6": Object {
-                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-                    "fontSize": "1.25rem",
-                    "fontWeight": 500,
-                    "letterSpacing": "0.0075em",
-                    "lineHeight": 1.6,
-                  },
-                  "htmlFontSize": 16,
-                  "overline": Object {
-                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                    "letterSpacing": "0.08333em",
-                    "lineHeight": 2.66,
-                    "textTransform": "uppercase",
-                  },
-                  "pxToRem": [Function],
-                  "round": [Function],
-                  "subtitle1": Object {
-                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-                    "fontSize": "1rem",
-                    "fontWeight": 400,
-                    "letterSpacing": "0.00938em",
-                    "lineHeight": 1.75,
-                  },
-                  "subtitle2": Object {
-                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-                    "fontSize": "0.875rem",
-                    "fontWeight": 500,
-                    "letterSpacing": "0.00714em",
-                    "lineHeight": 1.57,
-                  },
-                },
-                "zIndex": Object {
-                  "appBar": 1100,
-                  "drawer": 1200,
-                  "mobileStepper": 1000,
-                  "modal": 1300,
-                  "snackbar": 1400,
-                  "speedDial": 1050,
-                  "tooltip": 1500,
-                },
-              },
-              "name": "MuiBackdrop",
-            },
-            "propTypes": Object {
-              "classes": [Function],
-              "innerRef": [Function],
-            },
-            "render": [Function],
-            "useStyles": [Function],
+            "docked": "MuiDrawer-docked",
+            "modal": "MuiDrawer-modal",
+            "paper": "MuiDrawer-paper",
+            "paperAnchorBottom": "MuiDrawer-paperAnchorBottom",
+            "paperAnchorDockedBottom": "MuiDrawer-paperAnchorDockedBottom",
+            "paperAnchorDockedLeft": "MuiDrawer-paperAnchorDockedLeft",
+            "paperAnchorDockedRight": "MuiDrawer-paperAnchorDockedRight",
+            "paperAnchorDockedTop": "MuiDrawer-paperAnchorDockedTop",
+            "paperAnchorLeft": "MuiDrawer-paperAnchorLeft",
+            "paperAnchorRight": "MuiDrawer-paperAnchorRight",
+            "paperAnchorTop": "MuiDrawer-paperAnchorTop",
+            "root": "MuiDrawer-root",
           }
         }
-        BackdropProps={
-          Object {
-            "transitionDuration": Object {
-              "enter": 225,
-              "exit": 195,
-            },
-          }
-        }
-        className="MuiDrawer-root MuiDrawer-modal"
         onClose={[Function]}
         open={false}
-      />
-    </ForwardRef(Drawer)>
-  </WithStyles(ForwardRef(Drawer))>
-  <WithStyles(ForwardRef(Grid))
-    alignItems="flex-start"
-    container={true}
-    direction="row"
-    justify="space-evenly"
-    spacing={2}
-  >
-    <ForwardRef(Grid)
+      >
+        <ForwardRef(Modal)
+          BackdropComponent={
+            Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "Naked": Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "propTypes": Object {
+                  "children": [Function],
+                  "className": [Function],
+                  "classes": [Function],
+                  "invisible": [Function],
+                  "open": [Function],
+                  "transitionDuration": [Function],
+                },
+                "render": [Function],
+              },
+              "displayName": "WithStyles(ForwardRef(Backdrop))",
+              "options": Object {
+                "defaultTheme": Object {
+                  "breakpoints": Object {
+                    "between": [Function],
+                    "down": [Function],
+                    "keys": Array [
+                      "xs",
+                      "sm",
+                      "md",
+                      "lg",
+                      "xl",
+                    ],
+                    "only": [Function],
+                    "up": [Function],
+                    "values": Object {
+                      "lg": 1280,
+                      "md": 960,
+                      "sm": 600,
+                      "xl": 1920,
+                      "xs": 0,
+                    },
+                    "width": [Function],
+                  },
+                  "direction": "ltr",
+                  "mixins": Object {
+                    "gutters": [Function],
+                    "toolbar": Object {
+                      "@media (min-width:0px) and (orientation: landscape)": Object {
+                        "minHeight": 48,
+                      },
+                      "@media (min-width:600px)": Object {
+                        "minHeight": 64,
+                      },
+                      "minHeight": 56,
+                    },
+                  },
+                  "overrides": Object {},
+                  "palette": Object {
+                    "action": Object {
+                      "activatedOpacity": 0.12,
+                      "active": "rgba(0, 0, 0, 0.54)",
+                      "disabled": "rgba(0, 0, 0, 0.26)",
+                      "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                      "disabledOpacity": 0.38,
+                      "focus": "rgba(0, 0, 0, 0.12)",
+                      "focusOpacity": 0.12,
+                      "hover": "rgba(0, 0, 0, 0.04)",
+                      "hoverOpacity": 0.04,
+                      "selected": "rgba(0, 0, 0, 0.08)",
+                      "selectedOpacity": 0.08,
+                    },
+                    "augmentColor": [Function],
+                    "background": Object {
+                      "default": "#fafafa",
+                      "paper": "#fff",
+                    },
+                    "common": Object {
+                      "black": "#000",
+                      "white": "#fff",
+                    },
+                    "contrastThreshold": 3,
+                    "divider": "rgba(0, 0, 0, 0.12)",
+                    "error": Object {
+                      "contrastText": "#fff",
+                      "dark": "#d32f2f",
+                      "light": "#e57373",
+                      "main": "#f44336",
+                    },
+                    "getContrastText": [Function],
+                    "grey": Object {
+                      "100": "#f5f5f5",
+                      "200": "#eeeeee",
+                      "300": "#e0e0e0",
+                      "400": "#bdbdbd",
+                      "50": "#fafafa",
+                      "500": "#9e9e9e",
+                      "600": "#757575",
+                      "700": "#616161",
+                      "800": "#424242",
+                      "900": "#212121",
+                      "A100": "#d5d5d5",
+                      "A200": "#aaaaaa",
+                      "A400": "#303030",
+                      "A700": "#616161",
+                    },
+                    "info": Object {
+                      "contrastText": "#fff",
+                      "dark": "#1976d2",
+                      "light": "#64b5f6",
+                      "main": "#2196f3",
+                    },
+                    "primary": Object {
+                      "contrastText": "#fff",
+                      "dark": "#303f9f",
+                      "light": "#7986cb",
+                      "main": "#3f51b5",
+                    },
+                    "secondary": Object {
+                      "contrastText": "#fff",
+                      "dark": "#c51162",
+                      "light": "#ff4081",
+                      "main": "#f50057",
+                    },
+                    "success": Object {
+                      "contrastText": "rgba(0, 0, 0, 0.87)",
+                      "dark": "#388e3c",
+                      "light": "#81c784",
+                      "main": "#4caf50",
+                    },
+                    "text": Object {
+                      "disabled": "rgba(0, 0, 0, 0.38)",
+                      "hint": "rgba(0, 0, 0, 0.38)",
+                      "primary": "rgba(0, 0, 0, 0.87)",
+                      "secondary": "rgba(0, 0, 0, 0.54)",
+                    },
+                    "tonalOffset": 0.2,
+                    "type": "light",
+                    "warning": Object {
+                      "contrastText": "rgba(0, 0, 0, 0.87)",
+                      "dark": "#f57c00",
+                      "light": "#ffb74d",
+                      "main": "#ff9800",
+                    },
+                  },
+                  "props": Object {},
+                  "shadows": Array [
+                    "none",
+                    "0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)",
+                    "0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)",
+                    "0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12)",
+                    "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+                    "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+                    "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+                    "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+                    "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                    "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+                    "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+                    "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+                    "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+                    "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+                    "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+                    "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+                    "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+                    "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+                    "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+                    "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+                    "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+                    "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+                    "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+                    "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+                    "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+                  ],
+                  "shape": Object {
+                    "borderRadius": 4,
+                  },
+                  "spacing": [Function],
+                  "transitions": Object {
+                    "create": [Function],
+                    "duration": Object {
+                      "complex": 375,
+                      "enteringScreen": 225,
+                      "leavingScreen": 195,
+                      "short": 250,
+                      "shorter": 200,
+                      "shortest": 150,
+                      "standard": 300,
+                    },
+                    "easing": Object {
+                      "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                      "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                      "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                      "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+                    },
+                    "getAutoHeightDuration": [Function],
+                  },
+                  "typography": Object {
+                    "body1": Object {
+                      "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                      "fontSize": "1rem",
+                      "fontWeight": 400,
+                      "letterSpacing": "0.00938em",
+                      "lineHeight": 1.5,
+                    },
+                    "body2": Object {
+                      "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                      "letterSpacing": "0.01071em",
+                      "lineHeight": 1.43,
+                    },
+                    "button": Object {
+                      "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 500,
+                      "letterSpacing": "0.02857em",
+                      "lineHeight": 1.75,
+                      "textTransform": "uppercase",
+                    },
+                    "caption": Object {
+                      "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                      "letterSpacing": "0.03333em",
+                      "lineHeight": 1.66,
+                    },
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": 14,
+                    "fontWeightBold": 700,
+                    "fontWeightLight": 300,
+                    "fontWeightMedium": 500,
+                    "fontWeightRegular": 400,
+                    "h1": Object {
+                      "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                      "fontSize": "6rem",
+                      "fontWeight": 300,
+                      "letterSpacing": "-0.01562em",
+                      "lineHeight": 1.167,
+                    },
+                    "h2": Object {
+                      "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                      "fontSize": "3.75rem",
+                      "fontWeight": 300,
+                      "letterSpacing": "-0.00833em",
+                      "lineHeight": 1.2,
+                    },
+                    "h3": Object {
+                      "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                      "fontSize": "3rem",
+                      "fontWeight": 400,
+                      "letterSpacing": "0em",
+                      "lineHeight": 1.167,
+                    },
+                    "h4": Object {
+                      "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                      "fontSize": "2.125rem",
+                      "fontWeight": 400,
+                      "letterSpacing": "0.00735em",
+                      "lineHeight": 1.235,
+                    },
+                    "h5": Object {
+                      "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 400,
+                      "letterSpacing": "0em",
+                      "lineHeight": 1.334,
+                    },
+                    "h6": Object {
+                      "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                      "fontSize": "1.25rem",
+                      "fontWeight": 500,
+                      "letterSpacing": "0.0075em",
+                      "lineHeight": 1.6,
+                    },
+                    "htmlFontSize": 16,
+                    "overline": Object {
+                      "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                      "letterSpacing": "0.08333em",
+                      "lineHeight": 2.66,
+                      "textTransform": "uppercase",
+                    },
+                    "pxToRem": [Function],
+                    "round": [Function],
+                    "subtitle1": Object {
+                      "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                      "fontSize": "1rem",
+                      "fontWeight": 400,
+                      "letterSpacing": "0.00938em",
+                      "lineHeight": 1.75,
+                    },
+                    "subtitle2": Object {
+                      "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 500,
+                      "letterSpacing": "0.00714em",
+                      "lineHeight": 1.57,
+                    },
+                  },
+                  "zIndex": Object {
+                    "appBar": 1100,
+                    "drawer": 1200,
+                    "mobileStepper": 1000,
+                    "modal": 1300,
+                    "snackbar": 1400,
+                    "speedDial": 1050,
+                    "tooltip": 1500,
+                  },
+                },
+                "name": "MuiBackdrop",
+              },
+              "propTypes": Object {
+                "classes": [Function],
+                "innerRef": [Function],
+              },
+              "render": [Function],
+              "useStyles": [Function],
+            }
+          }
+          BackdropProps={
+            Object {
+              "transitionDuration": Object {
+                "enter": 225,
+                "exit": 195,
+              },
+            }
+          }
+          className="MuiDrawer-root MuiDrawer-modal"
+          onClose={[Function]}
+          open={false}
+        />
+      </ForwardRef(Drawer)>
+    </WithStyles(ForwardRef(Drawer))>
+    <WithStyles(ForwardRef(Grid))
       alignItems="flex-start"
-      classes={
-        Object {
-          "align-content-xs-center": "MuiGrid-align-content-xs-center",
-          "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
-          "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
-          "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
-          "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
-          "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
-          "align-items-xs-center": "MuiGrid-align-items-xs-center",
-          "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
-          "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
-          "container": "MuiGrid-container",
-          "direction-xs-column": "MuiGrid-direction-xs-column",
-          "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
-          "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
-          "grid-lg-1": "MuiGrid-grid-lg-1",
-          "grid-lg-10": "MuiGrid-grid-lg-10",
-          "grid-lg-11": "MuiGrid-grid-lg-11",
-          "grid-lg-12": "MuiGrid-grid-lg-12",
-          "grid-lg-2": "MuiGrid-grid-lg-2",
-          "grid-lg-3": "MuiGrid-grid-lg-3",
-          "grid-lg-4": "MuiGrid-grid-lg-4",
-          "grid-lg-5": "MuiGrid-grid-lg-5",
-          "grid-lg-6": "MuiGrid-grid-lg-6",
-          "grid-lg-7": "MuiGrid-grid-lg-7",
-          "grid-lg-8": "MuiGrid-grid-lg-8",
-          "grid-lg-9": "MuiGrid-grid-lg-9",
-          "grid-lg-auto": "MuiGrid-grid-lg-auto",
-          "grid-lg-true": "MuiGrid-grid-lg-true",
-          "grid-md-1": "MuiGrid-grid-md-1",
-          "grid-md-10": "MuiGrid-grid-md-10",
-          "grid-md-11": "MuiGrid-grid-md-11",
-          "grid-md-12": "MuiGrid-grid-md-12",
-          "grid-md-2": "MuiGrid-grid-md-2",
-          "grid-md-3": "MuiGrid-grid-md-3",
-          "grid-md-4": "MuiGrid-grid-md-4",
-          "grid-md-5": "MuiGrid-grid-md-5",
-          "grid-md-6": "MuiGrid-grid-md-6",
-          "grid-md-7": "MuiGrid-grid-md-7",
-          "grid-md-8": "MuiGrid-grid-md-8",
-          "grid-md-9": "MuiGrid-grid-md-9",
-          "grid-md-auto": "MuiGrid-grid-md-auto",
-          "grid-md-true": "MuiGrid-grid-md-true",
-          "grid-sm-1": "MuiGrid-grid-sm-1",
-          "grid-sm-10": "MuiGrid-grid-sm-10",
-          "grid-sm-11": "MuiGrid-grid-sm-11",
-          "grid-sm-12": "MuiGrid-grid-sm-12",
-          "grid-sm-2": "MuiGrid-grid-sm-2",
-          "grid-sm-3": "MuiGrid-grid-sm-3",
-          "grid-sm-4": "MuiGrid-grid-sm-4",
-          "grid-sm-5": "MuiGrid-grid-sm-5",
-          "grid-sm-6": "MuiGrid-grid-sm-6",
-          "grid-sm-7": "MuiGrid-grid-sm-7",
-          "grid-sm-8": "MuiGrid-grid-sm-8",
-          "grid-sm-9": "MuiGrid-grid-sm-9",
-          "grid-sm-auto": "MuiGrid-grid-sm-auto",
-          "grid-sm-true": "MuiGrid-grid-sm-true",
-          "grid-xl-1": "MuiGrid-grid-xl-1",
-          "grid-xl-10": "MuiGrid-grid-xl-10",
-          "grid-xl-11": "MuiGrid-grid-xl-11",
-          "grid-xl-12": "MuiGrid-grid-xl-12",
-          "grid-xl-2": "MuiGrid-grid-xl-2",
-          "grid-xl-3": "MuiGrid-grid-xl-3",
-          "grid-xl-4": "MuiGrid-grid-xl-4",
-          "grid-xl-5": "MuiGrid-grid-xl-5",
-          "grid-xl-6": "MuiGrid-grid-xl-6",
-          "grid-xl-7": "MuiGrid-grid-xl-7",
-          "grid-xl-8": "MuiGrid-grid-xl-8",
-          "grid-xl-9": "MuiGrid-grid-xl-9",
-          "grid-xl-auto": "MuiGrid-grid-xl-auto",
-          "grid-xl-true": "MuiGrid-grid-xl-true",
-          "grid-xs-1": "MuiGrid-grid-xs-1",
-          "grid-xs-10": "MuiGrid-grid-xs-10",
-          "grid-xs-11": "MuiGrid-grid-xs-11",
-          "grid-xs-12": "MuiGrid-grid-xs-12",
-          "grid-xs-2": "MuiGrid-grid-xs-2",
-          "grid-xs-3": "MuiGrid-grid-xs-3",
-          "grid-xs-4": "MuiGrid-grid-xs-4",
-          "grid-xs-5": "MuiGrid-grid-xs-5",
-          "grid-xs-6": "MuiGrid-grid-xs-6",
-          "grid-xs-7": "MuiGrid-grid-xs-7",
-          "grid-xs-8": "MuiGrid-grid-xs-8",
-          "grid-xs-9": "MuiGrid-grid-xs-9",
-          "grid-xs-auto": "MuiGrid-grid-xs-auto",
-          "grid-xs-true": "MuiGrid-grid-xs-true",
-          "item": "MuiGrid-item",
-          "justify-xs-center": "MuiGrid-justify-xs-center",
-          "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
-          "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
-          "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
-          "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
-          "root": "MuiGrid-root",
-          "spacing-xs-1": "MuiGrid-spacing-xs-1",
-          "spacing-xs-10": "MuiGrid-spacing-xs-10",
-          "spacing-xs-2": "MuiGrid-spacing-xs-2",
-          "spacing-xs-3": "MuiGrid-spacing-xs-3",
-          "spacing-xs-4": "MuiGrid-spacing-xs-4",
-          "spacing-xs-5": "MuiGrid-spacing-xs-5",
-          "spacing-xs-6": "MuiGrid-spacing-xs-6",
-          "spacing-xs-7": "MuiGrid-spacing-xs-7",
-          "spacing-xs-8": "MuiGrid-spacing-xs-8",
-          "spacing-xs-9": "MuiGrid-spacing-xs-9",
-          "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
-          "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
-          "zeroMinWidth": "MuiGrid-zeroMinWidth",
-        }
-      }
       container={true}
       direction="row"
       justify="space-evenly"
-      spacing={2}
+      spacing={0}
     >
-      <div
-        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-flex-start MuiGrid-justify-xs-space-evenly"
+      <ForwardRef(Grid)
+        alignItems="flex-start"
+        classes={
+          Object {
+            "align-content-xs-center": "MuiGrid-align-content-xs-center",
+            "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
+            "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
+            "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
+            "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
+            "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
+            "align-items-xs-center": "MuiGrid-align-items-xs-center",
+            "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
+            "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
+            "container": "MuiGrid-container",
+            "direction-xs-column": "MuiGrid-direction-xs-column",
+            "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
+            "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
+            "grid-lg-1": "MuiGrid-grid-lg-1",
+            "grid-lg-10": "MuiGrid-grid-lg-10",
+            "grid-lg-11": "MuiGrid-grid-lg-11",
+            "grid-lg-12": "MuiGrid-grid-lg-12",
+            "grid-lg-2": "MuiGrid-grid-lg-2",
+            "grid-lg-3": "MuiGrid-grid-lg-3",
+            "grid-lg-4": "MuiGrid-grid-lg-4",
+            "grid-lg-5": "MuiGrid-grid-lg-5",
+            "grid-lg-6": "MuiGrid-grid-lg-6",
+            "grid-lg-7": "MuiGrid-grid-lg-7",
+            "grid-lg-8": "MuiGrid-grid-lg-8",
+            "grid-lg-9": "MuiGrid-grid-lg-9",
+            "grid-lg-auto": "MuiGrid-grid-lg-auto",
+            "grid-lg-true": "MuiGrid-grid-lg-true",
+            "grid-md-1": "MuiGrid-grid-md-1",
+            "grid-md-10": "MuiGrid-grid-md-10",
+            "grid-md-11": "MuiGrid-grid-md-11",
+            "grid-md-12": "MuiGrid-grid-md-12",
+            "grid-md-2": "MuiGrid-grid-md-2",
+            "grid-md-3": "MuiGrid-grid-md-3",
+            "grid-md-4": "MuiGrid-grid-md-4",
+            "grid-md-5": "MuiGrid-grid-md-5",
+            "grid-md-6": "MuiGrid-grid-md-6",
+            "grid-md-7": "MuiGrid-grid-md-7",
+            "grid-md-8": "MuiGrid-grid-md-8",
+            "grid-md-9": "MuiGrid-grid-md-9",
+            "grid-md-auto": "MuiGrid-grid-md-auto",
+            "grid-md-true": "MuiGrid-grid-md-true",
+            "grid-sm-1": "MuiGrid-grid-sm-1",
+            "grid-sm-10": "MuiGrid-grid-sm-10",
+            "grid-sm-11": "MuiGrid-grid-sm-11",
+            "grid-sm-12": "MuiGrid-grid-sm-12",
+            "grid-sm-2": "MuiGrid-grid-sm-2",
+            "grid-sm-3": "MuiGrid-grid-sm-3",
+            "grid-sm-4": "MuiGrid-grid-sm-4",
+            "grid-sm-5": "MuiGrid-grid-sm-5",
+            "grid-sm-6": "MuiGrid-grid-sm-6",
+            "grid-sm-7": "MuiGrid-grid-sm-7",
+            "grid-sm-8": "MuiGrid-grid-sm-8",
+            "grid-sm-9": "MuiGrid-grid-sm-9",
+            "grid-sm-auto": "MuiGrid-grid-sm-auto",
+            "grid-sm-true": "MuiGrid-grid-sm-true",
+            "grid-xl-1": "MuiGrid-grid-xl-1",
+            "grid-xl-10": "MuiGrid-grid-xl-10",
+            "grid-xl-11": "MuiGrid-grid-xl-11",
+            "grid-xl-12": "MuiGrid-grid-xl-12",
+            "grid-xl-2": "MuiGrid-grid-xl-2",
+            "grid-xl-3": "MuiGrid-grid-xl-3",
+            "grid-xl-4": "MuiGrid-grid-xl-4",
+            "grid-xl-5": "MuiGrid-grid-xl-5",
+            "grid-xl-6": "MuiGrid-grid-xl-6",
+            "grid-xl-7": "MuiGrid-grid-xl-7",
+            "grid-xl-8": "MuiGrid-grid-xl-8",
+            "grid-xl-9": "MuiGrid-grid-xl-9",
+            "grid-xl-auto": "MuiGrid-grid-xl-auto",
+            "grid-xl-true": "MuiGrid-grid-xl-true",
+            "grid-xs-1": "MuiGrid-grid-xs-1",
+            "grid-xs-10": "MuiGrid-grid-xs-10",
+            "grid-xs-11": "MuiGrid-grid-xs-11",
+            "grid-xs-12": "MuiGrid-grid-xs-12",
+            "grid-xs-2": "MuiGrid-grid-xs-2",
+            "grid-xs-3": "MuiGrid-grid-xs-3",
+            "grid-xs-4": "MuiGrid-grid-xs-4",
+            "grid-xs-5": "MuiGrid-grid-xs-5",
+            "grid-xs-6": "MuiGrid-grid-xs-6",
+            "grid-xs-7": "MuiGrid-grid-xs-7",
+            "grid-xs-8": "MuiGrid-grid-xs-8",
+            "grid-xs-9": "MuiGrid-grid-xs-9",
+            "grid-xs-auto": "MuiGrid-grid-xs-auto",
+            "grid-xs-true": "MuiGrid-grid-xs-true",
+            "item": "MuiGrid-item",
+            "justify-xs-center": "MuiGrid-justify-xs-center",
+            "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
+            "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
+            "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
+            "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
+            "root": "MuiGrid-root",
+            "spacing-xs-1": "MuiGrid-spacing-xs-1",
+            "spacing-xs-10": "MuiGrid-spacing-xs-10",
+            "spacing-xs-2": "MuiGrid-spacing-xs-2",
+            "spacing-xs-3": "MuiGrid-spacing-xs-3",
+            "spacing-xs-4": "MuiGrid-spacing-xs-4",
+            "spacing-xs-5": "MuiGrid-spacing-xs-5",
+            "spacing-xs-6": "MuiGrid-spacing-xs-6",
+            "spacing-xs-7": "MuiGrid-spacing-xs-7",
+            "spacing-xs-8": "MuiGrid-spacing-xs-8",
+            "spacing-xs-9": "MuiGrid-spacing-xs-9",
+            "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
+            "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
+            "zeroMinWidth": "MuiGrid-zeroMinWidth",
+          }
+        }
+        container={true}
+        direction="row"
+        justify="space-evenly"
+        spacing={0}
       >
-        <WithStyles(ForwardRef(Grid))
-          alignItems="stretch"
-          container={true}
-          direction="column"
-          item={true}
-          justify="center"
-          xs={10}
+        <div
+          className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-flex-start MuiGrid-justify-xs-space-evenly"
         >
-          <ForwardRef(Grid)
+          <WithStyles(ForwardRef(Grid))
             alignItems="stretch"
-            classes={
-              Object {
-                "align-content-xs-center": "MuiGrid-align-content-xs-center",
-                "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
-                "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
-                "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
-                "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
-                "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
-                "align-items-xs-center": "MuiGrid-align-items-xs-center",
-                "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
-                "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
-                "container": "MuiGrid-container",
-                "direction-xs-column": "MuiGrid-direction-xs-column",
-                "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
-                "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
-                "grid-lg-1": "MuiGrid-grid-lg-1",
-                "grid-lg-10": "MuiGrid-grid-lg-10",
-                "grid-lg-11": "MuiGrid-grid-lg-11",
-                "grid-lg-12": "MuiGrid-grid-lg-12",
-                "grid-lg-2": "MuiGrid-grid-lg-2",
-                "grid-lg-3": "MuiGrid-grid-lg-3",
-                "grid-lg-4": "MuiGrid-grid-lg-4",
-                "grid-lg-5": "MuiGrid-grid-lg-5",
-                "grid-lg-6": "MuiGrid-grid-lg-6",
-                "grid-lg-7": "MuiGrid-grid-lg-7",
-                "grid-lg-8": "MuiGrid-grid-lg-8",
-                "grid-lg-9": "MuiGrid-grid-lg-9",
-                "grid-lg-auto": "MuiGrid-grid-lg-auto",
-                "grid-lg-true": "MuiGrid-grid-lg-true",
-                "grid-md-1": "MuiGrid-grid-md-1",
-                "grid-md-10": "MuiGrid-grid-md-10",
-                "grid-md-11": "MuiGrid-grid-md-11",
-                "grid-md-12": "MuiGrid-grid-md-12",
-                "grid-md-2": "MuiGrid-grid-md-2",
-                "grid-md-3": "MuiGrid-grid-md-3",
-                "grid-md-4": "MuiGrid-grid-md-4",
-                "grid-md-5": "MuiGrid-grid-md-5",
-                "grid-md-6": "MuiGrid-grid-md-6",
-                "grid-md-7": "MuiGrid-grid-md-7",
-                "grid-md-8": "MuiGrid-grid-md-8",
-                "grid-md-9": "MuiGrid-grid-md-9",
-                "grid-md-auto": "MuiGrid-grid-md-auto",
-                "grid-md-true": "MuiGrid-grid-md-true",
-                "grid-sm-1": "MuiGrid-grid-sm-1",
-                "grid-sm-10": "MuiGrid-grid-sm-10",
-                "grid-sm-11": "MuiGrid-grid-sm-11",
-                "grid-sm-12": "MuiGrid-grid-sm-12",
-                "grid-sm-2": "MuiGrid-grid-sm-2",
-                "grid-sm-3": "MuiGrid-grid-sm-3",
-                "grid-sm-4": "MuiGrid-grid-sm-4",
-                "grid-sm-5": "MuiGrid-grid-sm-5",
-                "grid-sm-6": "MuiGrid-grid-sm-6",
-                "grid-sm-7": "MuiGrid-grid-sm-7",
-                "grid-sm-8": "MuiGrid-grid-sm-8",
-                "grid-sm-9": "MuiGrid-grid-sm-9",
-                "grid-sm-auto": "MuiGrid-grid-sm-auto",
-                "grid-sm-true": "MuiGrid-grid-sm-true",
-                "grid-xl-1": "MuiGrid-grid-xl-1",
-                "grid-xl-10": "MuiGrid-grid-xl-10",
-                "grid-xl-11": "MuiGrid-grid-xl-11",
-                "grid-xl-12": "MuiGrid-grid-xl-12",
-                "grid-xl-2": "MuiGrid-grid-xl-2",
-                "grid-xl-3": "MuiGrid-grid-xl-3",
-                "grid-xl-4": "MuiGrid-grid-xl-4",
-                "grid-xl-5": "MuiGrid-grid-xl-5",
-                "grid-xl-6": "MuiGrid-grid-xl-6",
-                "grid-xl-7": "MuiGrid-grid-xl-7",
-                "grid-xl-8": "MuiGrid-grid-xl-8",
-                "grid-xl-9": "MuiGrid-grid-xl-9",
-                "grid-xl-auto": "MuiGrid-grid-xl-auto",
-                "grid-xl-true": "MuiGrid-grid-xl-true",
-                "grid-xs-1": "MuiGrid-grid-xs-1",
-                "grid-xs-10": "MuiGrid-grid-xs-10",
-                "grid-xs-11": "MuiGrid-grid-xs-11",
-                "grid-xs-12": "MuiGrid-grid-xs-12",
-                "grid-xs-2": "MuiGrid-grid-xs-2",
-                "grid-xs-3": "MuiGrid-grid-xs-3",
-                "grid-xs-4": "MuiGrid-grid-xs-4",
-                "grid-xs-5": "MuiGrid-grid-xs-5",
-                "grid-xs-6": "MuiGrid-grid-xs-6",
-                "grid-xs-7": "MuiGrid-grid-xs-7",
-                "grid-xs-8": "MuiGrid-grid-xs-8",
-                "grid-xs-9": "MuiGrid-grid-xs-9",
-                "grid-xs-auto": "MuiGrid-grid-xs-auto",
-                "grid-xs-true": "MuiGrid-grid-xs-true",
-                "item": "MuiGrid-item",
-                "justify-xs-center": "MuiGrid-justify-xs-center",
-                "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
-                "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
-                "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
-                "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
-                "root": "MuiGrid-root",
-                "spacing-xs-1": "MuiGrid-spacing-xs-1",
-                "spacing-xs-10": "MuiGrid-spacing-xs-10",
-                "spacing-xs-2": "MuiGrid-spacing-xs-2",
-                "spacing-xs-3": "MuiGrid-spacing-xs-3",
-                "spacing-xs-4": "MuiGrid-spacing-xs-4",
-                "spacing-xs-5": "MuiGrid-spacing-xs-5",
-                "spacing-xs-6": "MuiGrid-spacing-xs-6",
-                "spacing-xs-7": "MuiGrid-spacing-xs-7",
-                "spacing-xs-8": "MuiGrid-spacing-xs-8",
-                "spacing-xs-9": "MuiGrid-spacing-xs-9",
-                "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
-                "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
-                "zeroMinWidth": "MuiGrid-zeroMinWidth",
-              }
-            }
             container={true}
             direction="column"
             item={true}
             justify="center"
+            spacing={2}
             xs={10}
           >
-            <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-direction-xs-column MuiGrid-justify-xs-center MuiGrid-grid-xs-10"
+            <ForwardRef(Grid)
+              alignItems="stretch"
+              classes={
+                Object {
+                  "align-content-xs-center": "MuiGrid-align-content-xs-center",
+                  "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
+                  "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
+                  "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
+                  "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
+                  "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
+                  "align-items-xs-center": "MuiGrid-align-items-xs-center",
+                  "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
+                  "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
+                  "container": "MuiGrid-container",
+                  "direction-xs-column": "MuiGrid-direction-xs-column",
+                  "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
+                  "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
+                  "grid-lg-1": "MuiGrid-grid-lg-1",
+                  "grid-lg-10": "MuiGrid-grid-lg-10",
+                  "grid-lg-11": "MuiGrid-grid-lg-11",
+                  "grid-lg-12": "MuiGrid-grid-lg-12",
+                  "grid-lg-2": "MuiGrid-grid-lg-2",
+                  "grid-lg-3": "MuiGrid-grid-lg-3",
+                  "grid-lg-4": "MuiGrid-grid-lg-4",
+                  "grid-lg-5": "MuiGrid-grid-lg-5",
+                  "grid-lg-6": "MuiGrid-grid-lg-6",
+                  "grid-lg-7": "MuiGrid-grid-lg-7",
+                  "grid-lg-8": "MuiGrid-grid-lg-8",
+                  "grid-lg-9": "MuiGrid-grid-lg-9",
+                  "grid-lg-auto": "MuiGrid-grid-lg-auto",
+                  "grid-lg-true": "MuiGrid-grid-lg-true",
+                  "grid-md-1": "MuiGrid-grid-md-1",
+                  "grid-md-10": "MuiGrid-grid-md-10",
+                  "grid-md-11": "MuiGrid-grid-md-11",
+                  "grid-md-12": "MuiGrid-grid-md-12",
+                  "grid-md-2": "MuiGrid-grid-md-2",
+                  "grid-md-3": "MuiGrid-grid-md-3",
+                  "grid-md-4": "MuiGrid-grid-md-4",
+                  "grid-md-5": "MuiGrid-grid-md-5",
+                  "grid-md-6": "MuiGrid-grid-md-6",
+                  "grid-md-7": "MuiGrid-grid-md-7",
+                  "grid-md-8": "MuiGrid-grid-md-8",
+                  "grid-md-9": "MuiGrid-grid-md-9",
+                  "grid-md-auto": "MuiGrid-grid-md-auto",
+                  "grid-md-true": "MuiGrid-grid-md-true",
+                  "grid-sm-1": "MuiGrid-grid-sm-1",
+                  "grid-sm-10": "MuiGrid-grid-sm-10",
+                  "grid-sm-11": "MuiGrid-grid-sm-11",
+                  "grid-sm-12": "MuiGrid-grid-sm-12",
+                  "grid-sm-2": "MuiGrid-grid-sm-2",
+                  "grid-sm-3": "MuiGrid-grid-sm-3",
+                  "grid-sm-4": "MuiGrid-grid-sm-4",
+                  "grid-sm-5": "MuiGrid-grid-sm-5",
+                  "grid-sm-6": "MuiGrid-grid-sm-6",
+                  "grid-sm-7": "MuiGrid-grid-sm-7",
+                  "grid-sm-8": "MuiGrid-grid-sm-8",
+                  "grid-sm-9": "MuiGrid-grid-sm-9",
+                  "grid-sm-auto": "MuiGrid-grid-sm-auto",
+                  "grid-sm-true": "MuiGrid-grid-sm-true",
+                  "grid-xl-1": "MuiGrid-grid-xl-1",
+                  "grid-xl-10": "MuiGrid-grid-xl-10",
+                  "grid-xl-11": "MuiGrid-grid-xl-11",
+                  "grid-xl-12": "MuiGrid-grid-xl-12",
+                  "grid-xl-2": "MuiGrid-grid-xl-2",
+                  "grid-xl-3": "MuiGrid-grid-xl-3",
+                  "grid-xl-4": "MuiGrid-grid-xl-4",
+                  "grid-xl-5": "MuiGrid-grid-xl-5",
+                  "grid-xl-6": "MuiGrid-grid-xl-6",
+                  "grid-xl-7": "MuiGrid-grid-xl-7",
+                  "grid-xl-8": "MuiGrid-grid-xl-8",
+                  "grid-xl-9": "MuiGrid-grid-xl-9",
+                  "grid-xl-auto": "MuiGrid-grid-xl-auto",
+                  "grid-xl-true": "MuiGrid-grid-xl-true",
+                  "grid-xs-1": "MuiGrid-grid-xs-1",
+                  "grid-xs-10": "MuiGrid-grid-xs-10",
+                  "grid-xs-11": "MuiGrid-grid-xs-11",
+                  "grid-xs-12": "MuiGrid-grid-xs-12",
+                  "grid-xs-2": "MuiGrid-grid-xs-2",
+                  "grid-xs-3": "MuiGrid-grid-xs-3",
+                  "grid-xs-4": "MuiGrid-grid-xs-4",
+                  "grid-xs-5": "MuiGrid-grid-xs-5",
+                  "grid-xs-6": "MuiGrid-grid-xs-6",
+                  "grid-xs-7": "MuiGrid-grid-xs-7",
+                  "grid-xs-8": "MuiGrid-grid-xs-8",
+                  "grid-xs-9": "MuiGrid-grid-xs-9",
+                  "grid-xs-auto": "MuiGrid-grid-xs-auto",
+                  "grid-xs-true": "MuiGrid-grid-xs-true",
+                  "item": "MuiGrid-item",
+                  "justify-xs-center": "MuiGrid-justify-xs-center",
+                  "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
+                  "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
+                  "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
+                  "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
+                  "root": "MuiGrid-root",
+                  "spacing-xs-1": "MuiGrid-spacing-xs-1",
+                  "spacing-xs-10": "MuiGrid-spacing-xs-10",
+                  "spacing-xs-2": "MuiGrid-spacing-xs-2",
+                  "spacing-xs-3": "MuiGrid-spacing-xs-3",
+                  "spacing-xs-4": "MuiGrid-spacing-xs-4",
+                  "spacing-xs-5": "MuiGrid-spacing-xs-5",
+                  "spacing-xs-6": "MuiGrid-spacing-xs-6",
+                  "spacing-xs-7": "MuiGrid-spacing-xs-7",
+                  "spacing-xs-8": "MuiGrid-spacing-xs-8",
+                  "spacing-xs-9": "MuiGrid-spacing-xs-9",
+                  "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
+                  "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
+                  "zeroMinWidth": "MuiGrid-zeroMinWidth",
+                }
+              }
+              container={true}
+              direction="column"
+              item={true}
+              justify="center"
+              spacing={2}
+              xs={10}
             >
-              <WithStyles(ForwardRef(Grid))
-                container={true}
-                direction="row"
-                item={true}
-                justify="flex-end"
+              <div
+                className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-item MuiGrid-direction-xs-column MuiGrid-justify-xs-center MuiGrid-grid-xs-10"
               >
-                <ForwardRef(Grid)
-                  classes={
-                    Object {
-                      "align-content-xs-center": "MuiGrid-align-content-xs-center",
-                      "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
-                      "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
-                      "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
-                      "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
-                      "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
-                      "align-items-xs-center": "MuiGrid-align-items-xs-center",
-                      "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
-                      "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
-                      "container": "MuiGrid-container",
-                      "direction-xs-column": "MuiGrid-direction-xs-column",
-                      "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
-                      "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
-                      "grid-lg-1": "MuiGrid-grid-lg-1",
-                      "grid-lg-10": "MuiGrid-grid-lg-10",
-                      "grid-lg-11": "MuiGrid-grid-lg-11",
-                      "grid-lg-12": "MuiGrid-grid-lg-12",
-                      "grid-lg-2": "MuiGrid-grid-lg-2",
-                      "grid-lg-3": "MuiGrid-grid-lg-3",
-                      "grid-lg-4": "MuiGrid-grid-lg-4",
-                      "grid-lg-5": "MuiGrid-grid-lg-5",
-                      "grid-lg-6": "MuiGrid-grid-lg-6",
-                      "grid-lg-7": "MuiGrid-grid-lg-7",
-                      "grid-lg-8": "MuiGrid-grid-lg-8",
-                      "grid-lg-9": "MuiGrid-grid-lg-9",
-                      "grid-lg-auto": "MuiGrid-grid-lg-auto",
-                      "grid-lg-true": "MuiGrid-grid-lg-true",
-                      "grid-md-1": "MuiGrid-grid-md-1",
-                      "grid-md-10": "MuiGrid-grid-md-10",
-                      "grid-md-11": "MuiGrid-grid-md-11",
-                      "grid-md-12": "MuiGrid-grid-md-12",
-                      "grid-md-2": "MuiGrid-grid-md-2",
-                      "grid-md-3": "MuiGrid-grid-md-3",
-                      "grid-md-4": "MuiGrid-grid-md-4",
-                      "grid-md-5": "MuiGrid-grid-md-5",
-                      "grid-md-6": "MuiGrid-grid-md-6",
-                      "grid-md-7": "MuiGrid-grid-md-7",
-                      "grid-md-8": "MuiGrid-grid-md-8",
-                      "grid-md-9": "MuiGrid-grid-md-9",
-                      "grid-md-auto": "MuiGrid-grid-md-auto",
-                      "grid-md-true": "MuiGrid-grid-md-true",
-                      "grid-sm-1": "MuiGrid-grid-sm-1",
-                      "grid-sm-10": "MuiGrid-grid-sm-10",
-                      "grid-sm-11": "MuiGrid-grid-sm-11",
-                      "grid-sm-12": "MuiGrid-grid-sm-12",
-                      "grid-sm-2": "MuiGrid-grid-sm-2",
-                      "grid-sm-3": "MuiGrid-grid-sm-3",
-                      "grid-sm-4": "MuiGrid-grid-sm-4",
-                      "grid-sm-5": "MuiGrid-grid-sm-5",
-                      "grid-sm-6": "MuiGrid-grid-sm-6",
-                      "grid-sm-7": "MuiGrid-grid-sm-7",
-                      "grid-sm-8": "MuiGrid-grid-sm-8",
-                      "grid-sm-9": "MuiGrid-grid-sm-9",
-                      "grid-sm-auto": "MuiGrid-grid-sm-auto",
-                      "grid-sm-true": "MuiGrid-grid-sm-true",
-                      "grid-xl-1": "MuiGrid-grid-xl-1",
-                      "grid-xl-10": "MuiGrid-grid-xl-10",
-                      "grid-xl-11": "MuiGrid-grid-xl-11",
-                      "grid-xl-12": "MuiGrid-grid-xl-12",
-                      "grid-xl-2": "MuiGrid-grid-xl-2",
-                      "grid-xl-3": "MuiGrid-grid-xl-3",
-                      "grid-xl-4": "MuiGrid-grid-xl-4",
-                      "grid-xl-5": "MuiGrid-grid-xl-5",
-                      "grid-xl-6": "MuiGrid-grid-xl-6",
-                      "grid-xl-7": "MuiGrid-grid-xl-7",
-                      "grid-xl-8": "MuiGrid-grid-xl-8",
-                      "grid-xl-9": "MuiGrid-grid-xl-9",
-                      "grid-xl-auto": "MuiGrid-grid-xl-auto",
-                      "grid-xl-true": "MuiGrid-grid-xl-true",
-                      "grid-xs-1": "MuiGrid-grid-xs-1",
-                      "grid-xs-10": "MuiGrid-grid-xs-10",
-                      "grid-xs-11": "MuiGrid-grid-xs-11",
-                      "grid-xs-12": "MuiGrid-grid-xs-12",
-                      "grid-xs-2": "MuiGrid-grid-xs-2",
-                      "grid-xs-3": "MuiGrid-grid-xs-3",
-                      "grid-xs-4": "MuiGrid-grid-xs-4",
-                      "grid-xs-5": "MuiGrid-grid-xs-5",
-                      "grid-xs-6": "MuiGrid-grid-xs-6",
-                      "grid-xs-7": "MuiGrid-grid-xs-7",
-                      "grid-xs-8": "MuiGrid-grid-xs-8",
-                      "grid-xs-9": "MuiGrid-grid-xs-9",
-                      "grid-xs-auto": "MuiGrid-grid-xs-auto",
-                      "grid-xs-true": "MuiGrid-grid-xs-true",
-                      "item": "MuiGrid-item",
-                      "justify-xs-center": "MuiGrid-justify-xs-center",
-                      "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
-                      "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
-                      "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
-                      "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
-                      "root": "MuiGrid-root",
-                      "spacing-xs-1": "MuiGrid-spacing-xs-1",
-                      "spacing-xs-10": "MuiGrid-spacing-xs-10",
-                      "spacing-xs-2": "MuiGrid-spacing-xs-2",
-                      "spacing-xs-3": "MuiGrid-spacing-xs-3",
-                      "spacing-xs-4": "MuiGrid-spacing-xs-4",
-                      "spacing-xs-5": "MuiGrid-spacing-xs-5",
-                      "spacing-xs-6": "MuiGrid-spacing-xs-6",
-                      "spacing-xs-7": "MuiGrid-spacing-xs-7",
-                      "spacing-xs-8": "MuiGrid-spacing-xs-8",
-                      "spacing-xs-9": "MuiGrid-spacing-xs-9",
-                      "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
-                      "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
-                      "zeroMinWidth": "MuiGrid-zeroMinWidth",
-                    }
-                  }
+                <WithStyles(ForwardRef(Grid))
                   container={true}
                   direction="row"
                   item={true}
-                  justify="flex-end"
+                  justify="space-between"
                 >
-                  <div
-                    className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end"
+                  <ForwardRef(Grid)
+                    classes={
+                      Object {
+                        "align-content-xs-center": "MuiGrid-align-content-xs-center",
+                        "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
+                        "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
+                        "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
+                        "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
+                        "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
+                        "align-items-xs-center": "MuiGrid-align-items-xs-center",
+                        "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
+                        "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
+                        "container": "MuiGrid-container",
+                        "direction-xs-column": "MuiGrid-direction-xs-column",
+                        "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
+                        "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
+                        "grid-lg-1": "MuiGrid-grid-lg-1",
+                        "grid-lg-10": "MuiGrid-grid-lg-10",
+                        "grid-lg-11": "MuiGrid-grid-lg-11",
+                        "grid-lg-12": "MuiGrid-grid-lg-12",
+                        "grid-lg-2": "MuiGrid-grid-lg-2",
+                        "grid-lg-3": "MuiGrid-grid-lg-3",
+                        "grid-lg-4": "MuiGrid-grid-lg-4",
+                        "grid-lg-5": "MuiGrid-grid-lg-5",
+                        "grid-lg-6": "MuiGrid-grid-lg-6",
+                        "grid-lg-7": "MuiGrid-grid-lg-7",
+                        "grid-lg-8": "MuiGrid-grid-lg-8",
+                        "grid-lg-9": "MuiGrid-grid-lg-9",
+                        "grid-lg-auto": "MuiGrid-grid-lg-auto",
+                        "grid-lg-true": "MuiGrid-grid-lg-true",
+                        "grid-md-1": "MuiGrid-grid-md-1",
+                        "grid-md-10": "MuiGrid-grid-md-10",
+                        "grid-md-11": "MuiGrid-grid-md-11",
+                        "grid-md-12": "MuiGrid-grid-md-12",
+                        "grid-md-2": "MuiGrid-grid-md-2",
+                        "grid-md-3": "MuiGrid-grid-md-3",
+                        "grid-md-4": "MuiGrid-grid-md-4",
+                        "grid-md-5": "MuiGrid-grid-md-5",
+                        "grid-md-6": "MuiGrid-grid-md-6",
+                        "grid-md-7": "MuiGrid-grid-md-7",
+                        "grid-md-8": "MuiGrid-grid-md-8",
+                        "grid-md-9": "MuiGrid-grid-md-9",
+                        "grid-md-auto": "MuiGrid-grid-md-auto",
+                        "grid-md-true": "MuiGrid-grid-md-true",
+                        "grid-sm-1": "MuiGrid-grid-sm-1",
+                        "grid-sm-10": "MuiGrid-grid-sm-10",
+                        "grid-sm-11": "MuiGrid-grid-sm-11",
+                        "grid-sm-12": "MuiGrid-grid-sm-12",
+                        "grid-sm-2": "MuiGrid-grid-sm-2",
+                        "grid-sm-3": "MuiGrid-grid-sm-3",
+                        "grid-sm-4": "MuiGrid-grid-sm-4",
+                        "grid-sm-5": "MuiGrid-grid-sm-5",
+                        "grid-sm-6": "MuiGrid-grid-sm-6",
+                        "grid-sm-7": "MuiGrid-grid-sm-7",
+                        "grid-sm-8": "MuiGrid-grid-sm-8",
+                        "grid-sm-9": "MuiGrid-grid-sm-9",
+                        "grid-sm-auto": "MuiGrid-grid-sm-auto",
+                        "grid-sm-true": "MuiGrid-grid-sm-true",
+                        "grid-xl-1": "MuiGrid-grid-xl-1",
+                        "grid-xl-10": "MuiGrid-grid-xl-10",
+                        "grid-xl-11": "MuiGrid-grid-xl-11",
+                        "grid-xl-12": "MuiGrid-grid-xl-12",
+                        "grid-xl-2": "MuiGrid-grid-xl-2",
+                        "grid-xl-3": "MuiGrid-grid-xl-3",
+                        "grid-xl-4": "MuiGrid-grid-xl-4",
+                        "grid-xl-5": "MuiGrid-grid-xl-5",
+                        "grid-xl-6": "MuiGrid-grid-xl-6",
+                        "grid-xl-7": "MuiGrid-grid-xl-7",
+                        "grid-xl-8": "MuiGrid-grid-xl-8",
+                        "grid-xl-9": "MuiGrid-grid-xl-9",
+                        "grid-xl-auto": "MuiGrid-grid-xl-auto",
+                        "grid-xl-true": "MuiGrid-grid-xl-true",
+                        "grid-xs-1": "MuiGrid-grid-xs-1",
+                        "grid-xs-10": "MuiGrid-grid-xs-10",
+                        "grid-xs-11": "MuiGrid-grid-xs-11",
+                        "grid-xs-12": "MuiGrid-grid-xs-12",
+                        "grid-xs-2": "MuiGrid-grid-xs-2",
+                        "grid-xs-3": "MuiGrid-grid-xs-3",
+                        "grid-xs-4": "MuiGrid-grid-xs-4",
+                        "grid-xs-5": "MuiGrid-grid-xs-5",
+                        "grid-xs-6": "MuiGrid-grid-xs-6",
+                        "grid-xs-7": "MuiGrid-grid-xs-7",
+                        "grid-xs-8": "MuiGrid-grid-xs-8",
+                        "grid-xs-9": "MuiGrid-grid-xs-9",
+                        "grid-xs-auto": "MuiGrid-grid-xs-auto",
+                        "grid-xs-true": "MuiGrid-grid-xs-true",
+                        "item": "MuiGrid-item",
+                        "justify-xs-center": "MuiGrid-justify-xs-center",
+                        "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
+                        "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
+                        "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
+                        "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
+                        "root": "MuiGrid-root",
+                        "spacing-xs-1": "MuiGrid-spacing-xs-1",
+                        "spacing-xs-10": "MuiGrid-spacing-xs-10",
+                        "spacing-xs-2": "MuiGrid-spacing-xs-2",
+                        "spacing-xs-3": "MuiGrid-spacing-xs-3",
+                        "spacing-xs-4": "MuiGrid-spacing-xs-4",
+                        "spacing-xs-5": "MuiGrid-spacing-xs-5",
+                        "spacing-xs-6": "MuiGrid-spacing-xs-6",
+                        "spacing-xs-7": "MuiGrid-spacing-xs-7",
+                        "spacing-xs-8": "MuiGrid-spacing-xs-8",
+                        "spacing-xs-9": "MuiGrid-spacing-xs-9",
+                        "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
+                        "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
+                        "zeroMinWidth": "MuiGrid-zeroMinWidth",
+                      }
+                    }
+                    container={true}
+                    direction="row"
+                    item={true}
+                    justify="space-between"
                   >
-                    <WithStyles(ForwardRef(Grid))
-                      item={true}
+                    <div
+                      className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-space-between"
                     >
-                      <ForwardRef(Grid)
-                        classes={
-                          Object {
-                            "align-content-xs-center": "MuiGrid-align-content-xs-center",
-                            "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
-                            "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
-                            "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
-                            "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
-                            "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
-                            "align-items-xs-center": "MuiGrid-align-items-xs-center",
-                            "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
-                            "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
-                            "container": "MuiGrid-container",
-                            "direction-xs-column": "MuiGrid-direction-xs-column",
-                            "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
-                            "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
-                            "grid-lg-1": "MuiGrid-grid-lg-1",
-                            "grid-lg-10": "MuiGrid-grid-lg-10",
-                            "grid-lg-11": "MuiGrid-grid-lg-11",
-                            "grid-lg-12": "MuiGrid-grid-lg-12",
-                            "grid-lg-2": "MuiGrid-grid-lg-2",
-                            "grid-lg-3": "MuiGrid-grid-lg-3",
-                            "grid-lg-4": "MuiGrid-grid-lg-4",
-                            "grid-lg-5": "MuiGrid-grid-lg-5",
-                            "grid-lg-6": "MuiGrid-grid-lg-6",
-                            "grid-lg-7": "MuiGrid-grid-lg-7",
-                            "grid-lg-8": "MuiGrid-grid-lg-8",
-                            "grid-lg-9": "MuiGrid-grid-lg-9",
-                            "grid-lg-auto": "MuiGrid-grid-lg-auto",
-                            "grid-lg-true": "MuiGrid-grid-lg-true",
-                            "grid-md-1": "MuiGrid-grid-md-1",
-                            "grid-md-10": "MuiGrid-grid-md-10",
-                            "grid-md-11": "MuiGrid-grid-md-11",
-                            "grid-md-12": "MuiGrid-grid-md-12",
-                            "grid-md-2": "MuiGrid-grid-md-2",
-                            "grid-md-3": "MuiGrid-grid-md-3",
-                            "grid-md-4": "MuiGrid-grid-md-4",
-                            "grid-md-5": "MuiGrid-grid-md-5",
-                            "grid-md-6": "MuiGrid-grid-md-6",
-                            "grid-md-7": "MuiGrid-grid-md-7",
-                            "grid-md-8": "MuiGrid-grid-md-8",
-                            "grid-md-9": "MuiGrid-grid-md-9",
-                            "grid-md-auto": "MuiGrid-grid-md-auto",
-                            "grid-md-true": "MuiGrid-grid-md-true",
-                            "grid-sm-1": "MuiGrid-grid-sm-1",
-                            "grid-sm-10": "MuiGrid-grid-sm-10",
-                            "grid-sm-11": "MuiGrid-grid-sm-11",
-                            "grid-sm-12": "MuiGrid-grid-sm-12",
-                            "grid-sm-2": "MuiGrid-grid-sm-2",
-                            "grid-sm-3": "MuiGrid-grid-sm-3",
-                            "grid-sm-4": "MuiGrid-grid-sm-4",
-                            "grid-sm-5": "MuiGrid-grid-sm-5",
-                            "grid-sm-6": "MuiGrid-grid-sm-6",
-                            "grid-sm-7": "MuiGrid-grid-sm-7",
-                            "grid-sm-8": "MuiGrid-grid-sm-8",
-                            "grid-sm-9": "MuiGrid-grid-sm-9",
-                            "grid-sm-auto": "MuiGrid-grid-sm-auto",
-                            "grid-sm-true": "MuiGrid-grid-sm-true",
-                            "grid-xl-1": "MuiGrid-grid-xl-1",
-                            "grid-xl-10": "MuiGrid-grid-xl-10",
-                            "grid-xl-11": "MuiGrid-grid-xl-11",
-                            "grid-xl-12": "MuiGrid-grid-xl-12",
-                            "grid-xl-2": "MuiGrid-grid-xl-2",
-                            "grid-xl-3": "MuiGrid-grid-xl-3",
-                            "grid-xl-4": "MuiGrid-grid-xl-4",
-                            "grid-xl-5": "MuiGrid-grid-xl-5",
-                            "grid-xl-6": "MuiGrid-grid-xl-6",
-                            "grid-xl-7": "MuiGrid-grid-xl-7",
-                            "grid-xl-8": "MuiGrid-grid-xl-8",
-                            "grid-xl-9": "MuiGrid-grid-xl-9",
-                            "grid-xl-auto": "MuiGrid-grid-xl-auto",
-                            "grid-xl-true": "MuiGrid-grid-xl-true",
-                            "grid-xs-1": "MuiGrid-grid-xs-1",
-                            "grid-xs-10": "MuiGrid-grid-xs-10",
-                            "grid-xs-11": "MuiGrid-grid-xs-11",
-                            "grid-xs-12": "MuiGrid-grid-xs-12",
-                            "grid-xs-2": "MuiGrid-grid-xs-2",
-                            "grid-xs-3": "MuiGrid-grid-xs-3",
-                            "grid-xs-4": "MuiGrid-grid-xs-4",
-                            "grid-xs-5": "MuiGrid-grid-xs-5",
-                            "grid-xs-6": "MuiGrid-grid-xs-6",
-                            "grid-xs-7": "MuiGrid-grid-xs-7",
-                            "grid-xs-8": "MuiGrid-grid-xs-8",
-                            "grid-xs-9": "MuiGrid-grid-xs-9",
-                            "grid-xs-auto": "MuiGrid-grid-xs-auto",
-                            "grid-xs-true": "MuiGrid-grid-xs-true",
-                            "item": "MuiGrid-item",
-                            "justify-xs-center": "MuiGrid-justify-xs-center",
-                            "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
-                            "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
-                            "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
-                            "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
-                            "root": "MuiGrid-root",
-                            "spacing-xs-1": "MuiGrid-spacing-xs-1",
-                            "spacing-xs-10": "MuiGrid-spacing-xs-10",
-                            "spacing-xs-2": "MuiGrid-spacing-xs-2",
-                            "spacing-xs-3": "MuiGrid-spacing-xs-3",
-                            "spacing-xs-4": "MuiGrid-spacing-xs-4",
-                            "spacing-xs-5": "MuiGrid-spacing-xs-5",
-                            "spacing-xs-6": "MuiGrid-spacing-xs-6",
-                            "spacing-xs-7": "MuiGrid-spacing-xs-7",
-                            "spacing-xs-8": "MuiGrid-spacing-xs-8",
-                            "spacing-xs-9": "MuiGrid-spacing-xs-9",
-                            "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
-                            "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
-                            "zeroMinWidth": "MuiGrid-zeroMinWidth",
-                          }
-                        }
+                      <WithStyles(ForwardRef(Grid))
                         item={true}
                       >
-                        <div
-                          className="MuiGrid-root MuiGrid-item"
+                        <ForwardRef(Grid)
+                          classes={
+                            Object {
+                              "align-content-xs-center": "MuiGrid-align-content-xs-center",
+                              "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
+                              "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
+                              "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
+                              "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
+                              "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
+                              "align-items-xs-center": "MuiGrid-align-items-xs-center",
+                              "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
+                              "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
+                              "container": "MuiGrid-container",
+                              "direction-xs-column": "MuiGrid-direction-xs-column",
+                              "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
+                              "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
+                              "grid-lg-1": "MuiGrid-grid-lg-1",
+                              "grid-lg-10": "MuiGrid-grid-lg-10",
+                              "grid-lg-11": "MuiGrid-grid-lg-11",
+                              "grid-lg-12": "MuiGrid-grid-lg-12",
+                              "grid-lg-2": "MuiGrid-grid-lg-2",
+                              "grid-lg-3": "MuiGrid-grid-lg-3",
+                              "grid-lg-4": "MuiGrid-grid-lg-4",
+                              "grid-lg-5": "MuiGrid-grid-lg-5",
+                              "grid-lg-6": "MuiGrid-grid-lg-6",
+                              "grid-lg-7": "MuiGrid-grid-lg-7",
+                              "grid-lg-8": "MuiGrid-grid-lg-8",
+                              "grid-lg-9": "MuiGrid-grid-lg-9",
+                              "grid-lg-auto": "MuiGrid-grid-lg-auto",
+                              "grid-lg-true": "MuiGrid-grid-lg-true",
+                              "grid-md-1": "MuiGrid-grid-md-1",
+                              "grid-md-10": "MuiGrid-grid-md-10",
+                              "grid-md-11": "MuiGrid-grid-md-11",
+                              "grid-md-12": "MuiGrid-grid-md-12",
+                              "grid-md-2": "MuiGrid-grid-md-2",
+                              "grid-md-3": "MuiGrid-grid-md-3",
+                              "grid-md-4": "MuiGrid-grid-md-4",
+                              "grid-md-5": "MuiGrid-grid-md-5",
+                              "grid-md-6": "MuiGrid-grid-md-6",
+                              "grid-md-7": "MuiGrid-grid-md-7",
+                              "grid-md-8": "MuiGrid-grid-md-8",
+                              "grid-md-9": "MuiGrid-grid-md-9",
+                              "grid-md-auto": "MuiGrid-grid-md-auto",
+                              "grid-md-true": "MuiGrid-grid-md-true",
+                              "grid-sm-1": "MuiGrid-grid-sm-1",
+                              "grid-sm-10": "MuiGrid-grid-sm-10",
+                              "grid-sm-11": "MuiGrid-grid-sm-11",
+                              "grid-sm-12": "MuiGrid-grid-sm-12",
+                              "grid-sm-2": "MuiGrid-grid-sm-2",
+                              "grid-sm-3": "MuiGrid-grid-sm-3",
+                              "grid-sm-4": "MuiGrid-grid-sm-4",
+                              "grid-sm-5": "MuiGrid-grid-sm-5",
+                              "grid-sm-6": "MuiGrid-grid-sm-6",
+                              "grid-sm-7": "MuiGrid-grid-sm-7",
+                              "grid-sm-8": "MuiGrid-grid-sm-8",
+                              "grid-sm-9": "MuiGrid-grid-sm-9",
+                              "grid-sm-auto": "MuiGrid-grid-sm-auto",
+                              "grid-sm-true": "MuiGrid-grid-sm-true",
+                              "grid-xl-1": "MuiGrid-grid-xl-1",
+                              "grid-xl-10": "MuiGrid-grid-xl-10",
+                              "grid-xl-11": "MuiGrid-grid-xl-11",
+                              "grid-xl-12": "MuiGrid-grid-xl-12",
+                              "grid-xl-2": "MuiGrid-grid-xl-2",
+                              "grid-xl-3": "MuiGrid-grid-xl-3",
+                              "grid-xl-4": "MuiGrid-grid-xl-4",
+                              "grid-xl-5": "MuiGrid-grid-xl-5",
+                              "grid-xl-6": "MuiGrid-grid-xl-6",
+                              "grid-xl-7": "MuiGrid-grid-xl-7",
+                              "grid-xl-8": "MuiGrid-grid-xl-8",
+                              "grid-xl-9": "MuiGrid-grid-xl-9",
+                              "grid-xl-auto": "MuiGrid-grid-xl-auto",
+                              "grid-xl-true": "MuiGrid-grid-xl-true",
+                              "grid-xs-1": "MuiGrid-grid-xs-1",
+                              "grid-xs-10": "MuiGrid-grid-xs-10",
+                              "grid-xs-11": "MuiGrid-grid-xs-11",
+                              "grid-xs-12": "MuiGrid-grid-xs-12",
+                              "grid-xs-2": "MuiGrid-grid-xs-2",
+                              "grid-xs-3": "MuiGrid-grid-xs-3",
+                              "grid-xs-4": "MuiGrid-grid-xs-4",
+                              "grid-xs-5": "MuiGrid-grid-xs-5",
+                              "grid-xs-6": "MuiGrid-grid-xs-6",
+                              "grid-xs-7": "MuiGrid-grid-xs-7",
+                              "grid-xs-8": "MuiGrid-grid-xs-8",
+                              "grid-xs-9": "MuiGrid-grid-xs-9",
+                              "grid-xs-auto": "MuiGrid-grid-xs-auto",
+                              "grid-xs-true": "MuiGrid-grid-xs-true",
+                              "item": "MuiGrid-item",
+                              "justify-xs-center": "MuiGrid-justify-xs-center",
+                              "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
+                              "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
+                              "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
+                              "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
+                              "root": "MuiGrid-root",
+                              "spacing-xs-1": "MuiGrid-spacing-xs-1",
+                              "spacing-xs-10": "MuiGrid-spacing-xs-10",
+                              "spacing-xs-2": "MuiGrid-spacing-xs-2",
+                              "spacing-xs-3": "MuiGrid-spacing-xs-3",
+                              "spacing-xs-4": "MuiGrid-spacing-xs-4",
+                              "spacing-xs-5": "MuiGrid-spacing-xs-5",
+                              "spacing-xs-6": "MuiGrid-spacing-xs-6",
+                              "spacing-xs-7": "MuiGrid-spacing-xs-7",
+                              "spacing-xs-8": "MuiGrid-spacing-xs-8",
+                              "spacing-xs-9": "MuiGrid-spacing-xs-9",
+                              "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
+                              "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
+                              "zeroMinWidth": "MuiGrid-zeroMinWidth",
+                            }
+                          }
+                          item={true}
                         >
-                          <WithStyles(ForwardRef(Button))
-                            color="default"
-                            onClick={[Function]}
+                          <div
+                            className="MuiGrid-root MuiGrid-item"
                           >
-                            <ForwardRef(Button)
-                              classes={
-                                Object {
-                                  "colorInherit": "MuiButton-colorInherit",
-                                  "contained": "MuiButton-contained",
-                                  "containedPrimary": "MuiButton-containedPrimary",
-                                  "containedSecondary": "MuiButton-containedSecondary",
-                                  "containedSizeLarge": "MuiButton-containedSizeLarge",
-                                  "containedSizeSmall": "MuiButton-containedSizeSmall",
-                                  "disableElevation": "MuiButton-disableElevation",
-                                  "disabled": "Mui-disabled",
-                                  "endIcon": "MuiButton-endIcon",
-                                  "focusVisible": "Mui-focusVisible",
-                                  "fullWidth": "MuiButton-fullWidth",
-                                  "iconSizeLarge": "MuiButton-iconSizeLarge",
-                                  "iconSizeMedium": "MuiButton-iconSizeMedium",
-                                  "iconSizeSmall": "MuiButton-iconSizeSmall",
-                                  "label": "MuiButton-label",
-                                  "outlined": "MuiButton-outlined",
-                                  "outlinedPrimary": "MuiButton-outlinedPrimary",
-                                  "outlinedSecondary": "MuiButton-outlinedSecondary",
-                                  "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                                  "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                                  "root": "MuiButton-root",
-                                  "sizeLarge": "MuiButton-sizeLarge",
-                                  "sizeSmall": "MuiButton-sizeSmall",
-                                  "startIcon": "MuiButton-startIcon",
-                                  "text": "MuiButton-text",
-                                  "textPrimary": "MuiButton-textPrimary",
-                                  "textSecondary": "MuiButton-textSecondary",
-                                  "textSizeLarge": "MuiButton-textSizeLarge",
-                                  "textSizeSmall": "MuiButton-textSizeSmall",
-                                }
-                              }
+                            <Styled(MuiBox)
+                              m={1}
+                            >
+                              <div
+                                className="MuiBox-root MuiBox-root-117"
+                              >
+                                <WithStyles(ForwardRef(Typography))
+                                  variant="h6"
+                                >
+                                  <ForwardRef(Typography)
+                                    classes={
+                                      Object {
+                                        "alignCenter": "MuiTypography-alignCenter",
+                                        "alignJustify": "MuiTypography-alignJustify",
+                                        "alignLeft": "MuiTypography-alignLeft",
+                                        "alignRight": "MuiTypography-alignRight",
+                                        "body1": "MuiTypography-body1",
+                                        "body2": "MuiTypography-body2",
+                                        "button": "MuiTypography-button",
+                                        "caption": "MuiTypography-caption",
+                                        "colorError": "MuiTypography-colorError",
+                                        "colorInherit": "MuiTypography-colorInherit",
+                                        "colorPrimary": "MuiTypography-colorPrimary",
+                                        "colorSecondary": "MuiTypography-colorSecondary",
+                                        "colorTextPrimary": "MuiTypography-colorTextPrimary",
+                                        "colorTextSecondary": "MuiTypography-colorTextSecondary",
+                                        "displayBlock": "MuiTypography-displayBlock",
+                                        "displayInline": "MuiTypography-displayInline",
+                                        "gutterBottom": "MuiTypography-gutterBottom",
+                                        "h1": "MuiTypography-h1",
+                                        "h2": "MuiTypography-h2",
+                                        "h3": "MuiTypography-h3",
+                                        "h4": "MuiTypography-h4",
+                                        "h5": "MuiTypography-h5",
+                                        "h6": "MuiTypography-h6",
+                                        "noWrap": "MuiTypography-noWrap",
+                                        "overline": "MuiTypography-overline",
+                                        "paragraph": "MuiTypography-paragraph",
+                                        "root": "MuiTypography-root",
+                                        "srOnly": "MuiTypography-srOnly",
+                                        "subtitle1": "MuiTypography-subtitle1",
+                                        "subtitle2": "MuiTypography-subtitle2",
+                                      }
+                                    }
+                                    variant="h6"
+                                  >
+                                    <h6
+                                      className="MuiTypography-root MuiTypography-h6"
+                                    />
+                                  </ForwardRef(Typography)>
+                                </WithStyles(ForwardRef(Typography))>
+                              </div>
+                            </Styled(MuiBox)>
+                          </div>
+                        </ForwardRef(Grid)>
+                      </WithStyles(ForwardRef(Grid))>
+                      <WithStyles(ForwardRef(Grid))
+                        item={true}
+                      >
+                        <ForwardRef(Grid)
+                          classes={
+                            Object {
+                              "align-content-xs-center": "MuiGrid-align-content-xs-center",
+                              "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
+                              "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
+                              "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
+                              "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
+                              "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
+                              "align-items-xs-center": "MuiGrid-align-items-xs-center",
+                              "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
+                              "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
+                              "container": "MuiGrid-container",
+                              "direction-xs-column": "MuiGrid-direction-xs-column",
+                              "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
+                              "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
+                              "grid-lg-1": "MuiGrid-grid-lg-1",
+                              "grid-lg-10": "MuiGrid-grid-lg-10",
+                              "grid-lg-11": "MuiGrid-grid-lg-11",
+                              "grid-lg-12": "MuiGrid-grid-lg-12",
+                              "grid-lg-2": "MuiGrid-grid-lg-2",
+                              "grid-lg-3": "MuiGrid-grid-lg-3",
+                              "grid-lg-4": "MuiGrid-grid-lg-4",
+                              "grid-lg-5": "MuiGrid-grid-lg-5",
+                              "grid-lg-6": "MuiGrid-grid-lg-6",
+                              "grid-lg-7": "MuiGrid-grid-lg-7",
+                              "grid-lg-8": "MuiGrid-grid-lg-8",
+                              "grid-lg-9": "MuiGrid-grid-lg-9",
+                              "grid-lg-auto": "MuiGrid-grid-lg-auto",
+                              "grid-lg-true": "MuiGrid-grid-lg-true",
+                              "grid-md-1": "MuiGrid-grid-md-1",
+                              "grid-md-10": "MuiGrid-grid-md-10",
+                              "grid-md-11": "MuiGrid-grid-md-11",
+                              "grid-md-12": "MuiGrid-grid-md-12",
+                              "grid-md-2": "MuiGrid-grid-md-2",
+                              "grid-md-3": "MuiGrid-grid-md-3",
+                              "grid-md-4": "MuiGrid-grid-md-4",
+                              "grid-md-5": "MuiGrid-grid-md-5",
+                              "grid-md-6": "MuiGrid-grid-md-6",
+                              "grid-md-7": "MuiGrid-grid-md-7",
+                              "grid-md-8": "MuiGrid-grid-md-8",
+                              "grid-md-9": "MuiGrid-grid-md-9",
+                              "grid-md-auto": "MuiGrid-grid-md-auto",
+                              "grid-md-true": "MuiGrid-grid-md-true",
+                              "grid-sm-1": "MuiGrid-grid-sm-1",
+                              "grid-sm-10": "MuiGrid-grid-sm-10",
+                              "grid-sm-11": "MuiGrid-grid-sm-11",
+                              "grid-sm-12": "MuiGrid-grid-sm-12",
+                              "grid-sm-2": "MuiGrid-grid-sm-2",
+                              "grid-sm-3": "MuiGrid-grid-sm-3",
+                              "grid-sm-4": "MuiGrid-grid-sm-4",
+                              "grid-sm-5": "MuiGrid-grid-sm-5",
+                              "grid-sm-6": "MuiGrid-grid-sm-6",
+                              "grid-sm-7": "MuiGrid-grid-sm-7",
+                              "grid-sm-8": "MuiGrid-grid-sm-8",
+                              "grid-sm-9": "MuiGrid-grid-sm-9",
+                              "grid-sm-auto": "MuiGrid-grid-sm-auto",
+                              "grid-sm-true": "MuiGrid-grid-sm-true",
+                              "grid-xl-1": "MuiGrid-grid-xl-1",
+                              "grid-xl-10": "MuiGrid-grid-xl-10",
+                              "grid-xl-11": "MuiGrid-grid-xl-11",
+                              "grid-xl-12": "MuiGrid-grid-xl-12",
+                              "grid-xl-2": "MuiGrid-grid-xl-2",
+                              "grid-xl-3": "MuiGrid-grid-xl-3",
+                              "grid-xl-4": "MuiGrid-grid-xl-4",
+                              "grid-xl-5": "MuiGrid-grid-xl-5",
+                              "grid-xl-6": "MuiGrid-grid-xl-6",
+                              "grid-xl-7": "MuiGrid-grid-xl-7",
+                              "grid-xl-8": "MuiGrid-grid-xl-8",
+                              "grid-xl-9": "MuiGrid-grid-xl-9",
+                              "grid-xl-auto": "MuiGrid-grid-xl-auto",
+                              "grid-xl-true": "MuiGrid-grid-xl-true",
+                              "grid-xs-1": "MuiGrid-grid-xs-1",
+                              "grid-xs-10": "MuiGrid-grid-xs-10",
+                              "grid-xs-11": "MuiGrid-grid-xs-11",
+                              "grid-xs-12": "MuiGrid-grid-xs-12",
+                              "grid-xs-2": "MuiGrid-grid-xs-2",
+                              "grid-xs-3": "MuiGrid-grid-xs-3",
+                              "grid-xs-4": "MuiGrid-grid-xs-4",
+                              "grid-xs-5": "MuiGrid-grid-xs-5",
+                              "grid-xs-6": "MuiGrid-grid-xs-6",
+                              "grid-xs-7": "MuiGrid-grid-xs-7",
+                              "grid-xs-8": "MuiGrid-grid-xs-8",
+                              "grid-xs-9": "MuiGrid-grid-xs-9",
+                              "grid-xs-auto": "MuiGrid-grid-xs-auto",
+                              "grid-xs-true": "MuiGrid-grid-xs-true",
+                              "item": "MuiGrid-item",
+                              "justify-xs-center": "MuiGrid-justify-xs-center",
+                              "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
+                              "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
+                              "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
+                              "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
+                              "root": "MuiGrid-root",
+                              "spacing-xs-1": "MuiGrid-spacing-xs-1",
+                              "spacing-xs-10": "MuiGrid-spacing-xs-10",
+                              "spacing-xs-2": "MuiGrid-spacing-xs-2",
+                              "spacing-xs-3": "MuiGrid-spacing-xs-3",
+                              "spacing-xs-4": "MuiGrid-spacing-xs-4",
+                              "spacing-xs-5": "MuiGrid-spacing-xs-5",
+                              "spacing-xs-6": "MuiGrid-spacing-xs-6",
+                              "spacing-xs-7": "MuiGrid-spacing-xs-7",
+                              "spacing-xs-8": "MuiGrid-spacing-xs-8",
+                              "spacing-xs-9": "MuiGrid-spacing-xs-9",
+                              "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
+                              "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
+                              "zeroMinWidth": "MuiGrid-zeroMinWidth",
+                            }
+                          }
+                          item={true}
+                        >
+                          <div
+                            className="MuiGrid-root MuiGrid-item"
+                          >
+                            <WithStyles(ForwardRef(Button))
                               color="default"
                               onClick={[Function]}
                             >
-                              <WithStyles(ForwardRef(ButtonBase))
-                                className="MuiButton-root MuiButton-text"
-                                component="button"
-                                disabled={false}
-                                focusRipple={true}
-                                focusVisibleClassName="Mui-focusVisible"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <ForwardRef(ButtonBase)
-                                  className="MuiButton-root MuiButton-text"
-                                  classes={
-                                    Object {
-                                      "disabled": "Mui-disabled",
-                                      "focusVisible": "Mui-focusVisible",
-                                      "root": "MuiButtonBase-root",
-                                    }
+                              <ForwardRef(Button)
+                                classes={
+                                  Object {
+                                    "colorInherit": "MuiButton-colorInherit",
+                                    "contained": "MuiButton-contained",
+                                    "containedPrimary": "MuiButton-containedPrimary",
+                                    "containedSecondary": "MuiButton-containedSecondary",
+                                    "containedSizeLarge": "MuiButton-containedSizeLarge",
+                                    "containedSizeSmall": "MuiButton-containedSizeSmall",
+                                    "disableElevation": "MuiButton-disableElevation",
+                                    "disabled": "Mui-disabled",
+                                    "endIcon": "MuiButton-endIcon",
+                                    "focusVisible": "Mui-focusVisible",
+                                    "fullWidth": "MuiButton-fullWidth",
+                                    "iconSizeLarge": "MuiButton-iconSizeLarge",
+                                    "iconSizeMedium": "MuiButton-iconSizeMedium",
+                                    "iconSizeSmall": "MuiButton-iconSizeSmall",
+                                    "label": "MuiButton-label",
+                                    "outlined": "MuiButton-outlined",
+                                    "outlinedPrimary": "MuiButton-outlinedPrimary",
+                                    "outlinedSecondary": "MuiButton-outlinedSecondary",
+                                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                                    "root": "MuiButton-root",
+                                    "sizeLarge": "MuiButton-sizeLarge",
+                                    "sizeSmall": "MuiButton-sizeSmall",
+                                    "startIcon": "MuiButton-startIcon",
+                                    "text": "MuiButton-text",
+                                    "textPrimary": "MuiButton-textPrimary",
+                                    "textSecondary": "MuiButton-textSecondary",
+                                    "textSizeLarge": "MuiButton-textSizeLarge",
+                                    "textSizeSmall": "MuiButton-textSizeSmall",
                                   }
+                                }
+                                color="default"
+                                onClick={[Function]}
+                              >
+                                <WithStyles(ForwardRef(ButtonBase))
+                                  className="MuiButton-root MuiButton-text"
                                   component="button"
                                   disabled={false}
                                   focusRipple={true}
@@ -929,541 +1105,539 @@ exports[`The MissionControl container renders on the page with no errors 1`] = `
                                   onClick={[Function]}
                                   type="button"
                                 >
-                                  <button
-                                    className="MuiButtonBase-root MuiButton-root MuiButton-text"
+                                  <ForwardRef(ButtonBase)
+                                    className="MuiButton-root MuiButton-text"
+                                    classes={
+                                      Object {
+                                        "disabled": "Mui-disabled",
+                                        "focusVisible": "Mui-focusVisible",
+                                        "root": "MuiButtonBase-root",
+                                      }
+                                    }
+                                    component="button"
                                     disabled={false}
-                                    onBlur={[Function]}
+                                    focusRipple={true}
+                                    focusVisibleClassName="Mui-focusVisible"
                                     onClick={[Function]}
-                                    onDragLeave={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onKeyUp={[Function]}
-                                    onMouseDown={[Function]}
-                                    onMouseLeave={[Function]}
-                                    onMouseUp={[Function]}
-                                    onTouchEnd={[Function]}
-                                    onTouchMove={[Function]}
-                                    onTouchStart={[Function]}
-                                    tabIndex={0}
                                     type="button"
                                   >
-                                    <span
-                                      className="MuiButton-label"
+                                    <button
+                                      className="MuiButtonBase-root MuiButton-root MuiButton-text"
+                                      disabled={false}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onDragLeave={[Function]}
+                                      onFocus={[Function]}
+                                      onKeyDown={[Function]}
+                                      onKeyUp={[Function]}
+                                      onMouseDown={[Function]}
+                                      onMouseLeave={[Function]}
+                                      onMouseUp={[Function]}
+                                      onTouchEnd={[Function]}
+                                      onTouchMove={[Function]}
+                                      onTouchStart={[Function]}
+                                      tabIndex={0}
+                                      type="button"
                                     >
-                                      <FormattedMessage
-                                        defaultMessage="Edit Project"
-                                        id="app.mission_control.edit"
-                                        values={Object {}}
+                                      <span
+                                        className="MuiButton-label"
                                       >
-                                        Edit Project
-                                      </FormattedMessage>
-                                    </span>
-                                    <WithStyles(memo)
-                                      center={false}
-                                    >
-                                      <ForwardRef(TouchRipple)
-                                        center={false}
-                                        classes={
-                                          Object {
-                                            "child": "MuiTouchRipple-child",
-                                            "childLeaving": "MuiTouchRipple-childLeaving",
-                                            "childPulsate": "MuiTouchRipple-childPulsate",
-                                            "ripple": "MuiTouchRipple-ripple",
-                                            "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                            "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                            "root": "MuiTouchRipple-root",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="MuiTouchRipple-root"
+                                        <FormattedMessage
+                                          defaultMessage="Edit Project"
+                                          id="app.mission_control.edit"
+                                          values={Object {}}
                                         >
-                                          <TransitionGroup
-                                            childFactory={[Function]}
-                                            component={null}
-                                            exit={true}
-                                          />
-                                        </span>
-                                      </ForwardRef(TouchRipple)>
-                                    </WithStyles(memo)>
-                                  </button>
-                                </ForwardRef(ButtonBase)>
-                              </WithStyles(ForwardRef(ButtonBase))>
-                            </ForwardRef(Button)>
-                          </WithStyles(ForwardRef(Button))>
-                        </div>
-                      </ForwardRef(Grid)>
-                    </WithStyles(ForwardRef(Grid))>
-                  </div>
-                </ForwardRef(Grid)>
-              </WithStyles(ForwardRef(Grid))>
-              <WithStyles(ForwardRef(Grid))
-                item={true}
-              >
-                <ForwardRef(Grid)
-                  classes={
-                    Object {
-                      "align-content-xs-center": "MuiGrid-align-content-xs-center",
-                      "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
-                      "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
-                      "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
-                      "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
-                      "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
-                      "align-items-xs-center": "MuiGrid-align-items-xs-center",
-                      "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
-                      "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
-                      "container": "MuiGrid-container",
-                      "direction-xs-column": "MuiGrid-direction-xs-column",
-                      "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
-                      "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
-                      "grid-lg-1": "MuiGrid-grid-lg-1",
-                      "grid-lg-10": "MuiGrid-grid-lg-10",
-                      "grid-lg-11": "MuiGrid-grid-lg-11",
-                      "grid-lg-12": "MuiGrid-grid-lg-12",
-                      "grid-lg-2": "MuiGrid-grid-lg-2",
-                      "grid-lg-3": "MuiGrid-grid-lg-3",
-                      "grid-lg-4": "MuiGrid-grid-lg-4",
-                      "grid-lg-5": "MuiGrid-grid-lg-5",
-                      "grid-lg-6": "MuiGrid-grid-lg-6",
-                      "grid-lg-7": "MuiGrid-grid-lg-7",
-                      "grid-lg-8": "MuiGrid-grid-lg-8",
-                      "grid-lg-9": "MuiGrid-grid-lg-9",
-                      "grid-lg-auto": "MuiGrid-grid-lg-auto",
-                      "grid-lg-true": "MuiGrid-grid-lg-true",
-                      "grid-md-1": "MuiGrid-grid-md-1",
-                      "grid-md-10": "MuiGrid-grid-md-10",
-                      "grid-md-11": "MuiGrid-grid-md-11",
-                      "grid-md-12": "MuiGrid-grid-md-12",
-                      "grid-md-2": "MuiGrid-grid-md-2",
-                      "grid-md-3": "MuiGrid-grid-md-3",
-                      "grid-md-4": "MuiGrid-grid-md-4",
-                      "grid-md-5": "MuiGrid-grid-md-5",
-                      "grid-md-6": "MuiGrid-grid-md-6",
-                      "grid-md-7": "MuiGrid-grid-md-7",
-                      "grid-md-8": "MuiGrid-grid-md-8",
-                      "grid-md-9": "MuiGrid-grid-md-9",
-                      "grid-md-auto": "MuiGrid-grid-md-auto",
-                      "grid-md-true": "MuiGrid-grid-md-true",
-                      "grid-sm-1": "MuiGrid-grid-sm-1",
-                      "grid-sm-10": "MuiGrid-grid-sm-10",
-                      "grid-sm-11": "MuiGrid-grid-sm-11",
-                      "grid-sm-12": "MuiGrid-grid-sm-12",
-                      "grid-sm-2": "MuiGrid-grid-sm-2",
-                      "grid-sm-3": "MuiGrid-grid-sm-3",
-                      "grid-sm-4": "MuiGrid-grid-sm-4",
-                      "grid-sm-5": "MuiGrid-grid-sm-5",
-                      "grid-sm-6": "MuiGrid-grid-sm-6",
-                      "grid-sm-7": "MuiGrid-grid-sm-7",
-                      "grid-sm-8": "MuiGrid-grid-sm-8",
-                      "grid-sm-9": "MuiGrid-grid-sm-9",
-                      "grid-sm-auto": "MuiGrid-grid-sm-auto",
-                      "grid-sm-true": "MuiGrid-grid-sm-true",
-                      "grid-xl-1": "MuiGrid-grid-xl-1",
-                      "grid-xl-10": "MuiGrid-grid-xl-10",
-                      "grid-xl-11": "MuiGrid-grid-xl-11",
-                      "grid-xl-12": "MuiGrid-grid-xl-12",
-                      "grid-xl-2": "MuiGrid-grid-xl-2",
-                      "grid-xl-3": "MuiGrid-grid-xl-3",
-                      "grid-xl-4": "MuiGrid-grid-xl-4",
-                      "grid-xl-5": "MuiGrid-grid-xl-5",
-                      "grid-xl-6": "MuiGrid-grid-xl-6",
-                      "grid-xl-7": "MuiGrid-grid-xl-7",
-                      "grid-xl-8": "MuiGrid-grid-xl-8",
-                      "grid-xl-9": "MuiGrid-grid-xl-9",
-                      "grid-xl-auto": "MuiGrid-grid-xl-auto",
-                      "grid-xl-true": "MuiGrid-grid-xl-true",
-                      "grid-xs-1": "MuiGrid-grid-xs-1",
-                      "grid-xs-10": "MuiGrid-grid-xs-10",
-                      "grid-xs-11": "MuiGrid-grid-xs-11",
-                      "grid-xs-12": "MuiGrid-grid-xs-12",
-                      "grid-xs-2": "MuiGrid-grid-xs-2",
-                      "grid-xs-3": "MuiGrid-grid-xs-3",
-                      "grid-xs-4": "MuiGrid-grid-xs-4",
-                      "grid-xs-5": "MuiGrid-grid-xs-5",
-                      "grid-xs-6": "MuiGrid-grid-xs-6",
-                      "grid-xs-7": "MuiGrid-grid-xs-7",
-                      "grid-xs-8": "MuiGrid-grid-xs-8",
-                      "grid-xs-9": "MuiGrid-grid-xs-9",
-                      "grid-xs-auto": "MuiGrid-grid-xs-auto",
-                      "grid-xs-true": "MuiGrid-grid-xs-true",
-                      "item": "MuiGrid-item",
-                      "justify-xs-center": "MuiGrid-justify-xs-center",
-                      "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
-                      "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
-                      "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
-                      "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
-                      "root": "MuiGrid-root",
-                      "spacing-xs-1": "MuiGrid-spacing-xs-1",
-                      "spacing-xs-10": "MuiGrid-spacing-xs-10",
-                      "spacing-xs-2": "MuiGrid-spacing-xs-2",
-                      "spacing-xs-3": "MuiGrid-spacing-xs-3",
-                      "spacing-xs-4": "MuiGrid-spacing-xs-4",
-                      "spacing-xs-5": "MuiGrid-spacing-xs-5",
-                      "spacing-xs-6": "MuiGrid-spacing-xs-6",
-                      "spacing-xs-7": "MuiGrid-spacing-xs-7",
-                      "spacing-xs-8": "MuiGrid-spacing-xs-8",
-                      "spacing-xs-9": "MuiGrid-spacing-xs-9",
-                      "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
-                      "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
-                      "zeroMinWidth": "MuiGrid-zeroMinWidth",
-                    }
-                  }
+                                          Edit Project
+                                        </FormattedMessage>
+                                      </span>
+                                      <WithStyles(memo)
+                                        center={false}
+                                      >
+                                        <ForwardRef(TouchRipple)
+                                          center={false}
+                                          classes={
+                                            Object {
+                                              "child": "MuiTouchRipple-child",
+                                              "childLeaving": "MuiTouchRipple-childLeaving",
+                                              "childPulsate": "MuiTouchRipple-childPulsate",
+                                              "ripple": "MuiTouchRipple-ripple",
+                                              "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                              "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                              "root": "MuiTouchRipple-root",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="MuiTouchRipple-root"
+                                          >
+                                            <TransitionGroup
+                                              childFactory={[Function]}
+                                              component={null}
+                                              exit={true}
+                                            />
+                                          </span>
+                                        </ForwardRef(TouchRipple)>
+                                      </WithStyles(memo)>
+                                    </button>
+                                  </ForwardRef(ButtonBase)>
+                                </WithStyles(ForwardRef(ButtonBase))>
+                              </ForwardRef(Button)>
+                            </WithStyles(ForwardRef(Button))>
+                          </div>
+                        </ForwardRef(Grid)>
+                      </WithStyles(ForwardRef(Grid))>
+                    </div>
+                  </ForwardRef(Grid)>
+                </WithStyles(ForwardRef(Grid))>
+                <WithStyles(ForwardRef(Grid))
                   item={true}
                 >
-                  <div
-                    className="MuiGrid-root MuiGrid-item"
-                  >
-                    <Component
-                      location={
-                        Object {
-                          "state": Object {
-                            "readOnly": false,
-                          },
-                        }
+                  <ForwardRef(Grid)
+                    classes={
+                      Object {
+                        "align-content-xs-center": "MuiGrid-align-content-xs-center",
+                        "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
+                        "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
+                        "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
+                        "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
+                        "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
+                        "align-items-xs-center": "MuiGrid-align-items-xs-center",
+                        "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
+                        "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
+                        "container": "MuiGrid-container",
+                        "direction-xs-column": "MuiGrid-direction-xs-column",
+                        "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
+                        "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
+                        "grid-lg-1": "MuiGrid-grid-lg-1",
+                        "grid-lg-10": "MuiGrid-grid-lg-10",
+                        "grid-lg-11": "MuiGrid-grid-lg-11",
+                        "grid-lg-12": "MuiGrid-grid-lg-12",
+                        "grid-lg-2": "MuiGrid-grid-lg-2",
+                        "grid-lg-3": "MuiGrid-grid-lg-3",
+                        "grid-lg-4": "MuiGrid-grid-lg-4",
+                        "grid-lg-5": "MuiGrid-grid-lg-5",
+                        "grid-lg-6": "MuiGrid-grid-lg-6",
+                        "grid-lg-7": "MuiGrid-grid-lg-7",
+                        "grid-lg-8": "MuiGrid-grid-lg-8",
+                        "grid-lg-9": "MuiGrid-grid-lg-9",
+                        "grid-lg-auto": "MuiGrid-grid-lg-auto",
+                        "grid-lg-true": "MuiGrid-grid-lg-true",
+                        "grid-md-1": "MuiGrid-grid-md-1",
+                        "grid-md-10": "MuiGrid-grid-md-10",
+                        "grid-md-11": "MuiGrid-grid-md-11",
+                        "grid-md-12": "MuiGrid-grid-md-12",
+                        "grid-md-2": "MuiGrid-grid-md-2",
+                        "grid-md-3": "MuiGrid-grid-md-3",
+                        "grid-md-4": "MuiGrid-grid-md-4",
+                        "grid-md-5": "MuiGrid-grid-md-5",
+                        "grid-md-6": "MuiGrid-grid-md-6",
+                        "grid-md-7": "MuiGrid-grid-md-7",
+                        "grid-md-8": "MuiGrid-grid-md-8",
+                        "grid-md-9": "MuiGrid-grid-md-9",
+                        "grid-md-auto": "MuiGrid-grid-md-auto",
+                        "grid-md-true": "MuiGrid-grid-md-true",
+                        "grid-sm-1": "MuiGrid-grid-sm-1",
+                        "grid-sm-10": "MuiGrid-grid-sm-10",
+                        "grid-sm-11": "MuiGrid-grid-sm-11",
+                        "grid-sm-12": "MuiGrid-grid-sm-12",
+                        "grid-sm-2": "MuiGrid-grid-sm-2",
+                        "grid-sm-3": "MuiGrid-grid-sm-3",
+                        "grid-sm-4": "MuiGrid-grid-sm-4",
+                        "grid-sm-5": "MuiGrid-grid-sm-5",
+                        "grid-sm-6": "MuiGrid-grid-sm-6",
+                        "grid-sm-7": "MuiGrid-grid-sm-7",
+                        "grid-sm-8": "MuiGrid-grid-sm-8",
+                        "grid-sm-9": "MuiGrid-grid-sm-9",
+                        "grid-sm-auto": "MuiGrid-grid-sm-auto",
+                        "grid-sm-true": "MuiGrid-grid-sm-true",
+                        "grid-xl-1": "MuiGrid-grid-xl-1",
+                        "grid-xl-10": "MuiGrid-grid-xl-10",
+                        "grid-xl-11": "MuiGrid-grid-xl-11",
+                        "grid-xl-12": "MuiGrid-grid-xl-12",
+                        "grid-xl-2": "MuiGrid-grid-xl-2",
+                        "grid-xl-3": "MuiGrid-grid-xl-3",
+                        "grid-xl-4": "MuiGrid-grid-xl-4",
+                        "grid-xl-5": "MuiGrid-grid-xl-5",
+                        "grid-xl-6": "MuiGrid-grid-xl-6",
+                        "grid-xl-7": "MuiGrid-grid-xl-7",
+                        "grid-xl-8": "MuiGrid-grid-xl-8",
+                        "grid-xl-9": "MuiGrid-grid-xl-9",
+                        "grid-xl-auto": "MuiGrid-grid-xl-auto",
+                        "grid-xl-true": "MuiGrid-grid-xl-true",
+                        "grid-xs-1": "MuiGrid-grid-xs-1",
+                        "grid-xs-10": "MuiGrid-grid-xs-10",
+                        "grid-xs-11": "MuiGrid-grid-xs-11",
+                        "grid-xs-12": "MuiGrid-grid-xs-12",
+                        "grid-xs-2": "MuiGrid-grid-xs-2",
+                        "grid-xs-3": "MuiGrid-grid-xs-3",
+                        "grid-xs-4": "MuiGrid-grid-xs-4",
+                        "grid-xs-5": "MuiGrid-grid-xs-5",
+                        "grid-xs-6": "MuiGrid-grid-xs-6",
+                        "grid-xs-7": "MuiGrid-grid-xs-7",
+                        "grid-xs-8": "MuiGrid-grid-xs-8",
+                        "grid-xs-9": "MuiGrid-grid-xs-9",
+                        "grid-xs-auto": "MuiGrid-grid-xs-auto",
+                        "grid-xs-true": "MuiGrid-grid-xs-true",
+                        "item": "MuiGrid-item",
+                        "justify-xs-center": "MuiGrid-justify-xs-center",
+                        "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
+                        "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
+                        "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
+                        "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
+                        "root": "MuiGrid-root",
+                        "spacing-xs-1": "MuiGrid-spacing-xs-1",
+                        "spacing-xs-10": "MuiGrid-spacing-xs-10",
+                        "spacing-xs-2": "MuiGrid-spacing-xs-2",
+                        "spacing-xs-3": "MuiGrid-spacing-xs-3",
+                        "spacing-xs-4": "MuiGrid-spacing-xs-4",
+                        "spacing-xs-5": "MuiGrid-spacing-xs-5",
+                        "spacing-xs-6": "MuiGrid-spacing-xs-6",
+                        "spacing-xs-7": "MuiGrid-spacing-xs-7",
+                        "spacing-xs-8": "MuiGrid-spacing-xs-8",
+                        "spacing-xs-9": "MuiGrid-spacing-xs-9",
+                        "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
+                        "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
+                        "zeroMinWidth": "MuiGrid-zeroMinWidth",
                       }
+                    }
+                    item={true}
+                  >
+                    <div
+                      className="MuiGrid-root MuiGrid-item"
                     >
-                      <div />
-                    </Component>
-                  </div>
-                </ForwardRef(Grid)>
-              </WithStyles(ForwardRef(Grid))>
-            </div>
-          </ForwardRef(Grid)>
-        </WithStyles(ForwardRef(Grid))>
-        <WithStyles(ForwardRef(Grid))
-          alignItems="stretch"
-          container={true}
-          direction="column"
-          item={true}
-          spacing={2}
-          xs={2}
-        >
-          <ForwardRef(Grid)
+                      <Component
+                        location={
+                          Object {
+                            "state": Object {
+                              "readOnly": false,
+                            },
+                          }
+                        }
+                      >
+                        <div />
+                      </Component>
+                    </div>
+                  </ForwardRef(Grid)>
+                </WithStyles(ForwardRef(Grid))>
+              </div>
+            </ForwardRef(Grid)>
+          </WithStyles(ForwardRef(Grid))>
+          <WithStyles(ForwardRef(Grid))
             alignItems="stretch"
-            classes={
-              Object {
-                "align-content-xs-center": "MuiGrid-align-content-xs-center",
-                "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
-                "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
-                "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
-                "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
-                "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
-                "align-items-xs-center": "MuiGrid-align-items-xs-center",
-                "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
-                "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
-                "container": "MuiGrid-container",
-                "direction-xs-column": "MuiGrid-direction-xs-column",
-                "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
-                "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
-                "grid-lg-1": "MuiGrid-grid-lg-1",
-                "grid-lg-10": "MuiGrid-grid-lg-10",
-                "grid-lg-11": "MuiGrid-grid-lg-11",
-                "grid-lg-12": "MuiGrid-grid-lg-12",
-                "grid-lg-2": "MuiGrid-grid-lg-2",
-                "grid-lg-3": "MuiGrid-grid-lg-3",
-                "grid-lg-4": "MuiGrid-grid-lg-4",
-                "grid-lg-5": "MuiGrid-grid-lg-5",
-                "grid-lg-6": "MuiGrid-grid-lg-6",
-                "grid-lg-7": "MuiGrid-grid-lg-7",
-                "grid-lg-8": "MuiGrid-grid-lg-8",
-                "grid-lg-9": "MuiGrid-grid-lg-9",
-                "grid-lg-auto": "MuiGrid-grid-lg-auto",
-                "grid-lg-true": "MuiGrid-grid-lg-true",
-                "grid-md-1": "MuiGrid-grid-md-1",
-                "grid-md-10": "MuiGrid-grid-md-10",
-                "grid-md-11": "MuiGrid-grid-md-11",
-                "grid-md-12": "MuiGrid-grid-md-12",
-                "grid-md-2": "MuiGrid-grid-md-2",
-                "grid-md-3": "MuiGrid-grid-md-3",
-                "grid-md-4": "MuiGrid-grid-md-4",
-                "grid-md-5": "MuiGrid-grid-md-5",
-                "grid-md-6": "MuiGrid-grid-md-6",
-                "grid-md-7": "MuiGrid-grid-md-7",
-                "grid-md-8": "MuiGrid-grid-md-8",
-                "grid-md-9": "MuiGrid-grid-md-9",
-                "grid-md-auto": "MuiGrid-grid-md-auto",
-                "grid-md-true": "MuiGrid-grid-md-true",
-                "grid-sm-1": "MuiGrid-grid-sm-1",
-                "grid-sm-10": "MuiGrid-grid-sm-10",
-                "grid-sm-11": "MuiGrid-grid-sm-11",
-                "grid-sm-12": "MuiGrid-grid-sm-12",
-                "grid-sm-2": "MuiGrid-grid-sm-2",
-                "grid-sm-3": "MuiGrid-grid-sm-3",
-                "grid-sm-4": "MuiGrid-grid-sm-4",
-                "grid-sm-5": "MuiGrid-grid-sm-5",
-                "grid-sm-6": "MuiGrid-grid-sm-6",
-                "grid-sm-7": "MuiGrid-grid-sm-7",
-                "grid-sm-8": "MuiGrid-grid-sm-8",
-                "grid-sm-9": "MuiGrid-grid-sm-9",
-                "grid-sm-auto": "MuiGrid-grid-sm-auto",
-                "grid-sm-true": "MuiGrid-grid-sm-true",
-                "grid-xl-1": "MuiGrid-grid-xl-1",
-                "grid-xl-10": "MuiGrid-grid-xl-10",
-                "grid-xl-11": "MuiGrid-grid-xl-11",
-                "grid-xl-12": "MuiGrid-grid-xl-12",
-                "grid-xl-2": "MuiGrid-grid-xl-2",
-                "grid-xl-3": "MuiGrid-grid-xl-3",
-                "grid-xl-4": "MuiGrid-grid-xl-4",
-                "grid-xl-5": "MuiGrid-grid-xl-5",
-                "grid-xl-6": "MuiGrid-grid-xl-6",
-                "grid-xl-7": "MuiGrid-grid-xl-7",
-                "grid-xl-8": "MuiGrid-grid-xl-8",
-                "grid-xl-9": "MuiGrid-grid-xl-9",
-                "grid-xl-auto": "MuiGrid-grid-xl-auto",
-                "grid-xl-true": "MuiGrid-grid-xl-true",
-                "grid-xs-1": "MuiGrid-grid-xs-1",
-                "grid-xs-10": "MuiGrid-grid-xs-10",
-                "grid-xs-11": "MuiGrid-grid-xs-11",
-                "grid-xs-12": "MuiGrid-grid-xs-12",
-                "grid-xs-2": "MuiGrid-grid-xs-2",
-                "grid-xs-3": "MuiGrid-grid-xs-3",
-                "grid-xs-4": "MuiGrid-grid-xs-4",
-                "grid-xs-5": "MuiGrid-grid-xs-5",
-                "grid-xs-6": "MuiGrid-grid-xs-6",
-                "grid-xs-7": "MuiGrid-grid-xs-7",
-                "grid-xs-8": "MuiGrid-grid-xs-8",
-                "grid-xs-9": "MuiGrid-grid-xs-9",
-                "grid-xs-auto": "MuiGrid-grid-xs-auto",
-                "grid-xs-true": "MuiGrid-grid-xs-true",
-                "item": "MuiGrid-item",
-                "justify-xs-center": "MuiGrid-justify-xs-center",
-                "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
-                "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
-                "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
-                "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
-                "root": "MuiGrid-root",
-                "spacing-xs-1": "MuiGrid-spacing-xs-1",
-                "spacing-xs-10": "MuiGrid-spacing-xs-10",
-                "spacing-xs-2": "MuiGrid-spacing-xs-2",
-                "spacing-xs-3": "MuiGrid-spacing-xs-3",
-                "spacing-xs-4": "MuiGrid-spacing-xs-4",
-                "spacing-xs-5": "MuiGrid-spacing-xs-5",
-                "spacing-xs-6": "MuiGrid-spacing-xs-6",
-                "spacing-xs-7": "MuiGrid-spacing-xs-7",
-                "spacing-xs-8": "MuiGrid-spacing-xs-8",
-                "spacing-xs-9": "MuiGrid-spacing-xs-9",
-                "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
-                "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
-                "zeroMinWidth": "MuiGrid-zeroMinWidth",
-              }
-            }
             container={true}
             direction="column"
             item={true}
             spacing={2}
             xs={2}
           >
-            <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-item MuiGrid-direction-xs-column MuiGrid-grid-xs-2"
+            <ForwardRef(Grid)
+              alignItems="stretch"
+              classes={
+                Object {
+                  "align-content-xs-center": "MuiGrid-align-content-xs-center",
+                  "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
+                  "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
+                  "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
+                  "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
+                  "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
+                  "align-items-xs-center": "MuiGrid-align-items-xs-center",
+                  "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
+                  "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
+                  "container": "MuiGrid-container",
+                  "direction-xs-column": "MuiGrid-direction-xs-column",
+                  "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
+                  "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
+                  "grid-lg-1": "MuiGrid-grid-lg-1",
+                  "grid-lg-10": "MuiGrid-grid-lg-10",
+                  "grid-lg-11": "MuiGrid-grid-lg-11",
+                  "grid-lg-12": "MuiGrid-grid-lg-12",
+                  "grid-lg-2": "MuiGrid-grid-lg-2",
+                  "grid-lg-3": "MuiGrid-grid-lg-3",
+                  "grid-lg-4": "MuiGrid-grid-lg-4",
+                  "grid-lg-5": "MuiGrid-grid-lg-5",
+                  "grid-lg-6": "MuiGrid-grid-lg-6",
+                  "grid-lg-7": "MuiGrid-grid-lg-7",
+                  "grid-lg-8": "MuiGrid-grid-lg-8",
+                  "grid-lg-9": "MuiGrid-grid-lg-9",
+                  "grid-lg-auto": "MuiGrid-grid-lg-auto",
+                  "grid-lg-true": "MuiGrid-grid-lg-true",
+                  "grid-md-1": "MuiGrid-grid-md-1",
+                  "grid-md-10": "MuiGrid-grid-md-10",
+                  "grid-md-11": "MuiGrid-grid-md-11",
+                  "grid-md-12": "MuiGrid-grid-md-12",
+                  "grid-md-2": "MuiGrid-grid-md-2",
+                  "grid-md-3": "MuiGrid-grid-md-3",
+                  "grid-md-4": "MuiGrid-grid-md-4",
+                  "grid-md-5": "MuiGrid-grid-md-5",
+                  "grid-md-6": "MuiGrid-grid-md-6",
+                  "grid-md-7": "MuiGrid-grid-md-7",
+                  "grid-md-8": "MuiGrid-grid-md-8",
+                  "grid-md-9": "MuiGrid-grid-md-9",
+                  "grid-md-auto": "MuiGrid-grid-md-auto",
+                  "grid-md-true": "MuiGrid-grid-md-true",
+                  "grid-sm-1": "MuiGrid-grid-sm-1",
+                  "grid-sm-10": "MuiGrid-grid-sm-10",
+                  "grid-sm-11": "MuiGrid-grid-sm-11",
+                  "grid-sm-12": "MuiGrid-grid-sm-12",
+                  "grid-sm-2": "MuiGrid-grid-sm-2",
+                  "grid-sm-3": "MuiGrid-grid-sm-3",
+                  "grid-sm-4": "MuiGrid-grid-sm-4",
+                  "grid-sm-5": "MuiGrid-grid-sm-5",
+                  "grid-sm-6": "MuiGrid-grid-sm-6",
+                  "grid-sm-7": "MuiGrid-grid-sm-7",
+                  "grid-sm-8": "MuiGrid-grid-sm-8",
+                  "grid-sm-9": "MuiGrid-grid-sm-9",
+                  "grid-sm-auto": "MuiGrid-grid-sm-auto",
+                  "grid-sm-true": "MuiGrid-grid-sm-true",
+                  "grid-xl-1": "MuiGrid-grid-xl-1",
+                  "grid-xl-10": "MuiGrid-grid-xl-10",
+                  "grid-xl-11": "MuiGrid-grid-xl-11",
+                  "grid-xl-12": "MuiGrid-grid-xl-12",
+                  "grid-xl-2": "MuiGrid-grid-xl-2",
+                  "grid-xl-3": "MuiGrid-grid-xl-3",
+                  "grid-xl-4": "MuiGrid-grid-xl-4",
+                  "grid-xl-5": "MuiGrid-grid-xl-5",
+                  "grid-xl-6": "MuiGrid-grid-xl-6",
+                  "grid-xl-7": "MuiGrid-grid-xl-7",
+                  "grid-xl-8": "MuiGrid-grid-xl-8",
+                  "grid-xl-9": "MuiGrid-grid-xl-9",
+                  "grid-xl-auto": "MuiGrid-grid-xl-auto",
+                  "grid-xl-true": "MuiGrid-grid-xl-true",
+                  "grid-xs-1": "MuiGrid-grid-xs-1",
+                  "grid-xs-10": "MuiGrid-grid-xs-10",
+                  "grid-xs-11": "MuiGrid-grid-xs-11",
+                  "grid-xs-12": "MuiGrid-grid-xs-12",
+                  "grid-xs-2": "MuiGrid-grid-xs-2",
+                  "grid-xs-3": "MuiGrid-grid-xs-3",
+                  "grid-xs-4": "MuiGrid-grid-xs-4",
+                  "grid-xs-5": "MuiGrid-grid-xs-5",
+                  "grid-xs-6": "MuiGrid-grid-xs-6",
+                  "grid-xs-7": "MuiGrid-grid-xs-7",
+                  "grid-xs-8": "MuiGrid-grid-xs-8",
+                  "grid-xs-9": "MuiGrid-grid-xs-9",
+                  "grid-xs-auto": "MuiGrid-grid-xs-auto",
+                  "grid-xs-true": "MuiGrid-grid-xs-true",
+                  "item": "MuiGrid-item",
+                  "justify-xs-center": "MuiGrid-justify-xs-center",
+                  "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
+                  "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
+                  "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
+                  "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
+                  "root": "MuiGrid-root",
+                  "spacing-xs-1": "MuiGrid-spacing-xs-1",
+                  "spacing-xs-10": "MuiGrid-spacing-xs-10",
+                  "spacing-xs-2": "MuiGrid-spacing-xs-2",
+                  "spacing-xs-3": "MuiGrid-spacing-xs-3",
+                  "spacing-xs-4": "MuiGrid-spacing-xs-4",
+                  "spacing-xs-5": "MuiGrid-spacing-xs-5",
+                  "spacing-xs-6": "MuiGrid-spacing-xs-6",
+                  "spacing-xs-7": "MuiGrid-spacing-xs-7",
+                  "spacing-xs-8": "MuiGrid-spacing-xs-8",
+                  "spacing-xs-9": "MuiGrid-spacing-xs-9",
+                  "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
+                  "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
+                  "zeroMinWidth": "MuiGrid-zeroMinWidth",
+                }
+              }
+              container={true}
+              direction="column"
+              item={true}
+              spacing={2}
+              xs={2}
             >
-              <WithStyles(ForwardRef(Grid))
-                item={true}
+              <div
+                className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-item MuiGrid-direction-xs-column MuiGrid-grid-xs-2"
               >
-                <ForwardRef(Grid)
-                  classes={
-                    Object {
-                      "align-content-xs-center": "MuiGrid-align-content-xs-center",
-                      "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
-                      "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
-                      "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
-                      "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
-                      "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
-                      "align-items-xs-center": "MuiGrid-align-items-xs-center",
-                      "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
-                      "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
-                      "container": "MuiGrid-container",
-                      "direction-xs-column": "MuiGrid-direction-xs-column",
-                      "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
-                      "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
-                      "grid-lg-1": "MuiGrid-grid-lg-1",
-                      "grid-lg-10": "MuiGrid-grid-lg-10",
-                      "grid-lg-11": "MuiGrid-grid-lg-11",
-                      "grid-lg-12": "MuiGrid-grid-lg-12",
-                      "grid-lg-2": "MuiGrid-grid-lg-2",
-                      "grid-lg-3": "MuiGrid-grid-lg-3",
-                      "grid-lg-4": "MuiGrid-grid-lg-4",
-                      "grid-lg-5": "MuiGrid-grid-lg-5",
-                      "grid-lg-6": "MuiGrid-grid-lg-6",
-                      "grid-lg-7": "MuiGrid-grid-lg-7",
-                      "grid-lg-8": "MuiGrid-grid-lg-8",
-                      "grid-lg-9": "MuiGrid-grid-lg-9",
-                      "grid-lg-auto": "MuiGrid-grid-lg-auto",
-                      "grid-lg-true": "MuiGrid-grid-lg-true",
-                      "grid-md-1": "MuiGrid-grid-md-1",
-                      "grid-md-10": "MuiGrid-grid-md-10",
-                      "grid-md-11": "MuiGrid-grid-md-11",
-                      "grid-md-12": "MuiGrid-grid-md-12",
-                      "grid-md-2": "MuiGrid-grid-md-2",
-                      "grid-md-3": "MuiGrid-grid-md-3",
-                      "grid-md-4": "MuiGrid-grid-md-4",
-                      "grid-md-5": "MuiGrid-grid-md-5",
-                      "grid-md-6": "MuiGrid-grid-md-6",
-                      "grid-md-7": "MuiGrid-grid-md-7",
-                      "grid-md-8": "MuiGrid-grid-md-8",
-                      "grid-md-9": "MuiGrid-grid-md-9",
-                      "grid-md-auto": "MuiGrid-grid-md-auto",
-                      "grid-md-true": "MuiGrid-grid-md-true",
-                      "grid-sm-1": "MuiGrid-grid-sm-1",
-                      "grid-sm-10": "MuiGrid-grid-sm-10",
-                      "grid-sm-11": "MuiGrid-grid-sm-11",
-                      "grid-sm-12": "MuiGrid-grid-sm-12",
-                      "grid-sm-2": "MuiGrid-grid-sm-2",
-                      "grid-sm-3": "MuiGrid-grid-sm-3",
-                      "grid-sm-4": "MuiGrid-grid-sm-4",
-                      "grid-sm-5": "MuiGrid-grid-sm-5",
-                      "grid-sm-6": "MuiGrid-grid-sm-6",
-                      "grid-sm-7": "MuiGrid-grid-sm-7",
-                      "grid-sm-8": "MuiGrid-grid-sm-8",
-                      "grid-sm-9": "MuiGrid-grid-sm-9",
-                      "grid-sm-auto": "MuiGrid-grid-sm-auto",
-                      "grid-sm-true": "MuiGrid-grid-sm-true",
-                      "grid-xl-1": "MuiGrid-grid-xl-1",
-                      "grid-xl-10": "MuiGrid-grid-xl-10",
-                      "grid-xl-11": "MuiGrid-grid-xl-11",
-                      "grid-xl-12": "MuiGrid-grid-xl-12",
-                      "grid-xl-2": "MuiGrid-grid-xl-2",
-                      "grid-xl-3": "MuiGrid-grid-xl-3",
-                      "grid-xl-4": "MuiGrid-grid-xl-4",
-                      "grid-xl-5": "MuiGrid-grid-xl-5",
-                      "grid-xl-6": "MuiGrid-grid-xl-6",
-                      "grid-xl-7": "MuiGrid-grid-xl-7",
-                      "grid-xl-8": "MuiGrid-grid-xl-8",
-                      "grid-xl-9": "MuiGrid-grid-xl-9",
-                      "grid-xl-auto": "MuiGrid-grid-xl-auto",
-                      "grid-xl-true": "MuiGrid-grid-xl-true",
-                      "grid-xs-1": "MuiGrid-grid-xs-1",
-                      "grid-xs-10": "MuiGrid-grid-xs-10",
-                      "grid-xs-11": "MuiGrid-grid-xs-11",
-                      "grid-xs-12": "MuiGrid-grid-xs-12",
-                      "grid-xs-2": "MuiGrid-grid-xs-2",
-                      "grid-xs-3": "MuiGrid-grid-xs-3",
-                      "grid-xs-4": "MuiGrid-grid-xs-4",
-                      "grid-xs-5": "MuiGrid-grid-xs-5",
-                      "grid-xs-6": "MuiGrid-grid-xs-6",
-                      "grid-xs-7": "MuiGrid-grid-xs-7",
-                      "grid-xs-8": "MuiGrid-grid-xs-8",
-                      "grid-xs-9": "MuiGrid-grid-xs-9",
-                      "grid-xs-auto": "MuiGrid-grid-xs-auto",
-                      "grid-xs-true": "MuiGrid-grid-xs-true",
-                      "item": "MuiGrid-item",
-                      "justify-xs-center": "MuiGrid-justify-xs-center",
-                      "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
-                      "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
-                      "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
-                      "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
-                      "root": "MuiGrid-root",
-                      "spacing-xs-1": "MuiGrid-spacing-xs-1",
-                      "spacing-xs-10": "MuiGrid-spacing-xs-10",
-                      "spacing-xs-2": "MuiGrid-spacing-xs-2",
-                      "spacing-xs-3": "MuiGrid-spacing-xs-3",
-                      "spacing-xs-4": "MuiGrid-spacing-xs-4",
-                      "spacing-xs-5": "MuiGrid-spacing-xs-5",
-                      "spacing-xs-6": "MuiGrid-spacing-xs-6",
-                      "spacing-xs-7": "MuiGrid-spacing-xs-7",
-                      "spacing-xs-8": "MuiGrid-spacing-xs-8",
-                      "spacing-xs-9": "MuiGrid-spacing-xs-9",
-                      "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
-                      "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
-                      "zeroMinWidth": "MuiGrid-zeroMinWidth",
-                    }
-                  }
+                <WithStyles(ForwardRef(Grid))
                   item={true}
                 >
-                  <div
-                    className="MuiGrid-root MuiGrid-item"
+                  <ForwardRef(Grid)
+                    classes={
+                      Object {
+                        "align-content-xs-center": "MuiGrid-align-content-xs-center",
+                        "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
+                        "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
+                        "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
+                        "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
+                        "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
+                        "align-items-xs-center": "MuiGrid-align-items-xs-center",
+                        "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
+                        "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
+                        "container": "MuiGrid-container",
+                        "direction-xs-column": "MuiGrid-direction-xs-column",
+                        "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
+                        "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
+                        "grid-lg-1": "MuiGrid-grid-lg-1",
+                        "grid-lg-10": "MuiGrid-grid-lg-10",
+                        "grid-lg-11": "MuiGrid-grid-lg-11",
+                        "grid-lg-12": "MuiGrid-grid-lg-12",
+                        "grid-lg-2": "MuiGrid-grid-lg-2",
+                        "grid-lg-3": "MuiGrid-grid-lg-3",
+                        "grid-lg-4": "MuiGrid-grid-lg-4",
+                        "grid-lg-5": "MuiGrid-grid-lg-5",
+                        "grid-lg-6": "MuiGrid-grid-lg-6",
+                        "grid-lg-7": "MuiGrid-grid-lg-7",
+                        "grid-lg-8": "MuiGrid-grid-lg-8",
+                        "grid-lg-9": "MuiGrid-grid-lg-9",
+                        "grid-lg-auto": "MuiGrid-grid-lg-auto",
+                        "grid-lg-true": "MuiGrid-grid-lg-true",
+                        "grid-md-1": "MuiGrid-grid-md-1",
+                        "grid-md-10": "MuiGrid-grid-md-10",
+                        "grid-md-11": "MuiGrid-grid-md-11",
+                        "grid-md-12": "MuiGrid-grid-md-12",
+                        "grid-md-2": "MuiGrid-grid-md-2",
+                        "grid-md-3": "MuiGrid-grid-md-3",
+                        "grid-md-4": "MuiGrid-grid-md-4",
+                        "grid-md-5": "MuiGrid-grid-md-5",
+                        "grid-md-6": "MuiGrid-grid-md-6",
+                        "grid-md-7": "MuiGrid-grid-md-7",
+                        "grid-md-8": "MuiGrid-grid-md-8",
+                        "grid-md-9": "MuiGrid-grid-md-9",
+                        "grid-md-auto": "MuiGrid-grid-md-auto",
+                        "grid-md-true": "MuiGrid-grid-md-true",
+                        "grid-sm-1": "MuiGrid-grid-sm-1",
+                        "grid-sm-10": "MuiGrid-grid-sm-10",
+                        "grid-sm-11": "MuiGrid-grid-sm-11",
+                        "grid-sm-12": "MuiGrid-grid-sm-12",
+                        "grid-sm-2": "MuiGrid-grid-sm-2",
+                        "grid-sm-3": "MuiGrid-grid-sm-3",
+                        "grid-sm-4": "MuiGrid-grid-sm-4",
+                        "grid-sm-5": "MuiGrid-grid-sm-5",
+                        "grid-sm-6": "MuiGrid-grid-sm-6",
+                        "grid-sm-7": "MuiGrid-grid-sm-7",
+                        "grid-sm-8": "MuiGrid-grid-sm-8",
+                        "grid-sm-9": "MuiGrid-grid-sm-9",
+                        "grid-sm-auto": "MuiGrid-grid-sm-auto",
+                        "grid-sm-true": "MuiGrid-grid-sm-true",
+                        "grid-xl-1": "MuiGrid-grid-xl-1",
+                        "grid-xl-10": "MuiGrid-grid-xl-10",
+                        "grid-xl-11": "MuiGrid-grid-xl-11",
+                        "grid-xl-12": "MuiGrid-grid-xl-12",
+                        "grid-xl-2": "MuiGrid-grid-xl-2",
+                        "grid-xl-3": "MuiGrid-grid-xl-3",
+                        "grid-xl-4": "MuiGrid-grid-xl-4",
+                        "grid-xl-5": "MuiGrid-grid-xl-5",
+                        "grid-xl-6": "MuiGrid-grid-xl-6",
+                        "grid-xl-7": "MuiGrid-grid-xl-7",
+                        "grid-xl-8": "MuiGrid-grid-xl-8",
+                        "grid-xl-9": "MuiGrid-grid-xl-9",
+                        "grid-xl-auto": "MuiGrid-grid-xl-auto",
+                        "grid-xl-true": "MuiGrid-grid-xl-true",
+                        "grid-xs-1": "MuiGrid-grid-xs-1",
+                        "grid-xs-10": "MuiGrid-grid-xs-10",
+                        "grid-xs-11": "MuiGrid-grid-xs-11",
+                        "grid-xs-12": "MuiGrid-grid-xs-12",
+                        "grid-xs-2": "MuiGrid-grid-xs-2",
+                        "grid-xs-3": "MuiGrid-grid-xs-3",
+                        "grid-xs-4": "MuiGrid-grid-xs-4",
+                        "grid-xs-5": "MuiGrid-grid-xs-5",
+                        "grid-xs-6": "MuiGrid-grid-xs-6",
+                        "grid-xs-7": "MuiGrid-grid-xs-7",
+                        "grid-xs-8": "MuiGrid-grid-xs-8",
+                        "grid-xs-9": "MuiGrid-grid-xs-9",
+                        "grid-xs-auto": "MuiGrid-grid-xs-auto",
+                        "grid-xs-true": "MuiGrid-grid-xs-true",
+                        "item": "MuiGrid-item",
+                        "justify-xs-center": "MuiGrid-justify-xs-center",
+                        "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
+                        "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
+                        "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
+                        "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
+                        "root": "MuiGrid-root",
+                        "spacing-xs-1": "MuiGrid-spacing-xs-1",
+                        "spacing-xs-10": "MuiGrid-spacing-xs-10",
+                        "spacing-xs-2": "MuiGrid-spacing-xs-2",
+                        "spacing-xs-3": "MuiGrid-spacing-xs-3",
+                        "spacing-xs-4": "MuiGrid-spacing-xs-4",
+                        "spacing-xs-5": "MuiGrid-spacing-xs-5",
+                        "spacing-xs-6": "MuiGrid-spacing-xs-6",
+                        "spacing-xs-7": "MuiGrid-spacing-xs-7",
+                        "spacing-xs-8": "MuiGrid-spacing-xs-8",
+                        "spacing-xs-9": "MuiGrid-spacing-xs-9",
+                        "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
+                        "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
+                        "zeroMinWidth": "MuiGrid-zeroMinWidth",
+                      }
+                    }
+                    item={true}
                   >
-                    <WithStyles(ForwardRef(ExpansionPanel))>
-                      <ForwardRef(ExpansionPanel)
-                        classes={
-                          Object {
-                            "disabled": "Mui-disabled",
-                            "expanded": "Mui-expanded",
-                            "root": "MuiExpansionPanel-root",
-                            "rounded": "MuiExpansionPanel-rounded",
-                          }
-                        }
-                      >
-                        <WithStyles(ForwardRef(Paper))
-                          className="MuiExpansionPanel-root MuiExpansionPanel-rounded"
-                          square={false}
-                        >
-                          <ForwardRef(Paper)
-                            className="MuiExpansionPanel-root MuiExpansionPanel-rounded"
-                            classes={
-                              Object {
-                                "elevation0": "MuiPaper-elevation0",
-                                "elevation1": "MuiPaper-elevation1",
-                                "elevation10": "MuiPaper-elevation10",
-                                "elevation11": "MuiPaper-elevation11",
-                                "elevation12": "MuiPaper-elevation12",
-                                "elevation13": "MuiPaper-elevation13",
-                                "elevation14": "MuiPaper-elevation14",
-                                "elevation15": "MuiPaper-elevation15",
-                                "elevation16": "MuiPaper-elevation16",
-                                "elevation17": "MuiPaper-elevation17",
-                                "elevation18": "MuiPaper-elevation18",
-                                "elevation19": "MuiPaper-elevation19",
-                                "elevation2": "MuiPaper-elevation2",
-                                "elevation20": "MuiPaper-elevation20",
-                                "elevation21": "MuiPaper-elevation21",
-                                "elevation22": "MuiPaper-elevation22",
-                                "elevation23": "MuiPaper-elevation23",
-                                "elevation24": "MuiPaper-elevation24",
-                                "elevation3": "MuiPaper-elevation3",
-                                "elevation4": "MuiPaper-elevation4",
-                                "elevation5": "MuiPaper-elevation5",
-                                "elevation6": "MuiPaper-elevation6",
-                                "elevation7": "MuiPaper-elevation7",
-                                "elevation8": "MuiPaper-elevation8",
-                                "elevation9": "MuiPaper-elevation9",
-                                "outlined": "MuiPaper-outlined",
-                                "root": "MuiPaper-root",
-                                "rounded": "MuiPaper-rounded",
-                              }
+                    <div
+                      className="MuiGrid-root MuiGrid-item"
+                    >
+                      <WithStyles(ForwardRef(ExpansionPanel))>
+                        <ForwardRef(ExpansionPanel)
+                          classes={
+                            Object {
+                              "disabled": "Mui-disabled",
+                              "expanded": "Mui-expanded",
+                              "root": "MuiExpansionPanel-root",
+                              "rounded": "MuiExpansionPanel-rounded",
                             }
+                          }
+                        >
+                          <WithStyles(ForwardRef(Paper))
+                            className="MuiExpansionPanel-root MuiExpansionPanel-rounded"
                             square={false}
                           >
-                            <div
-                              className="MuiPaper-root MuiExpansionPanel-root MuiExpansionPanel-rounded MuiPaper-elevation1 MuiPaper-rounded"
+                            <ForwardRef(Paper)
+                              className="MuiExpansionPanel-root MuiExpansionPanel-rounded"
+                              classes={
+                                Object {
+                                  "elevation0": "MuiPaper-elevation0",
+                                  "elevation1": "MuiPaper-elevation1",
+                                  "elevation10": "MuiPaper-elevation10",
+                                  "elevation11": "MuiPaper-elevation11",
+                                  "elevation12": "MuiPaper-elevation12",
+                                  "elevation13": "MuiPaper-elevation13",
+                                  "elevation14": "MuiPaper-elevation14",
+                                  "elevation15": "MuiPaper-elevation15",
+                                  "elevation16": "MuiPaper-elevation16",
+                                  "elevation17": "MuiPaper-elevation17",
+                                  "elevation18": "MuiPaper-elevation18",
+                                  "elevation19": "MuiPaper-elevation19",
+                                  "elevation2": "MuiPaper-elevation2",
+                                  "elevation20": "MuiPaper-elevation20",
+                                  "elevation21": "MuiPaper-elevation21",
+                                  "elevation22": "MuiPaper-elevation22",
+                                  "elevation23": "MuiPaper-elevation23",
+                                  "elevation24": "MuiPaper-elevation24",
+                                  "elevation3": "MuiPaper-elevation3",
+                                  "elevation4": "MuiPaper-elevation4",
+                                  "elevation5": "MuiPaper-elevation5",
+                                  "elevation6": "MuiPaper-elevation6",
+                                  "elevation7": "MuiPaper-elevation7",
+                                  "elevation8": "MuiPaper-elevation8",
+                                  "elevation9": "MuiPaper-elevation9",
+                                  "outlined": "MuiPaper-outlined",
+                                  "root": "MuiPaper-root",
+                                  "rounded": "MuiPaper-rounded",
+                                }
+                              }
+                              square={false}
                             >
-                              <WithStyles(ForwardRef(ExpansionPanelSummary))
-                                expandIcon={<Memo(ExpandMoreIcon) />}
-                                key=".0"
+                              <div
+                                className="MuiPaper-root MuiExpansionPanel-root MuiExpansionPanel-rounded MuiPaper-elevation1 MuiPaper-rounded"
                               >
-                                <ForwardRef(ExpansionPanelSummary)
-                                  classes={
-                                    Object {
-                                      "content": "MuiExpansionPanelSummary-content",
-                                      "disabled": "Mui-disabled",
-                                      "expandIcon": "MuiExpansionPanelSummary-expandIcon",
-                                      "expanded": "Mui-expanded",
-                                      "focused": "Mui-focused",
-                                      "root": "MuiExpansionPanelSummary-root",
-                                    }
-                                  }
+                                <WithStyles(ForwardRef(ExpansionPanelSummary))
                                   expandIcon={<Memo(ExpandMoreIcon) />}
+                                  key=".0"
                                 >
-                                  <WithStyles(ForwardRef(ButtonBase))
-                                    aria-expanded={false}
-                                    className="MuiExpansionPanelSummary-root"
-                                    component="div"
-                                    disableRipple={true}
-                                    disabled={false}
-                                    focusRipple={false}
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocusVisible={[Function]}
+                                  <ForwardRef(ExpansionPanelSummary)
+                                    classes={
+                                      Object {
+                                        "content": "MuiExpansionPanelSummary-content",
+                                        "disabled": "Mui-disabled",
+                                        "expandIcon": "MuiExpansionPanelSummary-expandIcon",
+                                        "expanded": "Mui-expanded",
+                                        "focused": "Mui-focused",
+                                        "root": "MuiExpansionPanelSummary-root",
+                                      }
+                                    }
+                                    expandIcon={<Memo(ExpandMoreIcon) />}
                                   >
-                                    <ForwardRef(ButtonBase)
+                                    <WithStyles(ForwardRef(ButtonBase))
                                       aria-expanded={false}
                                       className="MuiExpansionPanelSummary-root"
-                                      classes={
-                                        Object {
-                                          "disabled": "Mui-disabled",
-                                          "focusVisible": "Mui-focusVisible",
-                                          "root": "MuiButtonBase-root",
-                                        }
-                                      }
                                       component="div"
                                       disableRipple={true}
                                       disabled={false}
@@ -1472,545 +1646,545 @@ exports[`The MissionControl container renders on the page with no errors 1`] = `
                                       onClick={[Function]}
                                       onFocusVisible={[Function]}
                                     >
-                                      <div
-                                        aria-disabled={false}
+                                      <ForwardRef(ButtonBase)
                                         aria-expanded={false}
-                                        className="MuiButtonBase-root MuiExpansionPanelSummary-root"
+                                        className="MuiExpansionPanelSummary-root"
+                                        classes={
+                                          Object {
+                                            "disabled": "Mui-disabled",
+                                            "focusVisible": "Mui-focusVisible",
+                                            "root": "MuiButtonBase-root",
+                                          }
+                                        }
+                                        component="div"
+                                        disableRipple={true}
+                                        disabled={false}
+                                        focusRipple={false}
                                         onBlur={[Function]}
                                         onClick={[Function]}
-                                        onDragLeave={[Function]}
-                                        onFocus={[Function]}
-                                        onKeyDown={[Function]}
-                                        onKeyUp={[Function]}
-                                        onMouseDown={[Function]}
-                                        onMouseLeave={[Function]}
-                                        onMouseUp={[Function]}
-                                        onTouchEnd={[Function]}
-                                        onTouchMove={[Function]}
-                                        onTouchStart={[Function]}
-                                        role="button"
-                                        tabIndex={0}
+                                        onFocusVisible={[Function]}
                                       >
                                         <div
-                                          className="MuiExpansionPanelSummary-content"
+                                          aria-disabled={false}
+                                          aria-expanded={false}
+                                          className="MuiButtonBase-root MuiExpansionPanelSummary-root"
+                                          onBlur={[Function]}
+                                          onClick={[Function]}
+                                          onDragLeave={[Function]}
+                                          onFocus={[Function]}
+                                          onKeyDown={[Function]}
+                                          onKeyUp={[Function]}
+                                          onMouseDown={[Function]}
+                                          onMouseLeave={[Function]}
+                                          onMouseUp={[Function]}
+                                          onTouchEnd={[Function]}
+                                          onTouchMove={[Function]}
+                                          onTouchStart={[Function]}
+                                          role="button"
+                                          tabIndex={0}
                                         >
-                                          <WithStyles(ForwardRef(Typography))>
-                                            <ForwardRef(Typography)
-                                              classes={
-                                                Object {
-                                                  "alignCenter": "MuiTypography-alignCenter",
-                                                  "alignJustify": "MuiTypography-alignJustify",
-                                                  "alignLeft": "MuiTypography-alignLeft",
-                                                  "alignRight": "MuiTypography-alignRight",
-                                                  "body1": "MuiTypography-body1",
-                                                  "body2": "MuiTypography-body2",
-                                                  "button": "MuiTypography-button",
-                                                  "caption": "MuiTypography-caption",
-                                                  "colorError": "MuiTypography-colorError",
-                                                  "colorInherit": "MuiTypography-colorInherit",
-                                                  "colorPrimary": "MuiTypography-colorPrimary",
-                                                  "colorSecondary": "MuiTypography-colorSecondary",
-                                                  "colorTextPrimary": "MuiTypography-colorTextPrimary",
-                                                  "colorTextSecondary": "MuiTypography-colorTextSecondary",
-                                                  "displayBlock": "MuiTypography-displayBlock",
-                                                  "displayInline": "MuiTypography-displayInline",
-                                                  "gutterBottom": "MuiTypography-gutterBottom",
-                                                  "h1": "MuiTypography-h1",
-                                                  "h2": "MuiTypography-h2",
-                                                  "h3": "MuiTypography-h3",
-                                                  "h4": "MuiTypography-h4",
-                                                  "h5": "MuiTypography-h5",
-                                                  "h6": "MuiTypography-h6",
-                                                  "noWrap": "MuiTypography-noWrap",
-                                                  "overline": "MuiTypography-overline",
-                                                  "paragraph": "MuiTypography-paragraph",
-                                                  "root": "MuiTypography-root",
-                                                  "srOnly": "MuiTypography-srOnly",
-                                                  "subtitle1": "MuiTypography-subtitle1",
-                                                  "subtitle2": "MuiTypography-subtitle2",
+                                          <div
+                                            className="MuiExpansionPanelSummary-content"
+                                          >
+                                            <WithStyles(ForwardRef(Typography))>
+                                              <ForwardRef(Typography)
+                                                classes={
+                                                  Object {
+                                                    "alignCenter": "MuiTypography-alignCenter",
+                                                    "alignJustify": "MuiTypography-alignJustify",
+                                                    "alignLeft": "MuiTypography-alignLeft",
+                                                    "alignRight": "MuiTypography-alignRight",
+                                                    "body1": "MuiTypography-body1",
+                                                    "body2": "MuiTypography-body2",
+                                                    "button": "MuiTypography-button",
+                                                    "caption": "MuiTypography-caption",
+                                                    "colorError": "MuiTypography-colorError",
+                                                    "colorInherit": "MuiTypography-colorInherit",
+                                                    "colorPrimary": "MuiTypography-colorPrimary",
+                                                    "colorSecondary": "MuiTypography-colorSecondary",
+                                                    "colorTextPrimary": "MuiTypography-colorTextPrimary",
+                                                    "colorTextSecondary": "MuiTypography-colorTextSecondary",
+                                                    "displayBlock": "MuiTypography-displayBlock",
+                                                    "displayInline": "MuiTypography-displayInline",
+                                                    "gutterBottom": "MuiTypography-gutterBottom",
+                                                    "h1": "MuiTypography-h1",
+                                                    "h2": "MuiTypography-h2",
+                                                    "h3": "MuiTypography-h3",
+                                                    "h4": "MuiTypography-h4",
+                                                    "h5": "MuiTypography-h5",
+                                                    "h6": "MuiTypography-h6",
+                                                    "noWrap": "MuiTypography-noWrap",
+                                                    "overline": "MuiTypography-overline",
+                                                    "paragraph": "MuiTypography-paragraph",
+                                                    "root": "MuiTypography-root",
+                                                    "srOnly": "MuiTypography-srOnly",
+                                                    "subtitle1": "MuiTypography-subtitle1",
+                                                    "subtitle2": "MuiTypography-subtitle2",
+                                                  }
                                                 }
-                                              }
-                                            >
-                                              <p
-                                                className="MuiTypography-root MuiTypography-body1"
                                               >
-                                                <FormattedMessage
-                                                  defaultMessage="Sensors"
-                                                  id="app.mission_control.sensors"
-                                                  values={Object {}}
+                                                <p
+                                                  className="MuiTypography-root MuiTypography-body1"
                                                 >
-                                                  Sensors
-                                                </FormattedMessage>
-                                              </p>
-                                            </ForwardRef(Typography)>
-                                          </WithStyles(ForwardRef(Typography))>
-                                        </div>
-                                        <WithStyles(ForwardRef(IconButton))
-                                          aria-hidden={true}
-                                          className="MuiExpansionPanelSummary-expandIcon"
-                                          component="div"
-                                          edge="end"
-                                          role={null}
-                                          tabIndex={null}
-                                        >
-                                          <ForwardRef(IconButton)
+                                                  <FormattedMessage
+                                                    defaultMessage="Sensors"
+                                                    id="app.mission_control.sensors"
+                                                    values={Object {}}
+                                                  >
+                                                    Sensors
+                                                  </FormattedMessage>
+                                                </p>
+                                              </ForwardRef(Typography)>
+                                            </WithStyles(ForwardRef(Typography))>
+                                          </div>
+                                          <WithStyles(ForwardRef(IconButton))
                                             aria-hidden={true}
                                             className="MuiExpansionPanelSummary-expandIcon"
-                                            classes={
-                                              Object {
-                                                "colorInherit": "MuiIconButton-colorInherit",
-                                                "colorPrimary": "MuiIconButton-colorPrimary",
-                                                "colorSecondary": "MuiIconButton-colorSecondary",
-                                                "disabled": "Mui-disabled",
-                                                "edgeEnd": "MuiIconButton-edgeEnd",
-                                                "edgeStart": "MuiIconButton-edgeStart",
-                                                "label": "MuiIconButton-label",
-                                                "root": "MuiIconButton-root",
-                                                "sizeSmall": "MuiIconButton-sizeSmall",
-                                              }
-                                            }
                                             component="div"
                                             edge="end"
                                             role={null}
                                             tabIndex={null}
                                           >
-                                            <WithStyles(ForwardRef(ButtonBase))
+                                            <ForwardRef(IconButton)
                                               aria-hidden={true}
-                                              centerRipple={true}
-                                              className="MuiIconButton-root MuiExpansionPanelSummary-expandIcon MuiIconButton-edgeEnd"
+                                              className="MuiExpansionPanelSummary-expandIcon"
+                                              classes={
+                                                Object {
+                                                  "colorInherit": "MuiIconButton-colorInherit",
+                                                  "colorPrimary": "MuiIconButton-colorPrimary",
+                                                  "colorSecondary": "MuiIconButton-colorSecondary",
+                                                  "disabled": "Mui-disabled",
+                                                  "edgeEnd": "MuiIconButton-edgeEnd",
+                                                  "edgeStart": "MuiIconButton-edgeStart",
+                                                  "label": "MuiIconButton-label",
+                                                  "root": "MuiIconButton-root",
+                                                  "sizeSmall": "MuiIconButton-sizeSmall",
+                                                }
+                                              }
                                               component="div"
-                                              disabled={false}
-                                              focusRipple={true}
+                                              edge="end"
                                               role={null}
                                               tabIndex={null}
                                             >
-                                              <ForwardRef(ButtonBase)
+                                              <WithStyles(ForwardRef(ButtonBase))
                                                 aria-hidden={true}
                                                 centerRipple={true}
                                                 className="MuiIconButton-root MuiExpansionPanelSummary-expandIcon MuiIconButton-edgeEnd"
-                                                classes={
-                                                  Object {
-                                                    "disabled": "Mui-disabled",
-                                                    "focusVisible": "Mui-focusVisible",
-                                                    "root": "MuiButtonBase-root",
-                                                  }
-                                                }
                                                 component="div"
                                                 disabled={false}
                                                 focusRipple={true}
                                                 role={null}
                                                 tabIndex={null}
                                               >
-                                                <div
-                                                  aria-disabled={false}
+                                                <ForwardRef(ButtonBase)
                                                   aria-hidden={true}
-                                                  className="MuiButtonBase-root MuiIconButton-root MuiExpansionPanelSummary-expandIcon MuiIconButton-edgeEnd"
-                                                  onBlur={[Function]}
-                                                  onDragLeave={[Function]}
-                                                  onFocus={[Function]}
-                                                  onKeyDown={[Function]}
-                                                  onKeyUp={[Function]}
-                                                  onMouseDown={[Function]}
-                                                  onMouseLeave={[Function]}
-                                                  onMouseUp={[Function]}
-                                                  onTouchEnd={[Function]}
-                                                  onTouchMove={[Function]}
-                                                  onTouchStart={[Function]}
+                                                  centerRipple={true}
+                                                  className="MuiIconButton-root MuiExpansionPanelSummary-expandIcon MuiIconButton-edgeEnd"
+                                                  classes={
+                                                    Object {
+                                                      "disabled": "Mui-disabled",
+                                                      "focusVisible": "Mui-focusVisible",
+                                                      "root": "MuiButtonBase-root",
+                                                    }
+                                                  }
+                                                  component="div"
+                                                  disabled={false}
+                                                  focusRipple={true}
                                                   role={null}
                                                   tabIndex={null}
                                                 >
-                                                  <span
-                                                    className="MuiIconButton-label"
+                                                  <div
+                                                    aria-disabled={false}
+                                                    aria-hidden={true}
+                                                    className="MuiButtonBase-root MuiIconButton-root MuiExpansionPanelSummary-expandIcon MuiIconButton-edgeEnd"
+                                                    onBlur={[Function]}
+                                                    onDragLeave={[Function]}
+                                                    onFocus={[Function]}
+                                                    onKeyDown={[Function]}
+                                                    onKeyUp={[Function]}
+                                                    onMouseDown={[Function]}
+                                                    onMouseLeave={[Function]}
+                                                    onMouseUp={[Function]}
+                                                    onTouchEnd={[Function]}
+                                                    onTouchMove={[Function]}
+                                                    onTouchStart={[Function]}
+                                                    role={null}
+                                                    tabIndex={null}
                                                   >
-                                                    <ForwardRef>
-                                                      <WithStyles(ForwardRef(SvgIcon))>
-                                                        <ForwardRef(SvgIcon)
-                                                          classes={
-                                                            Object {
-                                                              "colorAction": "MuiSvgIcon-colorAction",
-                                                              "colorDisabled": "MuiSvgIcon-colorDisabled",
-                                                              "colorError": "MuiSvgIcon-colorError",
-                                                              "colorPrimary": "MuiSvgIcon-colorPrimary",
-                                                              "colorSecondary": "MuiSvgIcon-colorSecondary",
-                                                              "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                                                              "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                                                              "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                                                              "root": "MuiSvgIcon-root",
-                                                            }
-                                                          }
-                                                        >
-                                                          <svg
-                                                            aria-hidden="true"
-                                                            className="MuiSvgIcon-root"
-                                                            focusable="false"
-                                                            viewBox="0 0 24 24"
-                                                          >
-                                                            <path
-                                                              d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
-                                                            />
-                                                          </svg>
-                                                        </ForwardRef(SvgIcon)>
-                                                      </WithStyles(ForwardRef(SvgIcon))>
-                                                    </ForwardRef>
-                                                  </span>
-                                                  <WithStyles(memo)
-                                                    center={true}
-                                                  >
-                                                    <ForwardRef(TouchRipple)
-                                                      center={true}
-                                                      classes={
-                                                        Object {
-                                                          "child": "MuiTouchRipple-child",
-                                                          "childLeaving": "MuiTouchRipple-childLeaving",
-                                                          "childPulsate": "MuiTouchRipple-childPulsate",
-                                                          "ripple": "MuiTouchRipple-ripple",
-                                                          "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                          "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                          "root": "MuiTouchRipple-root",
-                                                        }
-                                                      }
+                                                    <span
+                                                      className="MuiIconButton-label"
                                                     >
-                                                      <span
-                                                        className="MuiTouchRipple-root"
+                                                      <ForwardRef>
+                                                        <WithStyles(ForwardRef(SvgIcon))>
+                                                          <ForwardRef(SvgIcon)
+                                                            classes={
+                                                              Object {
+                                                                "colorAction": "MuiSvgIcon-colorAction",
+                                                                "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                                                "colorError": "MuiSvgIcon-colorError",
+                                                                "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                                                "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                                                "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                                                "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                                                "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                                                "root": "MuiSvgIcon-root",
+                                                              }
+                                                            }
+                                                          >
+                                                            <svg
+                                                              aria-hidden="true"
+                                                              className="MuiSvgIcon-root"
+                                                              focusable="false"
+                                                              viewBox="0 0 24 24"
+                                                            >
+                                                              <path
+                                                                d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                                                              />
+                                                            </svg>
+                                                          </ForwardRef(SvgIcon)>
+                                                        </WithStyles(ForwardRef(SvgIcon))>
+                                                      </ForwardRef>
+                                                    </span>
+                                                    <WithStyles(memo)
+                                                      center={true}
+                                                    >
+                                                      <ForwardRef(TouchRipple)
+                                                        center={true}
+                                                        classes={
+                                                          Object {
+                                                            "child": "MuiTouchRipple-child",
+                                                            "childLeaving": "MuiTouchRipple-childLeaving",
+                                                            "childPulsate": "MuiTouchRipple-childPulsate",
+                                                            "ripple": "MuiTouchRipple-ripple",
+                                                            "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                            "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                            "root": "MuiTouchRipple-root",
+                                                          }
+                                                        }
                                                       >
-                                                        <TransitionGroup
-                                                          childFactory={[Function]}
-                                                          component={null}
-                                                          exit={true}
-                                                        />
-                                                      </span>
-                                                    </ForwardRef(TouchRipple)>
-                                                  </WithStyles(memo)>
-                                                </div>
-                                              </ForwardRef(ButtonBase)>
-                                            </WithStyles(ForwardRef(ButtonBase))>
-                                          </ForwardRef(IconButton)>
-                                        </WithStyles(ForwardRef(IconButton))>
-                                      </div>
-                                    </ForwardRef(ButtonBase)>
-                                  </WithStyles(ForwardRef(ButtonBase))>
-                                </ForwardRef(ExpansionPanelSummary)>
-                              </WithStyles(ForwardRef(ExpansionPanelSummary))>
-                              <WithStyles(ForwardRef(Collapse))
-                                in={false}
-                                timeout="auto"
-                              >
-                                <ForwardRef(Collapse)
-                                  classes={
-                                    Object {
-                                      "container": "MuiCollapse-container",
-                                      "entered": "MuiCollapse-entered",
-                                      "hidden": "MuiCollapse-hidden",
-                                      "wrapper": "MuiCollapse-wrapper",
-                                      "wrapperInner": "MuiCollapse-wrapperInner",
-                                    }
-                                  }
+                                                        <span
+                                                          className="MuiTouchRipple-root"
+                                                        >
+                                                          <TransitionGroup
+                                                            childFactory={[Function]}
+                                                            component={null}
+                                                            exit={true}
+                                                          />
+                                                        </span>
+                                                      </ForwardRef(TouchRipple)>
+                                                    </WithStyles(memo)>
+                                                  </div>
+                                                </ForwardRef(ButtonBase)>
+                                              </WithStyles(ForwardRef(ButtonBase))>
+                                            </ForwardRef(IconButton)>
+                                          </WithStyles(ForwardRef(IconButton))>
+                                        </div>
+                                      </ForwardRef(ButtonBase)>
+                                    </WithStyles(ForwardRef(ButtonBase))>
+                                  </ForwardRef(ExpansionPanelSummary)>
+                                </WithStyles(ForwardRef(ExpansionPanelSummary))>
+                                <WithStyles(ForwardRef(Collapse))
                                   in={false}
                                   timeout="auto"
                                 >
-                                  <Transition
-                                    addEndListener={[Function]}
-                                    appear={false}
-                                    enter={true}
-                                    exit={true}
-                                    in={false}
-                                    mountOnEnter={false}
-                                    onEnter={[Function]}
-                                    onEntered={[Function]}
-                                    onEntering={[Function]}
-                                    onExit={[Function]}
-                                    onExited={[Function]}
-                                    onExiting={[Function]}
-                                    timeout={null}
-                                    unmountOnExit={false}
-                                  >
-                                    <div
-                                      className="MuiCollapse-container MuiCollapse-hidden"
-                                      style={
-                                        Object {
-                                          "minHeight": "0px",
-                                        }
+                                  <ForwardRef(Collapse)
+                                    classes={
+                                      Object {
+                                        "container": "MuiCollapse-container",
+                                        "entered": "MuiCollapse-entered",
+                                        "hidden": "MuiCollapse-hidden",
+                                        "wrapper": "MuiCollapse-wrapper",
+                                        "wrapperInner": "MuiCollapse-wrapperInner",
                                       }
+                                    }
+                                    in={false}
+                                    timeout="auto"
+                                  >
+                                    <Transition
+                                      addEndListener={[Function]}
+                                      appear={false}
+                                      enter={true}
+                                      exit={true}
+                                      in={false}
+                                      mountOnEnter={false}
+                                      onEnter={[Function]}
+                                      onEntered={[Function]}
+                                      onEntering={[Function]}
+                                      onExit={[Function]}
+                                      onExited={[Function]}
+                                      onExiting={[Function]}
+                                      timeout={null}
+                                      unmountOnExit={false}
                                     >
                                       <div
-                                        className="MuiCollapse-wrapper"
+                                        className="MuiCollapse-container MuiCollapse-hidden"
+                                        style={
+                                          Object {
+                                            "minHeight": "0px",
+                                          }
+                                        }
                                       >
                                         <div
-                                          className="MuiCollapse-wrapperInner"
+                                          className="MuiCollapse-wrapper"
                                         >
                                           <div
-                                            role="region"
+                                            className="MuiCollapse-wrapperInner"
                                           >
-                                            <WithStyles(ForwardRef(ExpansionPanelDetails))
-                                              key=".1"
+                                            <div
+                                              role="region"
                                             >
-                                              <ForwardRef(ExpansionPanelDetails)
-                                                classes={
-                                                  Object {
-                                                    "root": "MuiExpansionPanelDetails-root",
-                                                  }
-                                                }
+                                              <WithStyles(ForwardRef(ExpansionPanelDetails))
+                                                key=".1"
                                               >
-                                                <div
-                                                  className="MuiExpansionPanelDetails-root"
+                                                <ForwardRef(ExpansionPanelDetails)
+                                                  classes={
+                                                    Object {
+                                                      "root": "MuiExpansionPanelDetails-root",
+                                                    }
+                                                  }
                                                 >
-                                                  <WithStyles(Styled(MuiBox))
-                                                    border={1}
-                                                    borderColor="grey.500"
-                                                    borderRadius="borderRadius"
-                                                    p={2}
+                                                  <div
+                                                    className="MuiExpansionPanelDetails-root"
                                                   >
-                                                    <Styled(MuiBox)
+                                                    <WithStyles(Styled(MuiBox))
                                                       border={1}
                                                       borderColor="grey.500"
                                                       borderRadius="borderRadius"
-                                                      classes={
-                                                        Object {
-                                                          "root": "Styled(MuiBox)-root-240",
-                                                        }
-                                                      }
                                                       p={2}
                                                     >
-                                                      <div
-                                                        className="MuiBox-root MuiBox-root-242 Styled(MuiBox)-root-240"
+                                                      <Styled(MuiBox)
+                                                        border={1}
+                                                        borderColor="grey.500"
+                                                        borderRadius="borderRadius"
                                                         classes={
                                                           Object {
-                                                            "root": "Styled(MuiBox)-root-240",
+                                                            "root": "Styled(MuiBox)-root-242",
                                                           }
                                                         }
+                                                        p={2}
                                                       >
-                                                        <Component>
-                                                          <div />
-                                                        </Component>
-                                                      </div>
-                                                    </Styled(MuiBox)>
-                                                  </WithStyles(Styled(MuiBox))>
-                                                </div>
-                                              </ForwardRef(ExpansionPanelDetails)>
-                                            </WithStyles(ForwardRef(ExpansionPanelDetails))>
+                                                        <div
+                                                          className="MuiBox-root MuiBox-root-243 Styled(MuiBox)-root-242"
+                                                          classes={
+                                                            Object {
+                                                              "root": "Styled(MuiBox)-root-242",
+                                                            }
+                                                          }
+                                                        >
+                                                          <Component>
+                                                            <div />
+                                                          </Component>
+                                                        </div>
+                                                      </Styled(MuiBox)>
+                                                    </WithStyles(Styled(MuiBox))>
+                                                  </div>
+                                                </ForwardRef(ExpansionPanelDetails)>
+                                              </WithStyles(ForwardRef(ExpansionPanelDetails))>
+                                            </div>
                                           </div>
                                         </div>
                                       </div>
-                                    </div>
-                                  </Transition>
-                                </ForwardRef(Collapse)>
-                              </WithStyles(ForwardRef(Collapse))>
-                            </div>
-                          </ForwardRef(Paper)>
-                        </WithStyles(ForwardRef(Paper))>
-                      </ForwardRef(ExpansionPanel)>
-                    </WithStyles(ForwardRef(ExpansionPanel))>
-                  </div>
-                </ForwardRef(Grid)>
-              </WithStyles(ForwardRef(Grid))>
-              <WithStyles(ForwardRef(Grid))
-                item={true}
-              >
-                <ForwardRef(Grid)
-                  classes={
-                    Object {
-                      "align-content-xs-center": "MuiGrid-align-content-xs-center",
-                      "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
-                      "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
-                      "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
-                      "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
-                      "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
-                      "align-items-xs-center": "MuiGrid-align-items-xs-center",
-                      "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
-                      "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
-                      "container": "MuiGrid-container",
-                      "direction-xs-column": "MuiGrid-direction-xs-column",
-                      "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
-                      "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
-                      "grid-lg-1": "MuiGrid-grid-lg-1",
-                      "grid-lg-10": "MuiGrid-grid-lg-10",
-                      "grid-lg-11": "MuiGrid-grid-lg-11",
-                      "grid-lg-12": "MuiGrid-grid-lg-12",
-                      "grid-lg-2": "MuiGrid-grid-lg-2",
-                      "grid-lg-3": "MuiGrid-grid-lg-3",
-                      "grid-lg-4": "MuiGrid-grid-lg-4",
-                      "grid-lg-5": "MuiGrid-grid-lg-5",
-                      "grid-lg-6": "MuiGrid-grid-lg-6",
-                      "grid-lg-7": "MuiGrid-grid-lg-7",
-                      "grid-lg-8": "MuiGrid-grid-lg-8",
-                      "grid-lg-9": "MuiGrid-grid-lg-9",
-                      "grid-lg-auto": "MuiGrid-grid-lg-auto",
-                      "grid-lg-true": "MuiGrid-grid-lg-true",
-                      "grid-md-1": "MuiGrid-grid-md-1",
-                      "grid-md-10": "MuiGrid-grid-md-10",
-                      "grid-md-11": "MuiGrid-grid-md-11",
-                      "grid-md-12": "MuiGrid-grid-md-12",
-                      "grid-md-2": "MuiGrid-grid-md-2",
-                      "grid-md-3": "MuiGrid-grid-md-3",
-                      "grid-md-4": "MuiGrid-grid-md-4",
-                      "grid-md-5": "MuiGrid-grid-md-5",
-                      "grid-md-6": "MuiGrid-grid-md-6",
-                      "grid-md-7": "MuiGrid-grid-md-7",
-                      "grid-md-8": "MuiGrid-grid-md-8",
-                      "grid-md-9": "MuiGrid-grid-md-9",
-                      "grid-md-auto": "MuiGrid-grid-md-auto",
-                      "grid-md-true": "MuiGrid-grid-md-true",
-                      "grid-sm-1": "MuiGrid-grid-sm-1",
-                      "grid-sm-10": "MuiGrid-grid-sm-10",
-                      "grid-sm-11": "MuiGrid-grid-sm-11",
-                      "grid-sm-12": "MuiGrid-grid-sm-12",
-                      "grid-sm-2": "MuiGrid-grid-sm-2",
-                      "grid-sm-3": "MuiGrid-grid-sm-3",
-                      "grid-sm-4": "MuiGrid-grid-sm-4",
-                      "grid-sm-5": "MuiGrid-grid-sm-5",
-                      "grid-sm-6": "MuiGrid-grid-sm-6",
-                      "grid-sm-7": "MuiGrid-grid-sm-7",
-                      "grid-sm-8": "MuiGrid-grid-sm-8",
-                      "grid-sm-9": "MuiGrid-grid-sm-9",
-                      "grid-sm-auto": "MuiGrid-grid-sm-auto",
-                      "grid-sm-true": "MuiGrid-grid-sm-true",
-                      "grid-xl-1": "MuiGrid-grid-xl-1",
-                      "grid-xl-10": "MuiGrid-grid-xl-10",
-                      "grid-xl-11": "MuiGrid-grid-xl-11",
-                      "grid-xl-12": "MuiGrid-grid-xl-12",
-                      "grid-xl-2": "MuiGrid-grid-xl-2",
-                      "grid-xl-3": "MuiGrid-grid-xl-3",
-                      "grid-xl-4": "MuiGrid-grid-xl-4",
-                      "grid-xl-5": "MuiGrid-grid-xl-5",
-                      "grid-xl-6": "MuiGrid-grid-xl-6",
-                      "grid-xl-7": "MuiGrid-grid-xl-7",
-                      "grid-xl-8": "MuiGrid-grid-xl-8",
-                      "grid-xl-9": "MuiGrid-grid-xl-9",
-                      "grid-xl-auto": "MuiGrid-grid-xl-auto",
-                      "grid-xl-true": "MuiGrid-grid-xl-true",
-                      "grid-xs-1": "MuiGrid-grid-xs-1",
-                      "grid-xs-10": "MuiGrid-grid-xs-10",
-                      "grid-xs-11": "MuiGrid-grid-xs-11",
-                      "grid-xs-12": "MuiGrid-grid-xs-12",
-                      "grid-xs-2": "MuiGrid-grid-xs-2",
-                      "grid-xs-3": "MuiGrid-grid-xs-3",
-                      "grid-xs-4": "MuiGrid-grid-xs-4",
-                      "grid-xs-5": "MuiGrid-grid-xs-5",
-                      "grid-xs-6": "MuiGrid-grid-xs-6",
-                      "grid-xs-7": "MuiGrid-grid-xs-7",
-                      "grid-xs-8": "MuiGrid-grid-xs-8",
-                      "grid-xs-9": "MuiGrid-grid-xs-9",
-                      "grid-xs-auto": "MuiGrid-grid-xs-auto",
-                      "grid-xs-true": "MuiGrid-grid-xs-true",
-                      "item": "MuiGrid-item",
-                      "justify-xs-center": "MuiGrid-justify-xs-center",
-                      "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
-                      "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
-                      "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
-                      "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
-                      "root": "MuiGrid-root",
-                      "spacing-xs-1": "MuiGrid-spacing-xs-1",
-                      "spacing-xs-10": "MuiGrid-spacing-xs-10",
-                      "spacing-xs-2": "MuiGrid-spacing-xs-2",
-                      "spacing-xs-3": "MuiGrid-spacing-xs-3",
-                      "spacing-xs-4": "MuiGrid-spacing-xs-4",
-                      "spacing-xs-5": "MuiGrid-spacing-xs-5",
-                      "spacing-xs-6": "MuiGrid-spacing-xs-6",
-                      "spacing-xs-7": "MuiGrid-spacing-xs-7",
-                      "spacing-xs-8": "MuiGrid-spacing-xs-8",
-                      "spacing-xs-9": "MuiGrid-spacing-xs-9",
-                      "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
-                      "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
-                      "zeroMinWidth": "MuiGrid-zeroMinWidth",
-                    }
-                  }
+                                    </Transition>
+                                  </ForwardRef(Collapse)>
+                                </WithStyles(ForwardRef(Collapse))>
+                              </div>
+                            </ForwardRef(Paper)>
+                          </WithStyles(ForwardRef(Paper))>
+                        </ForwardRef(ExpansionPanel)>
+                      </WithStyles(ForwardRef(ExpansionPanel))>
+                    </div>
+                  </ForwardRef(Grid)>
+                </WithStyles(ForwardRef(Grid))>
+                <WithStyles(ForwardRef(Grid))
                   item={true}
                 >
-                  <div
-                    className="MuiGrid-root MuiGrid-item"
+                  <ForwardRef(Grid)
+                    classes={
+                      Object {
+                        "align-content-xs-center": "MuiGrid-align-content-xs-center",
+                        "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
+                        "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
+                        "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
+                        "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
+                        "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
+                        "align-items-xs-center": "MuiGrid-align-items-xs-center",
+                        "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
+                        "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
+                        "container": "MuiGrid-container",
+                        "direction-xs-column": "MuiGrid-direction-xs-column",
+                        "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
+                        "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
+                        "grid-lg-1": "MuiGrid-grid-lg-1",
+                        "grid-lg-10": "MuiGrid-grid-lg-10",
+                        "grid-lg-11": "MuiGrid-grid-lg-11",
+                        "grid-lg-12": "MuiGrid-grid-lg-12",
+                        "grid-lg-2": "MuiGrid-grid-lg-2",
+                        "grid-lg-3": "MuiGrid-grid-lg-3",
+                        "grid-lg-4": "MuiGrid-grid-lg-4",
+                        "grid-lg-5": "MuiGrid-grid-lg-5",
+                        "grid-lg-6": "MuiGrid-grid-lg-6",
+                        "grid-lg-7": "MuiGrid-grid-lg-7",
+                        "grid-lg-8": "MuiGrid-grid-lg-8",
+                        "grid-lg-9": "MuiGrid-grid-lg-9",
+                        "grid-lg-auto": "MuiGrid-grid-lg-auto",
+                        "grid-lg-true": "MuiGrid-grid-lg-true",
+                        "grid-md-1": "MuiGrid-grid-md-1",
+                        "grid-md-10": "MuiGrid-grid-md-10",
+                        "grid-md-11": "MuiGrid-grid-md-11",
+                        "grid-md-12": "MuiGrid-grid-md-12",
+                        "grid-md-2": "MuiGrid-grid-md-2",
+                        "grid-md-3": "MuiGrid-grid-md-3",
+                        "grid-md-4": "MuiGrid-grid-md-4",
+                        "grid-md-5": "MuiGrid-grid-md-5",
+                        "grid-md-6": "MuiGrid-grid-md-6",
+                        "grid-md-7": "MuiGrid-grid-md-7",
+                        "grid-md-8": "MuiGrid-grid-md-8",
+                        "grid-md-9": "MuiGrid-grid-md-9",
+                        "grid-md-auto": "MuiGrid-grid-md-auto",
+                        "grid-md-true": "MuiGrid-grid-md-true",
+                        "grid-sm-1": "MuiGrid-grid-sm-1",
+                        "grid-sm-10": "MuiGrid-grid-sm-10",
+                        "grid-sm-11": "MuiGrid-grid-sm-11",
+                        "grid-sm-12": "MuiGrid-grid-sm-12",
+                        "grid-sm-2": "MuiGrid-grid-sm-2",
+                        "grid-sm-3": "MuiGrid-grid-sm-3",
+                        "grid-sm-4": "MuiGrid-grid-sm-4",
+                        "grid-sm-5": "MuiGrid-grid-sm-5",
+                        "grid-sm-6": "MuiGrid-grid-sm-6",
+                        "grid-sm-7": "MuiGrid-grid-sm-7",
+                        "grid-sm-8": "MuiGrid-grid-sm-8",
+                        "grid-sm-9": "MuiGrid-grid-sm-9",
+                        "grid-sm-auto": "MuiGrid-grid-sm-auto",
+                        "grid-sm-true": "MuiGrid-grid-sm-true",
+                        "grid-xl-1": "MuiGrid-grid-xl-1",
+                        "grid-xl-10": "MuiGrid-grid-xl-10",
+                        "grid-xl-11": "MuiGrid-grid-xl-11",
+                        "grid-xl-12": "MuiGrid-grid-xl-12",
+                        "grid-xl-2": "MuiGrid-grid-xl-2",
+                        "grid-xl-3": "MuiGrid-grid-xl-3",
+                        "grid-xl-4": "MuiGrid-grid-xl-4",
+                        "grid-xl-5": "MuiGrid-grid-xl-5",
+                        "grid-xl-6": "MuiGrid-grid-xl-6",
+                        "grid-xl-7": "MuiGrid-grid-xl-7",
+                        "grid-xl-8": "MuiGrid-grid-xl-8",
+                        "grid-xl-9": "MuiGrid-grid-xl-9",
+                        "grid-xl-auto": "MuiGrid-grid-xl-auto",
+                        "grid-xl-true": "MuiGrid-grid-xl-true",
+                        "grid-xs-1": "MuiGrid-grid-xs-1",
+                        "grid-xs-10": "MuiGrid-grid-xs-10",
+                        "grid-xs-11": "MuiGrid-grid-xs-11",
+                        "grid-xs-12": "MuiGrid-grid-xs-12",
+                        "grid-xs-2": "MuiGrid-grid-xs-2",
+                        "grid-xs-3": "MuiGrid-grid-xs-3",
+                        "grid-xs-4": "MuiGrid-grid-xs-4",
+                        "grid-xs-5": "MuiGrid-grid-xs-5",
+                        "grid-xs-6": "MuiGrid-grid-xs-6",
+                        "grid-xs-7": "MuiGrid-grid-xs-7",
+                        "grid-xs-8": "MuiGrid-grid-xs-8",
+                        "grid-xs-9": "MuiGrid-grid-xs-9",
+                        "grid-xs-auto": "MuiGrid-grid-xs-auto",
+                        "grid-xs-true": "MuiGrid-grid-xs-true",
+                        "item": "MuiGrid-item",
+                        "justify-xs-center": "MuiGrid-justify-xs-center",
+                        "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
+                        "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
+                        "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
+                        "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
+                        "root": "MuiGrid-root",
+                        "spacing-xs-1": "MuiGrid-spacing-xs-1",
+                        "spacing-xs-10": "MuiGrid-spacing-xs-10",
+                        "spacing-xs-2": "MuiGrid-spacing-xs-2",
+                        "spacing-xs-3": "MuiGrid-spacing-xs-3",
+                        "spacing-xs-4": "MuiGrid-spacing-xs-4",
+                        "spacing-xs-5": "MuiGrid-spacing-xs-5",
+                        "spacing-xs-6": "MuiGrid-spacing-xs-6",
+                        "spacing-xs-7": "MuiGrid-spacing-xs-7",
+                        "spacing-xs-8": "MuiGrid-spacing-xs-8",
+                        "spacing-xs-9": "MuiGrid-spacing-xs-9",
+                        "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
+                        "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
+                        "zeroMinWidth": "MuiGrid-zeroMinWidth",
+                      }
+                    }
+                    item={true}
                   >
-                    <WithStyles(ForwardRef(ExpansionPanel))>
-                      <ForwardRef(ExpansionPanel)
-                        classes={
-                          Object {
-                            "disabled": "Mui-disabled",
-                            "expanded": "Mui-expanded",
-                            "root": "MuiExpansionPanel-root",
-                            "rounded": "MuiExpansionPanel-rounded",
-                          }
-                        }
-                      >
-                        <WithStyles(ForwardRef(Paper))
-                          className="MuiExpansionPanel-root MuiExpansionPanel-rounded"
-                          square={false}
-                        >
-                          <ForwardRef(Paper)
-                            className="MuiExpansionPanel-root MuiExpansionPanel-rounded"
-                            classes={
-                              Object {
-                                "elevation0": "MuiPaper-elevation0",
-                                "elevation1": "MuiPaper-elevation1",
-                                "elevation10": "MuiPaper-elevation10",
-                                "elevation11": "MuiPaper-elevation11",
-                                "elevation12": "MuiPaper-elevation12",
-                                "elevation13": "MuiPaper-elevation13",
-                                "elevation14": "MuiPaper-elevation14",
-                                "elevation15": "MuiPaper-elevation15",
-                                "elevation16": "MuiPaper-elevation16",
-                                "elevation17": "MuiPaper-elevation17",
-                                "elevation18": "MuiPaper-elevation18",
-                                "elevation19": "MuiPaper-elevation19",
-                                "elevation2": "MuiPaper-elevation2",
-                                "elevation20": "MuiPaper-elevation20",
-                                "elevation21": "MuiPaper-elevation21",
-                                "elevation22": "MuiPaper-elevation22",
-                                "elevation23": "MuiPaper-elevation23",
-                                "elevation24": "MuiPaper-elevation24",
-                                "elevation3": "MuiPaper-elevation3",
-                                "elevation4": "MuiPaper-elevation4",
-                                "elevation5": "MuiPaper-elevation5",
-                                "elevation6": "MuiPaper-elevation6",
-                                "elevation7": "MuiPaper-elevation7",
-                                "elevation8": "MuiPaper-elevation8",
-                                "elevation9": "MuiPaper-elevation9",
-                                "outlined": "MuiPaper-outlined",
-                                "root": "MuiPaper-root",
-                                "rounded": "MuiPaper-rounded",
-                              }
+                    <div
+                      className="MuiGrid-root MuiGrid-item"
+                    >
+                      <WithStyles(ForwardRef(ExpansionPanel))>
+                        <ForwardRef(ExpansionPanel)
+                          classes={
+                            Object {
+                              "disabled": "Mui-disabled",
+                              "expanded": "Mui-expanded",
+                              "root": "MuiExpansionPanel-root",
+                              "rounded": "MuiExpansionPanel-rounded",
                             }
+                          }
+                        >
+                          <WithStyles(ForwardRef(Paper))
+                            className="MuiExpansionPanel-root MuiExpansionPanel-rounded"
                             square={false}
                           >
-                            <div
-                              className="MuiPaper-root MuiExpansionPanel-root MuiExpansionPanel-rounded MuiPaper-elevation1 MuiPaper-rounded"
+                            <ForwardRef(Paper)
+                              className="MuiExpansionPanel-root MuiExpansionPanel-rounded"
+                              classes={
+                                Object {
+                                  "elevation0": "MuiPaper-elevation0",
+                                  "elevation1": "MuiPaper-elevation1",
+                                  "elevation10": "MuiPaper-elevation10",
+                                  "elevation11": "MuiPaper-elevation11",
+                                  "elevation12": "MuiPaper-elevation12",
+                                  "elevation13": "MuiPaper-elevation13",
+                                  "elevation14": "MuiPaper-elevation14",
+                                  "elevation15": "MuiPaper-elevation15",
+                                  "elevation16": "MuiPaper-elevation16",
+                                  "elevation17": "MuiPaper-elevation17",
+                                  "elevation18": "MuiPaper-elevation18",
+                                  "elevation19": "MuiPaper-elevation19",
+                                  "elevation2": "MuiPaper-elevation2",
+                                  "elevation20": "MuiPaper-elevation20",
+                                  "elevation21": "MuiPaper-elevation21",
+                                  "elevation22": "MuiPaper-elevation22",
+                                  "elevation23": "MuiPaper-elevation23",
+                                  "elevation24": "MuiPaper-elevation24",
+                                  "elevation3": "MuiPaper-elevation3",
+                                  "elevation4": "MuiPaper-elevation4",
+                                  "elevation5": "MuiPaper-elevation5",
+                                  "elevation6": "MuiPaper-elevation6",
+                                  "elevation7": "MuiPaper-elevation7",
+                                  "elevation8": "MuiPaper-elevation8",
+                                  "elevation9": "MuiPaper-elevation9",
+                                  "outlined": "MuiPaper-outlined",
+                                  "root": "MuiPaper-root",
+                                  "rounded": "MuiPaper-rounded",
+                                }
+                              }
+                              square={false}
                             >
-                              <WithStyles(ForwardRef(ExpansionPanelSummary))
-                                expandIcon={<Memo(ExpandMoreIcon) />}
-                                key=".0"
+                              <div
+                                className="MuiPaper-root MuiExpansionPanel-root MuiExpansionPanel-rounded MuiPaper-elevation1 MuiPaper-rounded"
                               >
-                                <ForwardRef(ExpansionPanelSummary)
-                                  classes={
-                                    Object {
-                                      "content": "MuiExpansionPanelSummary-content",
-                                      "disabled": "Mui-disabled",
-                                      "expandIcon": "MuiExpansionPanelSummary-expandIcon",
-                                      "expanded": "Mui-expanded",
-                                      "focused": "Mui-focused",
-                                      "root": "MuiExpansionPanelSummary-root",
-                                    }
-                                  }
+                                <WithStyles(ForwardRef(ExpansionPanelSummary))
                                   expandIcon={<Memo(ExpandMoreIcon) />}
+                                  key=".0"
                                 >
-                                  <WithStyles(ForwardRef(ButtonBase))
-                                    aria-expanded={false}
-                                    className="MuiExpansionPanelSummary-root"
-                                    component="div"
-                                    disableRipple={true}
-                                    disabled={false}
-                                    focusRipple={false}
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocusVisible={[Function]}
+                                  <ForwardRef(ExpansionPanelSummary)
+                                    classes={
+                                      Object {
+                                        "content": "MuiExpansionPanelSummary-content",
+                                        "disabled": "Mui-disabled",
+                                        "expandIcon": "MuiExpansionPanelSummary-expandIcon",
+                                        "expanded": "Mui-expanded",
+                                        "focused": "Mui-focused",
+                                        "root": "MuiExpansionPanelSummary-root",
+                                      }
+                                    }
+                                    expandIcon={<Memo(ExpandMoreIcon) />}
                                   >
-                                    <ForwardRef(ButtonBase)
+                                    <WithStyles(ForwardRef(ButtonBase))
                                       aria-expanded={false}
                                       className="MuiExpansionPanelSummary-root"
-                                      classes={
-                                        Object {
-                                          "disabled": "Mui-disabled",
-                                          "focusVisible": "Mui-focusVisible",
-                                          "root": "MuiButtonBase-root",
-                                        }
-                                      }
                                       component="div"
                                       disableRipple={true}
                                       disabled={false}
@@ -2019,436 +2193,455 @@ exports[`The MissionControl container renders on the page with no errors 1`] = `
                                       onClick={[Function]}
                                       onFocusVisible={[Function]}
                                     >
-                                      <div
-                                        aria-disabled={false}
+                                      <ForwardRef(ButtonBase)
                                         aria-expanded={false}
-                                        className="MuiButtonBase-root MuiExpansionPanelSummary-root"
+                                        className="MuiExpansionPanelSummary-root"
+                                        classes={
+                                          Object {
+                                            "disabled": "Mui-disabled",
+                                            "focusVisible": "Mui-focusVisible",
+                                            "root": "MuiButtonBase-root",
+                                          }
+                                        }
+                                        component="div"
+                                        disableRipple={true}
+                                        disabled={false}
+                                        focusRipple={false}
                                         onBlur={[Function]}
                                         onClick={[Function]}
-                                        onDragLeave={[Function]}
-                                        onFocus={[Function]}
-                                        onKeyDown={[Function]}
-                                        onKeyUp={[Function]}
-                                        onMouseDown={[Function]}
-                                        onMouseLeave={[Function]}
-                                        onMouseUp={[Function]}
-                                        onTouchEnd={[Function]}
-                                        onTouchMove={[Function]}
-                                        onTouchStart={[Function]}
-                                        role="button"
-                                        tabIndex={0}
+                                        onFocusVisible={[Function]}
                                       >
                                         <div
-                                          className="MuiExpansionPanelSummary-content"
+                                          aria-disabled={false}
+                                          aria-expanded={false}
+                                          className="MuiButtonBase-root MuiExpansionPanelSummary-root"
+                                          onBlur={[Function]}
+                                          onClick={[Function]}
+                                          onDragLeave={[Function]}
+                                          onFocus={[Function]}
+                                          onKeyDown={[Function]}
+                                          onKeyUp={[Function]}
+                                          onMouseDown={[Function]}
+                                          onMouseLeave={[Function]}
+                                          onMouseUp={[Function]}
+                                          onTouchEnd={[Function]}
+                                          onTouchMove={[Function]}
+                                          onTouchStart={[Function]}
+                                          role="button"
+                                          tabIndex={0}
                                         >
-                                          <WithStyles(ForwardRef(Typography))>
-                                            <ForwardRef(Typography)
-                                              classes={
-                                                Object {
-                                                  "alignCenter": "MuiTypography-alignCenter",
-                                                  "alignJustify": "MuiTypography-alignJustify",
-                                                  "alignLeft": "MuiTypography-alignLeft",
-                                                  "alignRight": "MuiTypography-alignRight",
-                                                  "body1": "MuiTypography-body1",
-                                                  "body2": "MuiTypography-body2",
-                                                  "button": "MuiTypography-button",
-                                                  "caption": "MuiTypography-caption",
-                                                  "colorError": "MuiTypography-colorError",
-                                                  "colorInherit": "MuiTypography-colorInherit",
-                                                  "colorPrimary": "MuiTypography-colorPrimary",
-                                                  "colorSecondary": "MuiTypography-colorSecondary",
-                                                  "colorTextPrimary": "MuiTypography-colorTextPrimary",
-                                                  "colorTextSecondary": "MuiTypography-colorTextSecondary",
-                                                  "displayBlock": "MuiTypography-displayBlock",
-                                                  "displayInline": "MuiTypography-displayInline",
-                                                  "gutterBottom": "MuiTypography-gutterBottom",
-                                                  "h1": "MuiTypography-h1",
-                                                  "h2": "MuiTypography-h2",
-                                                  "h3": "MuiTypography-h3",
-                                                  "h4": "MuiTypography-h4",
-                                                  "h5": "MuiTypography-h5",
-                                                  "h6": "MuiTypography-h6",
-                                                  "noWrap": "MuiTypography-noWrap",
-                                                  "overline": "MuiTypography-overline",
-                                                  "paragraph": "MuiTypography-paragraph",
-                                                  "root": "MuiTypography-root",
-                                                  "srOnly": "MuiTypography-srOnly",
-                                                  "subtitle1": "MuiTypography-subtitle1",
-                                                  "subtitle2": "MuiTypography-subtitle2",
+                                          <div
+                                            className="MuiExpansionPanelSummary-content"
+                                          >
+                                            <WithStyles(ForwardRef(Typography))>
+                                              <ForwardRef(Typography)
+                                                classes={
+                                                  Object {
+                                                    "alignCenter": "MuiTypography-alignCenter",
+                                                    "alignJustify": "MuiTypography-alignJustify",
+                                                    "alignLeft": "MuiTypography-alignLeft",
+                                                    "alignRight": "MuiTypography-alignRight",
+                                                    "body1": "MuiTypography-body1",
+                                                    "body2": "MuiTypography-body2",
+                                                    "button": "MuiTypography-button",
+                                                    "caption": "MuiTypography-caption",
+                                                    "colorError": "MuiTypography-colorError",
+                                                    "colorInherit": "MuiTypography-colorInherit",
+                                                    "colorPrimary": "MuiTypography-colorPrimary",
+                                                    "colorSecondary": "MuiTypography-colorSecondary",
+                                                    "colorTextPrimary": "MuiTypography-colorTextPrimary",
+                                                    "colorTextSecondary": "MuiTypography-colorTextSecondary",
+                                                    "displayBlock": "MuiTypography-displayBlock",
+                                                    "displayInline": "MuiTypography-displayInline",
+                                                    "gutterBottom": "MuiTypography-gutterBottom",
+                                                    "h1": "MuiTypography-h1",
+                                                    "h2": "MuiTypography-h2",
+                                                    "h3": "MuiTypography-h3",
+                                                    "h4": "MuiTypography-h4",
+                                                    "h5": "MuiTypography-h5",
+                                                    "h6": "MuiTypography-h6",
+                                                    "noWrap": "MuiTypography-noWrap",
+                                                    "overline": "MuiTypography-overline",
+                                                    "paragraph": "MuiTypography-paragraph",
+                                                    "root": "MuiTypography-root",
+                                                    "srOnly": "MuiTypography-srOnly",
+                                                    "subtitle1": "MuiTypography-subtitle1",
+                                                    "subtitle2": "MuiTypography-subtitle2",
+                                                  }
                                                 }
-                                              }
-                                            >
-                                              <p
-                                                className="MuiTypography-root MuiTypography-body1"
                                               >
-                                                <FormattedMessage
-                                                  defaultMessage="Debug Console"
-                                                  id="app.mission_control.console"
-                                                  values={Object {}}
+                                                <p
+                                                  className="MuiTypography-root MuiTypography-body1"
                                                 >
-                                                  Debug Console
-                                                </FormattedMessage>
-                                              </p>
-                                            </ForwardRef(Typography)>
-                                          </WithStyles(ForwardRef(Typography))>
-                                        </div>
-                                        <WithStyles(ForwardRef(IconButton))
-                                          aria-hidden={true}
-                                          className="MuiExpansionPanelSummary-expandIcon"
-                                          component="div"
-                                          edge="end"
-                                          role={null}
-                                          tabIndex={null}
-                                        >
-                                          <ForwardRef(IconButton)
+                                                  <FormattedMessage
+                                                    defaultMessage="Debug Console"
+                                                    id="app.mission_control.console"
+                                                    values={Object {}}
+                                                  >
+                                                    Debug Console
+                                                  </FormattedMessage>
+                                                </p>
+                                              </ForwardRef(Typography)>
+                                            </WithStyles(ForwardRef(Typography))>
+                                          </div>
+                                          <WithStyles(ForwardRef(IconButton))
                                             aria-hidden={true}
                                             className="MuiExpansionPanelSummary-expandIcon"
-                                            classes={
-                                              Object {
-                                                "colorInherit": "MuiIconButton-colorInherit",
-                                                "colorPrimary": "MuiIconButton-colorPrimary",
-                                                "colorSecondary": "MuiIconButton-colorSecondary",
-                                                "disabled": "Mui-disabled",
-                                                "edgeEnd": "MuiIconButton-edgeEnd",
-                                                "edgeStart": "MuiIconButton-edgeStart",
-                                                "label": "MuiIconButton-label",
-                                                "root": "MuiIconButton-root",
-                                                "sizeSmall": "MuiIconButton-sizeSmall",
-                                              }
-                                            }
                                             component="div"
                                             edge="end"
                                             role={null}
                                             tabIndex={null}
                                           >
-                                            <WithStyles(ForwardRef(ButtonBase))
+                                            <ForwardRef(IconButton)
                                               aria-hidden={true}
-                                              centerRipple={true}
-                                              className="MuiIconButton-root MuiExpansionPanelSummary-expandIcon MuiIconButton-edgeEnd"
+                                              className="MuiExpansionPanelSummary-expandIcon"
+                                              classes={
+                                                Object {
+                                                  "colorInherit": "MuiIconButton-colorInherit",
+                                                  "colorPrimary": "MuiIconButton-colorPrimary",
+                                                  "colorSecondary": "MuiIconButton-colorSecondary",
+                                                  "disabled": "Mui-disabled",
+                                                  "edgeEnd": "MuiIconButton-edgeEnd",
+                                                  "edgeStart": "MuiIconButton-edgeStart",
+                                                  "label": "MuiIconButton-label",
+                                                  "root": "MuiIconButton-root",
+                                                  "sizeSmall": "MuiIconButton-sizeSmall",
+                                                }
+                                              }
                                               component="div"
-                                              disabled={false}
-                                              focusRipple={true}
+                                              edge="end"
                                               role={null}
                                               tabIndex={null}
                                             >
-                                              <ForwardRef(ButtonBase)
+                                              <WithStyles(ForwardRef(ButtonBase))
                                                 aria-hidden={true}
                                                 centerRipple={true}
                                                 className="MuiIconButton-root MuiExpansionPanelSummary-expandIcon MuiIconButton-edgeEnd"
-                                                classes={
-                                                  Object {
-                                                    "disabled": "Mui-disabled",
-                                                    "focusVisible": "Mui-focusVisible",
-                                                    "root": "MuiButtonBase-root",
-                                                  }
-                                                }
                                                 component="div"
                                                 disabled={false}
                                                 focusRipple={true}
                                                 role={null}
                                                 tabIndex={null}
                                               >
-                                                <div
-                                                  aria-disabled={false}
+                                                <ForwardRef(ButtonBase)
                                                   aria-hidden={true}
-                                                  className="MuiButtonBase-root MuiIconButton-root MuiExpansionPanelSummary-expandIcon MuiIconButton-edgeEnd"
-                                                  onBlur={[Function]}
-                                                  onDragLeave={[Function]}
-                                                  onFocus={[Function]}
-                                                  onKeyDown={[Function]}
-                                                  onKeyUp={[Function]}
-                                                  onMouseDown={[Function]}
-                                                  onMouseLeave={[Function]}
-                                                  onMouseUp={[Function]}
-                                                  onTouchEnd={[Function]}
-                                                  onTouchMove={[Function]}
-                                                  onTouchStart={[Function]}
+                                                  centerRipple={true}
+                                                  className="MuiIconButton-root MuiExpansionPanelSummary-expandIcon MuiIconButton-edgeEnd"
+                                                  classes={
+                                                    Object {
+                                                      "disabled": "Mui-disabled",
+                                                      "focusVisible": "Mui-focusVisible",
+                                                      "root": "MuiButtonBase-root",
+                                                    }
+                                                  }
+                                                  component="div"
+                                                  disabled={false}
+                                                  focusRipple={true}
                                                   role={null}
                                                   tabIndex={null}
                                                 >
-                                                  <span
-                                                    className="MuiIconButton-label"
+                                                  <div
+                                                    aria-disabled={false}
+                                                    aria-hidden={true}
+                                                    className="MuiButtonBase-root MuiIconButton-root MuiExpansionPanelSummary-expandIcon MuiIconButton-edgeEnd"
+                                                    onBlur={[Function]}
+                                                    onDragLeave={[Function]}
+                                                    onFocus={[Function]}
+                                                    onKeyDown={[Function]}
+                                                    onKeyUp={[Function]}
+                                                    onMouseDown={[Function]}
+                                                    onMouseLeave={[Function]}
+                                                    onMouseUp={[Function]}
+                                                    onTouchEnd={[Function]}
+                                                    onTouchMove={[Function]}
+                                                    onTouchStart={[Function]}
+                                                    role={null}
+                                                    tabIndex={null}
                                                   >
-                                                    <ForwardRef>
-                                                      <WithStyles(ForwardRef(SvgIcon))>
-                                                        <ForwardRef(SvgIcon)
-                                                          classes={
-                                                            Object {
-                                                              "colorAction": "MuiSvgIcon-colorAction",
-                                                              "colorDisabled": "MuiSvgIcon-colorDisabled",
-                                                              "colorError": "MuiSvgIcon-colorError",
-                                                              "colorPrimary": "MuiSvgIcon-colorPrimary",
-                                                              "colorSecondary": "MuiSvgIcon-colorSecondary",
-                                                              "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                                                              "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                                                              "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                                                              "root": "MuiSvgIcon-root",
-                                                            }
-                                                          }
-                                                        >
-                                                          <svg
-                                                            aria-hidden="true"
-                                                            className="MuiSvgIcon-root"
-                                                            focusable="false"
-                                                            viewBox="0 0 24 24"
-                                                          >
-                                                            <path
-                                                              d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
-                                                            />
-                                                          </svg>
-                                                        </ForwardRef(SvgIcon)>
-                                                      </WithStyles(ForwardRef(SvgIcon))>
-                                                    </ForwardRef>
-                                                  </span>
-                                                  <WithStyles(memo)
-                                                    center={true}
-                                                  >
-                                                    <ForwardRef(TouchRipple)
-                                                      center={true}
-                                                      classes={
-                                                        Object {
-                                                          "child": "MuiTouchRipple-child",
-                                                          "childLeaving": "MuiTouchRipple-childLeaving",
-                                                          "childPulsate": "MuiTouchRipple-childPulsate",
-                                                          "ripple": "MuiTouchRipple-ripple",
-                                                          "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                          "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                          "root": "MuiTouchRipple-root",
-                                                        }
-                                                      }
+                                                    <span
+                                                      className="MuiIconButton-label"
                                                     >
-                                                      <span
-                                                        className="MuiTouchRipple-root"
+                                                      <ForwardRef>
+                                                        <WithStyles(ForwardRef(SvgIcon))>
+                                                          <ForwardRef(SvgIcon)
+                                                            classes={
+                                                              Object {
+                                                                "colorAction": "MuiSvgIcon-colorAction",
+                                                                "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                                                "colorError": "MuiSvgIcon-colorError",
+                                                                "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                                                "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                                                "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                                                "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                                                "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                                                "root": "MuiSvgIcon-root",
+                                                              }
+                                                            }
+                                                          >
+                                                            <svg
+                                                              aria-hidden="true"
+                                                              className="MuiSvgIcon-root"
+                                                              focusable="false"
+                                                              viewBox="0 0 24 24"
+                                                            >
+                                                              <path
+                                                                d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                                                              />
+                                                            </svg>
+                                                          </ForwardRef(SvgIcon)>
+                                                        </WithStyles(ForwardRef(SvgIcon))>
+                                                      </ForwardRef>
+                                                    </span>
+                                                    <WithStyles(memo)
+                                                      center={true}
+                                                    >
+                                                      <ForwardRef(TouchRipple)
+                                                        center={true}
+                                                        classes={
+                                                          Object {
+                                                            "child": "MuiTouchRipple-child",
+                                                            "childLeaving": "MuiTouchRipple-childLeaving",
+                                                            "childPulsate": "MuiTouchRipple-childPulsate",
+                                                            "ripple": "MuiTouchRipple-ripple",
+                                                            "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                            "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                            "root": "MuiTouchRipple-root",
+                                                          }
+                                                        }
                                                       >
-                                                        <TransitionGroup
-                                                          childFactory={[Function]}
-                                                          component={null}
-                                                          exit={true}
-                                                        />
-                                                      </span>
-                                                    </ForwardRef(TouchRipple)>
-                                                  </WithStyles(memo)>
-                                                </div>
-                                              </ForwardRef(ButtonBase)>
-                                            </WithStyles(ForwardRef(ButtonBase))>
-                                          </ForwardRef(IconButton)>
-                                        </WithStyles(ForwardRef(IconButton))>
-                                      </div>
-                                    </ForwardRef(ButtonBase)>
-                                  </WithStyles(ForwardRef(ButtonBase))>
-                                </ForwardRef(ExpansionPanelSummary)>
-                              </WithStyles(ForwardRef(ExpansionPanelSummary))>
-                              <WithStyles(ForwardRef(Collapse))
-                                in={false}
-                                timeout="auto"
-                              >
-                                <ForwardRef(Collapse)
-                                  classes={
-                                    Object {
-                                      "container": "MuiCollapse-container",
-                                      "entered": "MuiCollapse-entered",
-                                      "hidden": "MuiCollapse-hidden",
-                                      "wrapper": "MuiCollapse-wrapper",
-                                      "wrapperInner": "MuiCollapse-wrapperInner",
-                                    }
-                                  }
+                                                        <span
+                                                          className="MuiTouchRipple-root"
+                                                        >
+                                                          <TransitionGroup
+                                                            childFactory={[Function]}
+                                                            component={null}
+                                                            exit={true}
+                                                          />
+                                                        </span>
+                                                      </ForwardRef(TouchRipple)>
+                                                    </WithStyles(memo)>
+                                                  </div>
+                                                </ForwardRef(ButtonBase)>
+                                              </WithStyles(ForwardRef(ButtonBase))>
+                                            </ForwardRef(IconButton)>
+                                          </WithStyles(ForwardRef(IconButton))>
+                                        </div>
+                                      </ForwardRef(ButtonBase)>
+                                    </WithStyles(ForwardRef(ButtonBase))>
+                                  </ForwardRef(ExpansionPanelSummary)>
+                                </WithStyles(ForwardRef(ExpansionPanelSummary))>
+                                <WithStyles(ForwardRef(Collapse))
                                   in={false}
                                   timeout="auto"
                                 >
-                                  <Transition
-                                    addEndListener={[Function]}
-                                    appear={false}
-                                    enter={true}
-                                    exit={true}
-                                    in={false}
-                                    mountOnEnter={false}
-                                    onEnter={[Function]}
-                                    onEntered={[Function]}
-                                    onEntering={[Function]}
-                                    onExit={[Function]}
-                                    onExited={[Function]}
-                                    onExiting={[Function]}
-                                    timeout={null}
-                                    unmountOnExit={false}
-                                  >
-                                    <div
-                                      className="MuiCollapse-container MuiCollapse-hidden"
-                                      style={
-                                        Object {
-                                          "minHeight": "0px",
-                                        }
+                                  <ForwardRef(Collapse)
+                                    classes={
+                                      Object {
+                                        "container": "MuiCollapse-container",
+                                        "entered": "MuiCollapse-entered",
+                                        "hidden": "MuiCollapse-hidden",
+                                        "wrapper": "MuiCollapse-wrapper",
+                                        "wrapperInner": "MuiCollapse-wrapperInner",
                                       }
+                                    }
+                                    in={false}
+                                    timeout="auto"
+                                  >
+                                    <Transition
+                                      addEndListener={[Function]}
+                                      appear={false}
+                                      enter={true}
+                                      exit={true}
+                                      in={false}
+                                      mountOnEnter={false}
+                                      onEnter={[Function]}
+                                      onEntered={[Function]}
+                                      onEntering={[Function]}
+                                      onExit={[Function]}
+                                      onExited={[Function]}
+                                      onExiting={[Function]}
+                                      timeout={null}
+                                      unmountOnExit={false}
                                     >
                                       <div
-                                        className="MuiCollapse-wrapper"
+                                        className="MuiCollapse-container MuiCollapse-hidden"
+                                        style={
+                                          Object {
+                                            "minHeight": "0px",
+                                          }
+                                        }
                                       >
                                         <div
-                                          className="MuiCollapse-wrapperInner"
+                                          className="MuiCollapse-wrapper"
                                         >
                                           <div
-                                            role="region"
+                                            className="MuiCollapse-wrapperInner"
                                           >
-                                            <WithStyles(ForwardRef(ExpansionPanelDetails))
-                                              key=".1"
+                                            <div
+                                              role="region"
                                             >
-                                              <ForwardRef(ExpansionPanelDetails)
-                                                classes={
-                                                  Object {
-                                                    "root": "MuiExpansionPanelDetails-root",
-                                                  }
-                                                }
+                                              <WithStyles(ForwardRef(ExpansionPanelDetails))
+                                                key=".1"
                                               >
-                                                <div
-                                                  className="MuiExpansionPanelDetails-root"
+                                                <ForwardRef(ExpansionPanelDetails)
+                                                  classes={
+                                                    Object {
+                                                      "root": "MuiExpansionPanelDetails-root",
+                                                    }
+                                                  }
                                                 >
-                                                  <Component>
-                                                    <div />
-                                                  </Component>
-                                                </div>
-                                              </ForwardRef(ExpansionPanelDetails)>
-                                            </WithStyles(ForwardRef(ExpansionPanelDetails))>
+                                                  <div
+                                                    className="MuiExpansionPanelDetails-root"
+                                                  >
+                                                    <Component>
+                                                      <div />
+                                                    </Component>
+                                                  </div>
+                                                </ForwardRef(ExpansionPanelDetails)>
+                                              </WithStyles(ForwardRef(ExpansionPanelDetails))>
+                                            </div>
                                           </div>
                                         </div>
                                       </div>
-                                    </div>
-                                  </Transition>
-                                </ForwardRef(Collapse)>
-                              </WithStyles(ForwardRef(Collapse))>
-                            </div>
-                          </ForwardRef(Paper)>
-                        </WithStyles(ForwardRef(Paper))>
-                      </ForwardRef(ExpansionPanel)>
-                    </WithStyles(ForwardRef(ExpansionPanel))>
-                  </div>
-                </ForwardRef(Grid)>
-              </WithStyles(ForwardRef(Grid))>
-              <WithStyles(ForwardRef(Grid))
-                item={true}
-              >
-                <ForwardRef(Grid)
-                  classes={
-                    Object {
-                      "align-content-xs-center": "MuiGrid-align-content-xs-center",
-                      "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
-                      "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
-                      "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
-                      "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
-                      "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
-                      "align-items-xs-center": "MuiGrid-align-items-xs-center",
-                      "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
-                      "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
-                      "container": "MuiGrid-container",
-                      "direction-xs-column": "MuiGrid-direction-xs-column",
-                      "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
-                      "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
-                      "grid-lg-1": "MuiGrid-grid-lg-1",
-                      "grid-lg-10": "MuiGrid-grid-lg-10",
-                      "grid-lg-11": "MuiGrid-grid-lg-11",
-                      "grid-lg-12": "MuiGrid-grid-lg-12",
-                      "grid-lg-2": "MuiGrid-grid-lg-2",
-                      "grid-lg-3": "MuiGrid-grid-lg-3",
-                      "grid-lg-4": "MuiGrid-grid-lg-4",
-                      "grid-lg-5": "MuiGrid-grid-lg-5",
-                      "grid-lg-6": "MuiGrid-grid-lg-6",
-                      "grid-lg-7": "MuiGrid-grid-lg-7",
-                      "grid-lg-8": "MuiGrid-grid-lg-8",
-                      "grid-lg-9": "MuiGrid-grid-lg-9",
-                      "grid-lg-auto": "MuiGrid-grid-lg-auto",
-                      "grid-lg-true": "MuiGrid-grid-lg-true",
-                      "grid-md-1": "MuiGrid-grid-md-1",
-                      "grid-md-10": "MuiGrid-grid-md-10",
-                      "grid-md-11": "MuiGrid-grid-md-11",
-                      "grid-md-12": "MuiGrid-grid-md-12",
-                      "grid-md-2": "MuiGrid-grid-md-2",
-                      "grid-md-3": "MuiGrid-grid-md-3",
-                      "grid-md-4": "MuiGrid-grid-md-4",
-                      "grid-md-5": "MuiGrid-grid-md-5",
-                      "grid-md-6": "MuiGrid-grid-md-6",
-                      "grid-md-7": "MuiGrid-grid-md-7",
-                      "grid-md-8": "MuiGrid-grid-md-8",
-                      "grid-md-9": "MuiGrid-grid-md-9",
-                      "grid-md-auto": "MuiGrid-grid-md-auto",
-                      "grid-md-true": "MuiGrid-grid-md-true",
-                      "grid-sm-1": "MuiGrid-grid-sm-1",
-                      "grid-sm-10": "MuiGrid-grid-sm-10",
-                      "grid-sm-11": "MuiGrid-grid-sm-11",
-                      "grid-sm-12": "MuiGrid-grid-sm-12",
-                      "grid-sm-2": "MuiGrid-grid-sm-2",
-                      "grid-sm-3": "MuiGrid-grid-sm-3",
-                      "grid-sm-4": "MuiGrid-grid-sm-4",
-                      "grid-sm-5": "MuiGrid-grid-sm-5",
-                      "grid-sm-6": "MuiGrid-grid-sm-6",
-                      "grid-sm-7": "MuiGrid-grid-sm-7",
-                      "grid-sm-8": "MuiGrid-grid-sm-8",
-                      "grid-sm-9": "MuiGrid-grid-sm-9",
-                      "grid-sm-auto": "MuiGrid-grid-sm-auto",
-                      "grid-sm-true": "MuiGrid-grid-sm-true",
-                      "grid-xl-1": "MuiGrid-grid-xl-1",
-                      "grid-xl-10": "MuiGrid-grid-xl-10",
-                      "grid-xl-11": "MuiGrid-grid-xl-11",
-                      "grid-xl-12": "MuiGrid-grid-xl-12",
-                      "grid-xl-2": "MuiGrid-grid-xl-2",
-                      "grid-xl-3": "MuiGrid-grid-xl-3",
-                      "grid-xl-4": "MuiGrid-grid-xl-4",
-                      "grid-xl-5": "MuiGrid-grid-xl-5",
-                      "grid-xl-6": "MuiGrid-grid-xl-6",
-                      "grid-xl-7": "MuiGrid-grid-xl-7",
-                      "grid-xl-8": "MuiGrid-grid-xl-8",
-                      "grid-xl-9": "MuiGrid-grid-xl-9",
-                      "grid-xl-auto": "MuiGrid-grid-xl-auto",
-                      "grid-xl-true": "MuiGrid-grid-xl-true",
-                      "grid-xs-1": "MuiGrid-grid-xs-1",
-                      "grid-xs-10": "MuiGrid-grid-xs-10",
-                      "grid-xs-11": "MuiGrid-grid-xs-11",
-                      "grid-xs-12": "MuiGrid-grid-xs-12",
-                      "grid-xs-2": "MuiGrid-grid-xs-2",
-                      "grid-xs-3": "MuiGrid-grid-xs-3",
-                      "grid-xs-4": "MuiGrid-grid-xs-4",
-                      "grid-xs-5": "MuiGrid-grid-xs-5",
-                      "grid-xs-6": "MuiGrid-grid-xs-6",
-                      "grid-xs-7": "MuiGrid-grid-xs-7",
-                      "grid-xs-8": "MuiGrid-grid-xs-8",
-                      "grid-xs-9": "MuiGrid-grid-xs-9",
-                      "grid-xs-auto": "MuiGrid-grid-xs-auto",
-                      "grid-xs-true": "MuiGrid-grid-xs-true",
-                      "item": "MuiGrid-item",
-                      "justify-xs-center": "MuiGrid-justify-xs-center",
-                      "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
-                      "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
-                      "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
-                      "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
-                      "root": "MuiGrid-root",
-                      "spacing-xs-1": "MuiGrid-spacing-xs-1",
-                      "spacing-xs-10": "MuiGrid-spacing-xs-10",
-                      "spacing-xs-2": "MuiGrid-spacing-xs-2",
-                      "spacing-xs-3": "MuiGrid-spacing-xs-3",
-                      "spacing-xs-4": "MuiGrid-spacing-xs-4",
-                      "spacing-xs-5": "MuiGrid-spacing-xs-5",
-                      "spacing-xs-6": "MuiGrid-spacing-xs-6",
-                      "spacing-xs-7": "MuiGrid-spacing-xs-7",
-                      "spacing-xs-8": "MuiGrid-spacing-xs-8",
-                      "spacing-xs-9": "MuiGrid-spacing-xs-9",
-                      "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
-                      "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
-                      "zeroMinWidth": "MuiGrid-zeroMinWidth",
-                    }
-                  }
+                                    </Transition>
+                                  </ForwardRef(Collapse)>
+                                </WithStyles(ForwardRef(Collapse))>
+                              </div>
+                            </ForwardRef(Paper)>
+                          </WithStyles(ForwardRef(Paper))>
+                        </ForwardRef(ExpansionPanel)>
+                      </WithStyles(ForwardRef(ExpansionPanel))>
+                    </div>
+                  </ForwardRef(Grid)>
+                </WithStyles(ForwardRef(Grid))>
+                <WithStyles(ForwardRef(Grid))
                   item={true}
                 >
-                  <div
-                    className="MuiGrid-root MuiGrid-item"
+                  <ForwardRef(Grid)
+                    classes={
+                      Object {
+                        "align-content-xs-center": "MuiGrid-align-content-xs-center",
+                        "align-content-xs-flex-end": "MuiGrid-align-content-xs-flex-end",
+                        "align-content-xs-flex-start": "MuiGrid-align-content-xs-flex-start",
+                        "align-content-xs-space-around": "MuiGrid-align-content-xs-space-around",
+                        "align-content-xs-space-between": "MuiGrid-align-content-xs-space-between",
+                        "align-items-xs-baseline": "MuiGrid-align-items-xs-baseline",
+                        "align-items-xs-center": "MuiGrid-align-items-xs-center",
+                        "align-items-xs-flex-end": "MuiGrid-align-items-xs-flex-end",
+                        "align-items-xs-flex-start": "MuiGrid-align-items-xs-flex-start",
+                        "container": "MuiGrid-container",
+                        "direction-xs-column": "MuiGrid-direction-xs-column",
+                        "direction-xs-column-reverse": "MuiGrid-direction-xs-column-reverse",
+                        "direction-xs-row-reverse": "MuiGrid-direction-xs-row-reverse",
+                        "grid-lg-1": "MuiGrid-grid-lg-1",
+                        "grid-lg-10": "MuiGrid-grid-lg-10",
+                        "grid-lg-11": "MuiGrid-grid-lg-11",
+                        "grid-lg-12": "MuiGrid-grid-lg-12",
+                        "grid-lg-2": "MuiGrid-grid-lg-2",
+                        "grid-lg-3": "MuiGrid-grid-lg-3",
+                        "grid-lg-4": "MuiGrid-grid-lg-4",
+                        "grid-lg-5": "MuiGrid-grid-lg-5",
+                        "grid-lg-6": "MuiGrid-grid-lg-6",
+                        "grid-lg-7": "MuiGrid-grid-lg-7",
+                        "grid-lg-8": "MuiGrid-grid-lg-8",
+                        "grid-lg-9": "MuiGrid-grid-lg-9",
+                        "grid-lg-auto": "MuiGrid-grid-lg-auto",
+                        "grid-lg-true": "MuiGrid-grid-lg-true",
+                        "grid-md-1": "MuiGrid-grid-md-1",
+                        "grid-md-10": "MuiGrid-grid-md-10",
+                        "grid-md-11": "MuiGrid-grid-md-11",
+                        "grid-md-12": "MuiGrid-grid-md-12",
+                        "grid-md-2": "MuiGrid-grid-md-2",
+                        "grid-md-3": "MuiGrid-grid-md-3",
+                        "grid-md-4": "MuiGrid-grid-md-4",
+                        "grid-md-5": "MuiGrid-grid-md-5",
+                        "grid-md-6": "MuiGrid-grid-md-6",
+                        "grid-md-7": "MuiGrid-grid-md-7",
+                        "grid-md-8": "MuiGrid-grid-md-8",
+                        "grid-md-9": "MuiGrid-grid-md-9",
+                        "grid-md-auto": "MuiGrid-grid-md-auto",
+                        "grid-md-true": "MuiGrid-grid-md-true",
+                        "grid-sm-1": "MuiGrid-grid-sm-1",
+                        "grid-sm-10": "MuiGrid-grid-sm-10",
+                        "grid-sm-11": "MuiGrid-grid-sm-11",
+                        "grid-sm-12": "MuiGrid-grid-sm-12",
+                        "grid-sm-2": "MuiGrid-grid-sm-2",
+                        "grid-sm-3": "MuiGrid-grid-sm-3",
+                        "grid-sm-4": "MuiGrid-grid-sm-4",
+                        "grid-sm-5": "MuiGrid-grid-sm-5",
+                        "grid-sm-6": "MuiGrid-grid-sm-6",
+                        "grid-sm-7": "MuiGrid-grid-sm-7",
+                        "grid-sm-8": "MuiGrid-grid-sm-8",
+                        "grid-sm-9": "MuiGrid-grid-sm-9",
+                        "grid-sm-auto": "MuiGrid-grid-sm-auto",
+                        "grid-sm-true": "MuiGrid-grid-sm-true",
+                        "grid-xl-1": "MuiGrid-grid-xl-1",
+                        "grid-xl-10": "MuiGrid-grid-xl-10",
+                        "grid-xl-11": "MuiGrid-grid-xl-11",
+                        "grid-xl-12": "MuiGrid-grid-xl-12",
+                        "grid-xl-2": "MuiGrid-grid-xl-2",
+                        "grid-xl-3": "MuiGrid-grid-xl-3",
+                        "grid-xl-4": "MuiGrid-grid-xl-4",
+                        "grid-xl-5": "MuiGrid-grid-xl-5",
+                        "grid-xl-6": "MuiGrid-grid-xl-6",
+                        "grid-xl-7": "MuiGrid-grid-xl-7",
+                        "grid-xl-8": "MuiGrid-grid-xl-8",
+                        "grid-xl-9": "MuiGrid-grid-xl-9",
+                        "grid-xl-auto": "MuiGrid-grid-xl-auto",
+                        "grid-xl-true": "MuiGrid-grid-xl-true",
+                        "grid-xs-1": "MuiGrid-grid-xs-1",
+                        "grid-xs-10": "MuiGrid-grid-xs-10",
+                        "grid-xs-11": "MuiGrid-grid-xs-11",
+                        "grid-xs-12": "MuiGrid-grid-xs-12",
+                        "grid-xs-2": "MuiGrid-grid-xs-2",
+                        "grid-xs-3": "MuiGrid-grid-xs-3",
+                        "grid-xs-4": "MuiGrid-grid-xs-4",
+                        "grid-xs-5": "MuiGrid-grid-xs-5",
+                        "grid-xs-6": "MuiGrid-grid-xs-6",
+                        "grid-xs-7": "MuiGrid-grid-xs-7",
+                        "grid-xs-8": "MuiGrid-grid-xs-8",
+                        "grid-xs-9": "MuiGrid-grid-xs-9",
+                        "grid-xs-auto": "MuiGrid-grid-xs-auto",
+                        "grid-xs-true": "MuiGrid-grid-xs-true",
+                        "item": "MuiGrid-item",
+                        "justify-xs-center": "MuiGrid-justify-xs-center",
+                        "justify-xs-flex-end": "MuiGrid-justify-xs-flex-end",
+                        "justify-xs-space-around": "MuiGrid-justify-xs-space-around",
+                        "justify-xs-space-between": "MuiGrid-justify-xs-space-between",
+                        "justify-xs-space-evenly": "MuiGrid-justify-xs-space-evenly",
+                        "root": "MuiGrid-root",
+                        "spacing-xs-1": "MuiGrid-spacing-xs-1",
+                        "spacing-xs-10": "MuiGrid-spacing-xs-10",
+                        "spacing-xs-2": "MuiGrid-spacing-xs-2",
+                        "spacing-xs-3": "MuiGrid-spacing-xs-3",
+                        "spacing-xs-4": "MuiGrid-spacing-xs-4",
+                        "spacing-xs-5": "MuiGrid-spacing-xs-5",
+                        "spacing-xs-6": "MuiGrid-spacing-xs-6",
+                        "spacing-xs-7": "MuiGrid-spacing-xs-7",
+                        "spacing-xs-8": "MuiGrid-spacing-xs-8",
+                        "spacing-xs-9": "MuiGrid-spacing-xs-9",
+                        "wrap-xs-nowrap": "MuiGrid-wrap-xs-nowrap",
+                        "wrap-xs-wrap-reverse": "MuiGrid-wrap-xs-wrap-reverse",
+                        "zeroMinWidth": "MuiGrid-zeroMinWidth",
+                      }
+                    }
+                    item={true}
                   >
-                    <Component>
-                      <div />
-                    </Component>
-                  </div>
-                </ForwardRef(Grid)>
-              </WithStyles(ForwardRef(Grid))>
-            </div>
-          </ForwardRef(Grid)>
-        </WithStyles(ForwardRef(Grid))>
-      </div>
-    </ForwardRef(Grid)>
-  </WithStyles(ForwardRef(Grid))>
-</MissionControl>
+                    <div
+                      className="MuiGrid-root MuiGrid-item"
+                    >
+                      <Component>
+                        <div />
+                      </Component>
+                    </div>
+                  </ForwardRef(Grid)>
+                </WithStyles(ForwardRef(Grid))>
+              </div>
+            </ForwardRef(Grid)>
+          </WithStyles(ForwardRef(Grid))>
+        </div>
+      </ForwardRef(Grid)>
+    </WithStyles(ForwardRef(Grid))>
+  </MissionControl>
+</Connect(MissionControl)>
 `;

--- a/src/translations/locales/en.json
+++ b/src/translations/locales/en.json
@@ -44,7 +44,7 @@
   "app.mission_control.details": "Project Details",
   "app.mission_control.edit": "Edit Project",
   "app.mission_control.sensors": "Sensors",
-  "app.mission_control.show_code": "Show Me The Code!",
+  "app.mission_control.show_code": "View JavaScript",
   "app.password_reset.email": "Enter your e-mail address below, and well send you an e-mail allowing you to reset it.",
   "app.password_reset.email_placeholder": "Email",
   "app.password_reset.header": "Password Reset",

--- a/src/translations/locales/es.json
+++ b/src/translations/locales/es.json
@@ -44,7 +44,7 @@
   "app.mission_control.details": "Project Details",
   "app.mission_control.edit": "Edit Project",
   "app.mission_control.sensors": "Sensores",
-  "app.mission_control.show_code": "Mostrame el Codigo!",
+  "app.mission_control.show_code": "Mostrame el JavaScript",
   "app.password_reset.email": "Introduzca su dirección de correo electrónico y le enviaremos un mensaje que le permitirá restablecerla.",
   "app.password_reset.email_placeholder": "Correo electrónico",
   "app.password_reset.header": "Recuperación de la cuenta",


### PR DESCRIPTION
Plays with the spacing in mission-control to get everything within the screen and eliminate both browser scrollbars. (hopefully)

Since there isn't any interaction with other users in Mission Control, I took the community policy footer out of there.