### PR TITLE
Remove warnings in tests

### DIFF
--- a/src/actions/__test__/code.test.js
+++ b/src/actions/__test__/code.test.js
@@ -41,7 +41,7 @@ describe('Code actions', () => {
     expect(payload).toEqual(EXECUTION_RUN);
   });
 
-  test('changeName', async () => {
+  test('changeName', (done) => {
     const mock = new MockAdapter(axios);
     const program = {
       id: 1,
@@ -57,12 +57,12 @@ describe('Code actions', () => {
 
     const action = changeName(1, 'test name');
     const { type } = action;
-    const payload = await action.payload;
-
     expect(type).toEqual('CHANGE_NAME');
-    expect(payload).toEqual(program);
-
-    mock.restore();
+    action.payload.then((result) => {
+      expect(result).toEqual(program);
+      mock.restore();
+      done();
+    });
   });
 
   test('changeId', () => {
@@ -73,7 +73,7 @@ describe('Code actions', () => {
     expect(payload).toEqual(123);
   });
 
-  test('fetch program', async () => {
+  test('fetch program', (done) => {
     const mock = new MockAdapter(axios);
     const program = {
       id: 1,
@@ -86,14 +86,15 @@ describe('Code actions', () => {
 
     const action = fetchProgram(1);
     const { type } = action;
-    const payload = await action.payload;
-
     expect(type).toEqual('FETCH_PROGRAM');
-    expect(payload).toEqual(program);
-    mock.restore();
+    action.payload.then((result) => {
+      expect(result).toEqual(program);
+      mock.restore();
+      done();
+    });
   });
 
-  test('save program', async () => {
+  test('save program', (done) => {
     const mock = new MockAdapter(axios);
     const program = {
       id: 1,
@@ -111,14 +112,15 @@ describe('Code actions', () => {
 
     const action = saveProgram(1, program.content, program.name, program.lesson);
     const { type } = action;
-    const payload = await action.payload;
-
     expect(type).toEqual('SAVE_PROGRAM');
-    expect(payload).toEqual(program);
-    mock.restore();
+    action.payload.then((result) => {
+      expect(result).toEqual(program);
+      mock.restore();
+      done();
+    });
   });
 
-  test('create program', async () => {
+  test('create program', (done) => {
     const mock = new MockAdapter(axios);
     const program = {
       name: 'mybd',
@@ -131,14 +133,15 @@ describe('Code actions', () => {
 
     const action = createProgram(program.name);
     const { type } = action;
-    const payload = await action.payload;
-
     expect(type).toEqual('CREATE_PROGRAM');
-    expect(payload).toEqual(program);
-    mock.restore();
+    action.payload.then((result) => {
+      expect(result).toEqual(program);
+      mock.restore();
+      done();
+    });
   });
 
-  test('change program tags', async () => {
+  test('change program tags', (done) => {
     const mock = new MockAdapter(axios);
     const program = {
       owner_tags: ['tag1', 'tag2'],
@@ -148,11 +151,12 @@ describe('Code actions', () => {
 
     const action = changeProgramTags(1, program.owner_tags);
     const { type } = action;
-    const payload = await action.payload;
-
     expect(type).toEqual('CHANGE_PROGRAM_TAGS');
-    expect(payload).toEqual(program);
-    mock.restore();
+    action.payload.then((result) => {
+      expect(result).toEqual(program);
+      mock.restore();
+      done();
+    });
   });
 
   test('changeReadOnly', () => {

--- a/src/actions/__test__/program.test.js
+++ b/src/actions/__test__/program.test.js
@@ -4,7 +4,7 @@ import { clearPrograms, fetchPrograms, removeProgram } from '../program';
 
 
 describe('Program actions', () => {
-  test('fetch all programs', async () => {
+  test('fetch all programs', (done) => {
     const mock = new MockAdapter(axios);
     const programs = [{
       id: 33,
@@ -17,24 +17,26 @@ describe('Program actions', () => {
 
     const action = fetchPrograms();
     const { type } = action;
-    const payload = await action.payload;
-
     expect(type).toEqual('FETCH_PROGRAMS');
-    expect(payload).toEqual(programs);
-    mock.restore();
+    action.payload.then((result) => {
+      expect(result).toEqual(programs);
+      mock.restore();
+      done();
+    });
   });
 
-  test('remove program', async () => {
+  test('remove program', (done) => {
     const mock = new MockAdapter(axios);
 
     mock.onDelete('/api/v1/block-diagrams/1/').reply(204);
 
     const action = removeProgram(1);
     const { type } = action;
-    await action.payload;
-
     expect(type).toEqual('REMOVE_PROGRAM');
-    mock.restore();
+    action.payload.then(() => {
+      mock.restore();
+      done();
+    });
   });
 
   test('clear programs', () => {

--- a/src/actions/__test__/rover.test.js
+++ b/src/actions/__test__/rover.test.js
@@ -15,32 +15,34 @@ describe('Rover actions', () => {
     expect(payload.name).toEqual('Sparky');
   });
 
-  test('connect rover', async () => {
+  test('connect rover', (done) => {
     const characteristic = {
       startNotifications: jest.fn(),
       addEventListener: jest.fn(),
     };
     const service = {
-      getCharacteristic: () => Promise.resolve(characteristic),
+      getCharacteristic: jest.fn().mockResolvedValue(characteristic),
     };
     const server = {
-      getPrimaryService: () => Promise.resolve(service),
+      getPrimaryService: jest.fn().mockResolvedValue(service),
     };
-    const action = connect({ gatt: { connect: () => Promise.resolve(server) } });
+    const action = connect({ gatt: { connect: jest.fn().mockResolvedValue(server) } });
     const { type } = action;
-    const payload = await action.payload;
-
     expect(type).toEqual('CONNECT_ROVER');
-    expect(payload).toEqual([characteristic, characteristic]);
+    action.payload.then((result) => {
+      expect(result).toEqual([characteristic, characteristic]);
+      done();
+    });
   });
 
-  test('rover send', async () => {
-    const action = send({ writeValue: () => Promise.resolve(null) });
+  test('rover send', (done) => {
+    const action = send({ writeValue: jest.fn().mockResolvedValue(null) });
     const { type } = action;
-    const payload = await action.payload;
-
     expect(type).toEqual('SEND_ROVER');
-    expect(payload).toEqual(null);
+    action.payload.then((result) => {
+      expect(result).toEqual(null);
+      done();
+    });
   });
 
   test('disconnect rover', () => {

--- a/src/actions/__test__/tag.test.js
+++ b/src/actions/__test__/tag.test.js
@@ -4,7 +4,7 @@ import { fetchTags } from '../tag';
 
 
 describe('Tag actions', () => {
-  test('fetch all tags', async () => {
+  test('fetch all tags', (done) => {
     const mock = new MockAdapter(axios);
     const tags = [{
       name: 'tag1',
@@ -16,10 +16,11 @@ describe('Tag actions', () => {
 
     const action = fetchTags();
     const { type } = action;
-    const payload = await action.payload;
-
     expect(type).toEqual('FETCH_TAGS');
-    expect(payload).toEqual(tags);
-    mock.restore();
+    action.payload.then((result) => {
+      expect(result).toEqual(tags);
+      mock.restore();
+      done();
+    });
   });
 });

--- a/src/actions/__test__/user.test.js
+++ b/src/actions/__test__/user.test.js
@@ -22,7 +22,7 @@ describe('User actions', () => {
     expect(type).toEqual('UPDATE_USER');
     expect(payload).toEqual(user);
   });
-  test('editUserUsername', async () => {
+  test('editUserUsername', (done) => {
     const mock = new MockAdapter(axios);
     const username = 'test_username';
     const user = {
@@ -37,12 +37,13 @@ describe('User actions', () => {
 
     const action = editUserUsername(username);
     const { type } = action;
-    const payload = await action.payload;
-
     expect(type).toEqual('EDIT_USER_USERNAME');
-    expect(payload).toEqual(user);
+    action.payload.then((result) => {
+      expect(result).toEqual(user);
+      done();
+    });
   });
-  test('editUserPassword', async () => {
+  test('editUserPassword', (done) => {
     const mock = new MockAdapter(axios);
     const password = 'password123';
 
@@ -53,12 +54,13 @@ describe('User actions', () => {
 
     const action = editUserPassword(password);
     const { type } = action;
-    const payload = await action.payload;
-
     expect(type).toEqual('EDIT_USER_PASSWORD');
-    expect(payload).toEqual('Password changed');
+    action.payload.then((result) => {
+      expect(result).toEqual('Password changed');
+      done();
+    });
   });
-  test('fetchUserList', async () => {
+  test('fetchUserList', (done) => {
     const mock = new MockAdapter(axios);
     const userList = [
       {
@@ -73,9 +75,10 @@ describe('User actions', () => {
 
     const action = fetchUserList();
     const { type } = action;
-    const payload = await action.payload;
-
     expect(type).toEqual('FETCH_USER_LIST');
-    expect(payload).toEqual(userList);
+    action.payload.then((result) => {
+      expect(result).toEqual(userList);
+      done();
+    });
   });
 });

--- a/src/components/ProgramList.js
+++ b/src/components/ProgramList.js
@@ -83,7 +83,7 @@ class ProgramList extends Component {
     const readOnly = program.dataset.owned === 'false';
 
 
-    fetchProgram(program.id).then(() => {
+    return fetchProgram(program.id).then(() => {
       changeReadOnly(readOnly);
       this.setState({
         programLoaded: true,

--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -502,7 +502,11 @@ class Workspace extends Component {
             <Grid item style={{ minHeight: code.isReadOnly ? '65vh' : '75vh', maxHeight: '1080px' }}>
               <div ref={(editorDiv) => { this.editorDiv = editorDiv; }} id="blocklyDiv">
                 <Box zIndex="modal" style={{ position: 'absolute', bottom: '15%', left: '10%' }}>
-                  { React.cloneElement(children, { isConnected: !!rover.rover }) }
+                  {
+                    React.Children.map(children, (child) => React.cloneElement(child, {
+                      isConnected: !!rover.rover,
+                    }))
+                  }
                 </Box>
               </div>
             </Grid>

--- a/src/components/__tests__/ConnectionHelp.test.js
+++ b/src/components/__tests__/ConnectionHelp.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { Redirect } from 'react-router-dom';
@@ -22,7 +21,7 @@ describe('The ConnectionHelp component', () => {
   });
 
   test('renders on the page with no errors', () => {
-    const wrapper = mount((
+    const wrapper = mountWithIntl((
       <Provider store={store}>
         <ConnectionHelp />
       </Provider>
@@ -33,7 +32,7 @@ describe('The ConnectionHelp component', () => {
   });
 
   test('handles opening and closing dialog', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithIntl(
       <ConnectionHelp store={store} />,
     ).find('ConnectionHelp').dive();
 
@@ -50,13 +49,16 @@ describe('The ConnectionHelp component', () => {
 
   test('handles redirect button', () => {
     store = mockStore({
+      user: {
+        // showConnectionHelpOnLogin: false, // TODO
+      },
       rover: {
         rover: {
           name: 'Jim',
         },
       },
     });
-    const wrapper = shallow(
+    const wrapper = shallowWithIntl(
       <ConnectionHelp store={store} />,
     ).find('ConnectionHelp').dive();
     expect(wrapper.find(Redirect).exists()).toBe(false);

--- a/src/components/__tests__/ProgramList.test.js
+++ b/src/components/__tests__/ProgramList.test.js
@@ -16,10 +16,10 @@ let clearProgramList;
 describe('The ProgramList component', () => {
   beforeEach(() => {
     changeReadOnly = jest.fn();
-    fetchProgram = jest.fn(() => Promise.resolve({}));
-    fetchPrograms = jest.fn(() => Promise.resolve({}));
-    removeProgram = jest.fn(() => Promise.resolve({}));
-    fetchTags = jest.fn(() => Promise.resolve({}));
+    fetchProgram = jest.fn().mockResolvedValue();
+    fetchPrograms = jest.fn().mockResolvedValue();
+    removeProgram = jest.fn().mockResolvedValue();
+    fetchTags = jest.fn().mockResolvedValue();
     clearProgram = jest.fn();
     clearProgramList = jest.fn();
   });
@@ -68,7 +68,7 @@ describe('The ProgramList component', () => {
     expect(clearProgram.mock.calls.length).toBe(1);
   });
 
-  test('shows the correct number of programs for the user', async () => {
+  test('shows the correct number of programs for the user', () => {
     const programs = {
       next: null,
       previous: null,
@@ -155,7 +155,7 @@ describe('The ProgramList component', () => {
     });
   });
 
-  test('loads a program', async () => {
+  test('loads a program', (done) => {
     const programs = {
       next: null,
       previous: null,
@@ -184,7 +184,7 @@ describe('The ProgramList component', () => {
       />,
     ).dive().dive();
 
-    await wrapper.instance().loadProgram({
+    wrapper.instance().loadProgram({
       target: {
         parentNode: {
           parentNode: {
@@ -196,35 +196,36 @@ describe('The ProgramList component', () => {
           owned: 'false',
         },
       },
-    });
+    }).then(() => {
+      expect(changeReadOnly).toHaveBeenCalledWith(true);
+      expect(fetchProgram).toHaveBeenCalledWith(33);
+      expect(wrapper.state('programLoaded')).toBe(true);
 
-    expect(changeReadOnly).toHaveBeenCalledWith(true);
-    expect(fetchProgram).toHaveBeenCalledWith(33);
-    expect(wrapper.state('programLoaded')).toBe(true);
+      wrapper.setState({
+        programLoaded: false,
+      });
 
-    wrapper.setState({
-      programLoaded: false,
-    });
-
-    await wrapper.instance().loadProgram({
-      target: {
-        parentNode: {
+      wrapper.instance().loadProgram({
+        target: {
           parentNode: {
-            id: 55,
-            dataset: {
-              owned: 'true',
+            parentNode: {
+              id: 55,
+              dataset: {
+                owned: 'true',
+              },
             },
           },
         },
-      },
+      }).then(() => {
+        expect(changeReadOnly).toHaveBeenCalledWith(false);
+        expect(fetchProgram).toHaveBeenCalledWith(33);
+        expect(wrapper.state('programLoaded')).toBe(true);
+        done();
+      });
     });
-
-    expect(changeReadOnly).toHaveBeenCalledWith(false);
-    expect(fetchProgram).toHaveBeenCalledWith(33);
-    expect(wrapper.state('programLoaded')).toBe(true);
   });
 
-  test('fetches user programs after page change', async () => {
+  test('fetches user programs after page change', () => {
     const programs = {
       next: null,
       previous: null,
@@ -253,7 +254,7 @@ describe('The ProgramList component', () => {
       />,
     ).dive().dive();
 
-    await wrapper.instance().fetchUserPrograms({
+    wrapper.instance().fetchUserPrograms({
       page: 2,
     }, true);
 
@@ -263,7 +264,7 @@ describe('The ProgramList component', () => {
     });
   });
 
-  test('fetches community programs after page change', async () => {
+  test('fetches community programs after page change', () => {
     const programs = {
       next: null,
       previous: null,
@@ -292,7 +293,7 @@ describe('The ProgramList component', () => {
       />,
     ).dive().dive();
 
-    await wrapper.instance().fetchCommunityPrograms({
+    wrapper.instance().fetchCommunityPrograms({
       page: 2,
     }, false);
 
@@ -384,7 +385,7 @@ describe('The ProgramList component', () => {
     });
   });
 
-  test('removes a program and reloads the program list', async () => {
+  test('removes a program and reloads the program list', (done) => {
     const programs = {
       next: null,
       previous: null,
@@ -419,10 +420,11 @@ describe('The ProgramList component', () => {
         name: 'Unnamed_Design_3',
       },
     });
-    await wrapper.instance().removeProgram();
-
-    expect(fetchPrograms).toHaveBeenCalledTimes(2);
-    expect(removeProgram).toHaveBeenCalledWith(33);
+    wrapper.instance().removeProgram().then(() => {
+      expect(fetchPrograms).toHaveBeenCalledTimes(2);
+      expect(removeProgram).toHaveBeenCalledWith(33);
+      done();
+    });
   });
 
   test('shows confirm dialog', () => {

--- a/src/components/__tests__/ProgramName.test.js
+++ b/src/components/__tests__/ProgramName.test.js
@@ -5,8 +5,11 @@ import configureStore from 'redux-mock-store';
 import { Cookies } from 'react-cookie';
 
 import { updateValidAuth } from '@/actions/auth';
-import { changeName } from '@/actions/code';
 import ProgramName from '../ProgramName';
+
+jest.mock('@/actions/code');
+
+import { changeName } from '@/actions/code'; // eslint-disable-line import/first, import/order
 
 const cookiesValues = { auth_jwt: '1234' };
 const cookies = new Cookies(cookiesValues);
@@ -23,7 +26,7 @@ describe('The ProgramName component', () => {
         isReadOnly: false,
       },
     });
-    store.dispatch = jest.fn(() => Promise.resolve());
+    store.dispatch = jest.fn().mockResolvedValue();
   });
 
   test('renders on the page with no errors', () => {
@@ -105,8 +108,8 @@ describe('The ProgramName component', () => {
       status: 401,
     };
     store.dispatch = jest.fn();
-    store.dispatch.mockReturnValueOnce(Promise.reject(error));
-    store.dispatch.mockReturnValue(Promise.resolve());
+    store.dispatch.mockRejectedValueOnce(error);
+    store.dispatch.mockResolvedValue();
 
     const wrapper = shallowWithIntl(<ProgramName store={store} />, { context }).dive();
     wrapper.dive().dive().dive().dive()
@@ -132,7 +135,7 @@ describe('The ProgramName component', () => {
     error.response = {
       status: 500,
     };
-    store.dispatch = jest.fn(() => Promise.reject(error));
+    store.dispatch = jest.fn().mockRejectedValue(error);
 
     const wrapper = shallowWithIntl(<ProgramName store={store} />, { context }).dive();
     wrapper.dive().dive().dive().dive()

--- a/src/components/__tests__/ProgramTags.test.js
+++ b/src/components/__tests__/ProgramTags.test.js
@@ -4,8 +4,12 @@ import configureStore from 'redux-mock-store';
 import { Cookies } from 'react-cookie';
 
 import { updateValidAuth } from '@/actions/auth';
-import { changeProgramTags } from '@/actions/code';
 import ProgramTags from '../ProgramTags';
+
+jest.mock('@/actions/code');
+jest.mock('@/actions/tag');
+
+import { changeProgramTags } from '@/actions/code'; // eslint-disable-line import/first, import/order
 
 const cookiesValues = { auth_jwt: '1234' };
 const cookies = new Cookies(cookiesValues);
@@ -31,7 +35,7 @@ describe('The ProgramTags component', () => {
         }],
       },
     });
-    store.dispatch = jest.fn(() => Promise.resolve());
+    store.dispatch = jest.fn().mockResolvedValue();
   });
 
   test('renders on the page with no errors', () => {
@@ -60,7 +64,7 @@ describe('The ProgramTags component', () => {
         tags: [],
       },
     });
-    localStore.dispatch = jest.fn(() => Promise.resolve());
+    localStore.dispatch = jest.fn().mockResolvedValue();
     const wrapper = shallowWithIntl(
       <ProgramTags store={localStore} />,
       { context },
@@ -96,8 +100,8 @@ describe('The ProgramTags component', () => {
       status: 401,
     };
     store.dispatch = jest.fn();
-    store.dispatch.mockReturnValueOnce(Promise.reject(error));
-    store.dispatch.mockReturnValue(Promise.resolve());
+    store.dispatch.mockRejectedValueOnce(error);
+    store.dispatch.mockResolvedValue();
 
     const wrapper = shallowWithIntl(<ProgramTags store={store} />, { context }).dive().dive().dive()
       .dive()
@@ -121,7 +125,7 @@ describe('The ProgramTags component', () => {
     error.response = {
       status: 500,
     };
-    store.dispatch = jest.fn(() => Promise.reject(error));
+    store.dispatch = jest.fn().mockRejectedValue(error);
 
     const wrapper = shallowWithIntl(<ProgramTags store={store} />, { context }).dive().dive().dive()
       .dive()

--- a/src/components/__tests__/RoverConnection.test.js
+++ b/src/components/__tests__/RoverConnection.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
 import { EXECUTION_STOP } from '@/actions/code';
 import { COVERED, NOT_COVERED } from '@/actions/sensor';
 import RoverConnection from '../RoverConnection';
@@ -35,12 +34,12 @@ describe('The RoverConnection component', () => {
     changeExecutionState = jest.fn();
     changeLeftSensorState = jest.fn();
     changeRightSensorState = jest.fn();
-    connectToRover = jest.fn(() => Promise.resolve({}));
+    connectToRover = jest.fn().mockResolvedValue();
     disconnectFromRover = jest.fn();
-    scanForRover = jest.fn(() => Promise.resolve({ value: rover }));
+    scanForRover = jest.fn().mockResolvedValue({ value: rover });
     write = jest.fn();
 
-    wrapper = shallow(
+    wrapper = shallowWithIntl(
       <RoverConnection
         changeExecutionState={changeExecutionState}
         changeLeftSensorState={changeLeftSensorState}
@@ -56,7 +55,7 @@ describe('The RoverConnection component', () => {
   });
 
   test('renders disconnect button when connected', () => {
-    wrapper = mount(
+    wrapper = mountWithIntl(
       <RoverConnection
         changeExecutionState={changeExecutionState}
         changeLeftSensorState={changeLeftSensorState}
@@ -78,7 +77,7 @@ describe('The RoverConnection component', () => {
   });
 
   test('renders connect button when not connected', () => {
-    wrapper = mount(
+    wrapper = mountWithIntl(
       <RoverConnection
         changeExecutionState={changeExecutionState}
         changeLeftSensorState={changeLeftSensorState}
@@ -99,7 +98,7 @@ describe('The RoverConnection component', () => {
   });
 
   test('renders disabled connect button when on unsupported platform', () => {
-    wrapper = mount(
+    wrapper = mountWithIntl(
       <RoverConnection
         changeExecutionState={changeExecutionState}
         changeLeftSensorState={changeLeftSensorState}
@@ -123,7 +122,7 @@ describe('The RoverConnection component', () => {
   });
 
   test('should set and clear menu anchor element when menu is opening and closing', () => {
-    wrapper = shallow(
+    wrapper = shallowWithIntl(
       <RoverConnection
         changeExecutionState={changeExecutionState}
         changeLeftSensorState={changeLeftSensorState}
@@ -317,12 +316,13 @@ describe('The RoverConnection component', () => {
     expect(write).toHaveBeenCalledWith('Dew Point Sensor - 24 C');
   });
 
-  test('connects to rover', async () => {
-    await wrapper.instance().connect();
-
-    expect(scanForRover).toHaveBeenCalled();
-    expect(rover.addEventListener).toHaveBeenCalled();
-    expect(connectToRover).toHaveBeenCalledWith(rover, wrapper.instance().onMessage);
+  test('connects to rover', (done) => {
+    wrapper.instance().connect().then(() => {
+      expect(scanForRover).toHaveBeenCalled();
+      expect(rover.addEventListener).toHaveBeenCalled();
+      expect(connectToRover).toHaveBeenCalledWith(rover, wrapper.instance().onMessage);
+      done();
+    });
   });
 
   test('disconnects from rover', () => {

--- a/src/components/__tests__/TopNav.test.js
+++ b/src/components/__tests__/TopNav.test.js
@@ -3,8 +3,11 @@ import { Redirect } from 'react-router-dom';
 import { shallow } from 'enzyme';
 import { Cookies } from 'react-cookie';
 import configureStore from 'redux-mock-store';
-import { logout } from '@/actions/auth';
 import TopNav from '../TopNav';
+
+jest.mock('@/actions/auth');
+
+import { logout } from '@/actions/auth'; // eslint-disable-line import/first, import/order
 
 const cookies = new Cookies();
 const mockStore = configureStore();

--- a/src/components/__tests__/UserSetting.test.js
+++ b/src/components/__tests__/UserSetting.test.js
@@ -9,8 +9,8 @@ let editUserUsername;
 
 describe('The UserSetting component', () => {
   beforeEach(() => {
-    editUserPassword = jest.fn(() => Promise.resolve({}));
-    editUserUsername = jest.fn(() => Promise.resolve({}));
+    editUserPassword = jest.fn().mockResolvedValue();
+    editUserUsername = jest.fn().mockResolvedValue();
   });
 
   test('renders on the page with no errors', () => {
@@ -48,7 +48,7 @@ describe('The UserSetting component', () => {
     expect(wrapper.find({ type: 'password' }).exists()).toBe(false);
   });
 
-  test('saves user username', async () => {
+  test('saves user username', (done) => {
     const user = {
       user_id: 1,
       username: 'testuser',
@@ -70,17 +70,18 @@ describe('The UserSetting component', () => {
       },
     });
     wrapper.update();
-    await wrapper.instance().saveUserUsername({ preventDefault: jest.fn() });
-
-    expect(wrapper.state('saveSuccess')).toBe(true);
-    expect(wrapper.state('usernameError')).toBeNull();
-    expect(wrapper.find(Redirect).exists()).toBe(true);
-    expect(wrapper.find(Redirect).prop('to')).toBe('/accounts/login');
-    expect(editUserPassword).not.toHaveBeenCalled();
-    expect(editUserUsername).toHaveBeenCalledWith('newuser');
+    wrapper.instance().saveUserUsername({ preventDefault: jest.fn() }).then(() => {
+      expect(wrapper.state('saveSuccess')).toBe(true);
+      expect(wrapper.state('usernameError')).toBeNull();
+      expect(wrapper.find(Redirect).exists()).toBe(true);
+      expect(wrapper.find(Redirect).prop('to')).toBe('/accounts/login');
+      expect(editUserPassword).not.toHaveBeenCalled();
+      expect(editUserUsername).toHaveBeenCalledWith('newuser');
+      done();
+    });
   });
 
-  test('saves user password', async () => {
+  test('saves user password', (done) => {
     const user = {
       user_id: 1,
       username: 'testuser',
@@ -108,18 +109,19 @@ describe('The UserSetting component', () => {
       },
     });
     wrapper.update();
-    await wrapper.instance().saveUserPassword({ preventDefault: jest.fn() });
-
-    expect(wrapper.state('saveSuccess')).toBe(true);
-    expect(wrapper.state('password1Error')).toBeNull();
-    expect(wrapper.state('password2Error')).toBeNull();
-    expect(wrapper.find(Redirect).exists()).toBe(true);
-    expect(wrapper.find(Redirect).prop('to')).toBe('/accounts/login');
-    expect(editUserUsername).not.toHaveBeenCalled();
-    expect(editUserPassword).toHaveBeenCalledWith('password');
+    wrapper.instance().saveUserPassword({ preventDefault: jest.fn() }).then(() => {
+      expect(wrapper.state('saveSuccess')).toBe(true);
+      expect(wrapper.state('password1Error')).toBeNull();
+      expect(wrapper.state('password2Error')).toBeNull();
+      expect(wrapper.find(Redirect).exists()).toBe(true);
+      expect(wrapper.find(Redirect).prop('to')).toBe('/accounts/login');
+      expect(editUserUsername).not.toHaveBeenCalled();
+      expect(editUserPassword).toHaveBeenCalledWith('password');
+      done();
+    });
   });
 
-  test('errors on password mismatch', async () => {
+  test('errors on password mismatch', () => {
     const user = {
       user_id: 1,
       username: 'testuser',
@@ -147,7 +149,7 @@ describe('The UserSetting component', () => {
       },
     });
     wrapper.update();
-    await wrapper.instance().saveUserPassword({ preventDefault: jest.fn() });
+    wrapper.instance().saveUserPassword({ preventDefault: jest.fn() });
 
     expect(wrapper.state('saveSuccess')).toBe(false);
     expect(wrapper.state('password1Error')).toEqual(['Passwords must match']);
@@ -158,7 +160,7 @@ describe('The UserSetting component', () => {
     expect(editUserPassword).not.toHaveBeenCalled();
   });
 
-  test('displays error on username save error', async () => {
+  test('displays error on username save error', (done) => {
     const user = {
       user_id: 1,
       username: 'testuser',
@@ -172,7 +174,7 @@ describe('The UserSetting component', () => {
         username: ['Username taken'],
       },
     };
-    editUserUsername = jest.fn(() => Promise.reject(error));
+    editUserUsername = jest.fn().mockRejectedValue(error);
     const wrapper = shallowWithIntl(
       <UserSetting
         user={user}
@@ -181,18 +183,19 @@ describe('The UserSetting component', () => {
       />,
     ).dive().dive();
 
-    await wrapper.instance().saveUserUsername({ preventDefault: jest.fn() });
-
-    expect(wrapper.state('saveSuccess')).toBe(false);
-    expect(wrapper.state('usernameError')).toEqual(['Username taken']);
-    expect(wrapper.find(Alert).exists()).toBe(true);
-    expect(wrapper.find(Alert).last().prop('severity')).toBe('error');
-    expect(wrapper.find(TextField).first().prop('error')).toBe(true);
-    expect(wrapper.find(TextField).at(1).prop('error')).toBe(false);
-    expect(wrapper.find(TextField).at(2).prop('error')).toBe(false);
+    wrapper.instance().saveUserUsername({ preventDefault: jest.fn() }).then(() => {
+      expect(wrapper.state('saveSuccess')).toBe(false);
+      expect(wrapper.state('usernameError')).toEqual(['Username taken']);
+      expect(wrapper.find(Alert).exists()).toBe(true);
+      expect(wrapper.find(Alert).last().prop('severity')).toBe('error');
+      expect(wrapper.find(TextField).first().prop('error')).toBe(true);
+      expect(wrapper.find(TextField).at(1).prop('error')).toBe(false);
+      expect(wrapper.find(TextField).at(2).prop('error')).toBe(false);
+      done();
+    });
   });
 
-  test('displays error on password save error', async () => {
+  test('displays error on password save error', (done) => {
     const user = {
       user_id: 1,
       username: 'testuser',
@@ -207,7 +210,7 @@ describe('The UserSetting component', () => {
         new_password2: ['Too short'],
       },
     };
-    editUserPassword = jest.fn(() => Promise.reject(error));
+    editUserPassword = jest.fn().mockRejectedValue(error);
     const wrapper = shallowWithIntl(
       <UserSetting
         user={user}
@@ -216,15 +219,16 @@ describe('The UserSetting component', () => {
       />,
     ).dive().dive();
 
-    await wrapper.instance().saveUserPassword({ preventDefault: jest.fn() });
-
-    expect(wrapper.state('saveSuccess')).toBe(false);
-    expect(wrapper.state('password1Error')).toEqual(['Too short']);
-    expect(wrapper.state('password2Error')).toEqual(['Too short']);
-    expect(wrapper.find(Alert).exists()).toBe(true);
-    expect(wrapper.find(Alert).last().prop('severity')).toBe('error');
-    expect(wrapper.find(TextField).first().prop('error')).toBe(false);
-    expect(wrapper.find(TextField).at(1).prop('error')).toBe(true);
-    expect(wrapper.find(TextField).at(2).prop('error')).toBe(true);
+    wrapper.instance().saveUserPassword({ preventDefault: jest.fn() }).then(() => {
+      expect(wrapper.state('saveSuccess')).toBe(false);
+      expect(wrapper.state('password1Error')).toEqual(['Too short']);
+      expect(wrapper.state('password2Error')).toEqual(['Too short']);
+      expect(wrapper.find(Alert).exists()).toBe(true);
+      expect(wrapper.find(Alert).last().prop('severity')).toBe('error');
+      expect(wrapper.find(TextField).first().prop('error')).toBe(false);
+      expect(wrapper.find(TextField).at(1).prop('error')).toBe(true);
+      expect(wrapper.find(TextField).at(2).prop('error')).toBe(true);
+      done();
+    });
   });
 });

--- a/src/components/__tests__/Workspace.test.js
+++ b/src/components/__tests__/Workspace.test.js
@@ -4,7 +4,17 @@ import toJson from 'enzyme-to-json';
 import { Cookies } from 'react-cookie';
 import configureStore from 'redux-mock-store';
 import { updateValidAuth } from '@/actions/auth';
-import {
+import { COVERED, NOT_COVERED } from '@/actions/sensor';
+import Workspace from '../Workspace'; // eslint-disable-line import/order
+
+jest.mock('node-blockly/browser');
+jest.mock('sumo-logger');
+jest.mock('@/actions/code');
+jest.mock('@/actions/rover');
+
+import Blockly from 'node-blockly/browser'; // eslint-disable-line import/first, import/order
+import SumoLogger from 'sumo-logger'; // eslint-disable-line import/first, import/order
+import { // eslint-disable-line import/first
   changeExecutionState,
   createProgram,
   fetchProgram,
@@ -13,17 +23,8 @@ import {
   EXECUTION_STEP,
   EXECUTION_STOP,
   EXECUTION_RESET,
-} from '@/actions/code';
-import { COVERED, NOT_COVERED } from '@/actions/sensor';
-import { send } from '@/actions/rover';
-
-jest.mock('node-blockly/browser');
-jest.mock('sumo-logger');
-
-import Blockly from 'node-blockly/browser'; // eslint-disable-line import/first, import/order
-import SumoLogger from 'sumo-logger'; // eslint-disable-line import/first, import/order
-import Workspace from '../Workspace'; // eslint-disable-line import/first, import/order
-
+} from '@/actions/code'; // eslint-disable-line import/order
+import { send } from '@/actions/rover'; // eslint-disable-line import/first, import/order
 
 const cookiesValues = { auth_jwt: '1234' };
 const cookies = new Cookies(cookiesValues);
@@ -56,7 +57,7 @@ describe('The Workspace component', () => {
         },
       },
     });
-    store.dispatch = jest.fn(() => Promise.resolve());
+    store.dispatch = jest.fn().mockResolvedValue();
     playground = {
       addChangeListener: jest.fn((cb) => { cb(); }),
       highlightBlock: jest.fn(),
@@ -294,7 +295,7 @@ describe('The Workspace component', () => {
         right: NOT_COVERED,
       },
     });
-    localStore.dispatch = jest.fn(() => Promise.resolve());
+    localStore.dispatch = jest.fn().mockResolvedValue();
     const workspace = shallowWithIntl(
       <Workspace store={localStore}>
         <div />
@@ -667,7 +668,7 @@ describe('The Workspace component', () => {
         right: NOT_COVERED,
       },
     });
-    localStore.dispatch = jest.fn(() => Promise.resolve());
+    localStore.dispatch = jest.fn().mockResolvedValue();
     shallowWithIntl(
       <Workspace store={localStore}>
         <div />
@@ -689,8 +690,8 @@ describe('The Workspace component', () => {
       status: 401,
     };
     store.dispatch = jest.fn();
-    store.dispatch.mockReturnValueOnce(Promise.reject(error));
-    store.dispatch.mockReturnValue(Promise.resolve());
+    store.dispatch.mockRejectedValueOnce(error);
+    store.dispatch.mockResolvedValue();
 
     const wrapper = shallowWithIntl(
       <Workspace store={store}>
@@ -719,7 +720,7 @@ describe('The Workspace component', () => {
     error.response = {
       status: 500,
     };
-    store.dispatch = jest.fn(() => Promise.reject(error));
+    store.dispatch = jest.fn().mockRejectedValue(error);
 
     const wrapper = shallowWithIntl(
       <Workspace store={store}>
@@ -748,8 +749,8 @@ describe('The Workspace component', () => {
       status: 401,
     };
     store.dispatch = jest.fn();
-    store.dispatch.mockReturnValueOnce(Promise.reject(error));
-    store.dispatch.mockReturnValue(Promise.resolve());
+    store.dispatch.mockRejectedValueOnce(error);
+    store.dispatch.mockResolvedValue();
 
     const wrapper = shallowWithIntl(
       <Workspace store={store}>
@@ -778,7 +779,7 @@ describe('The Workspace component', () => {
     error.response = {
       status: 500,
     };
-    store.dispatch = jest.fn(() => Promise.reject(error));
+    store.dispatch = jest.fn().mockRejectedValue(error);
 
     const wrapper = shallowWithIntl(
       <Workspace store={store}>
@@ -807,8 +808,8 @@ describe('The Workspace component', () => {
       status: 401,
     };
     store.dispatch = jest.fn();
-    store.dispatch.mockReturnValueOnce(Promise.reject(error));
-    store.dispatch.mockReturnValue(Promise.resolve());
+    store.dispatch.mockRejectedValueOnce(error);
+    store.dispatch.mockResolvedValue();
 
     const wrapper = shallowWithIntl(
       <Workspace store={store}>
@@ -837,7 +838,7 @@ describe('The Workspace component', () => {
     error.response = {
       status: 500,
     };
-    store.dispatch = jest.fn(() => Promise.reject(error));
+    store.dispatch = jest.fn().mockRejectedValue(error);
 
     const wrapper = shallowWithIntl(
       <Workspace store={store}>
@@ -933,7 +934,7 @@ describe('The Workspace component', () => {
         right: NOT_COVERED,
       },
     });
-    localStore.dispatch = jest.fn(() => Promise.resolve());
+    localStore.dispatch = jest.fn().mockResolvedValue();
     const wrapper = shallowWithIntl(
       <Workspace store={localStore}>
         <div />
@@ -961,27 +962,27 @@ describe('The Workspace component', () => {
         right: NOT_COVERED,
       },
     });
-    localStore.dispatch = jest.fn(() => Promise.resolve());
-    const mockCreateProgram = jest.fn(() => Promise.resolve({
+    localStore.dispatch = jest.fn().mockResolvedValue();
+    const mockCreateProgram = jest.fn().mockResolvedValue({
       value: {
         id: 2,
         name: 'test program',
         lesson: 50,
       },
-    }));
-    const mockFetchProgram = jest.fn(() => Promise.resolve({
+    });
+    const mockFetchProgram = jest.fn().mockResolvedValue({
       value: {
         id: 1,
         name: 'test program',
         content: '<xml></xml>',
         reference_of: 50,
       },
-    }));
-    const mockSaveProgram = jest.fn(() => Promise.resolve({
+    });
+    const mockSaveProgram = jest.fn().mockResolvedValue({
       value: {
         name: 'test program',
       },
-    }));
+    });
     const workspace = shallowWithIntl(
       <Workspace store={localStore}>
         <div />
@@ -1019,27 +1020,27 @@ describe('The Workspace component', () => {
         right: NOT_COVERED,
       },
     });
-    localStore.dispatch = jest.fn(() => Promise.resolve());
-    const mockCreateProgram = jest.fn(() => Promise.resolve({
+    localStore.dispatch = jest.fn().mockResolvedValue();
+    const mockCreateProgram = jest.fn().mockResolvedValue({
       value: {
         id: 2,
         name: 'test program',
         lesson: null,
       },
-    }));
-    const mockFetchProgram = jest.fn(() => Promise.resolve({
+    });
+    const mockFetchProgram = jest.fn().mockResolvedValue({
       value: {
         id: 1,
         name: 'test program',
         content: '<xml></xml>',
         reference_of: null,
       },
-    }));
-    const mockSaveProgram = jest.fn(() => Promise.resolve({
+    });
+    const mockSaveProgram = jest.fn().mockResolvedValue({
       value: {
         name: 'test program',
       },
-    }));
+    });
     const workspace = shallowWithIntl(
       <Workspace store={localStore}>
         <div />
@@ -1106,6 +1107,8 @@ describe('The Workspace component', () => {
       .dive()
       .dive();
 
+    store.dispatch.mockClear();
+
     expect(store.dispatch).not.toHaveBeenCalledWith(saveProgram());
 
     jest.advanceTimersByTime(500);
@@ -1132,6 +1135,8 @@ describe('The Workspace component', () => {
       .dive()
       .dive()
       .dive();
+
+    store.dispatch.mockClear();
 
     expect(store.dispatch).not.toHaveBeenCalledWith(saveProgram());
 

--- a/src/components/__tests__/__snapshots__/ProgramTags.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ProgramTags.test.js.snap
@@ -8,10 +8,7 @@ exports[`The ProgramTags component renders on the page with no errors 1`] = `
       "dispatch": [MockFunction] {
         "calls": Array [
           Array [
-            Object {
-              "payload": Promise {},
-              "type": "FETCH_TAGS",
-            },
+            undefined,
           ],
         ],
         "results": Array [
@@ -45,10 +42,7 @@ exports[`The ProgramTags component renders on the page with no errors 1`] = `
         "dispatch": [MockFunction] {
           "calls": Array [
             Array [
-              Object {
-                "payload": Promise {},
-                "type": "FETCH_TAGS",
-              },
+              undefined,
             ],
           ],
           "results": Array [
@@ -82,10 +76,7 @@ exports[`The ProgramTags component renders on the page with no errors 1`] = `
           "dispatch": [MockFunction] {
             "calls": Array [
               Array [
-                Object {
-                  "payload": Promise {},
-                  "type": "FETCH_TAGS",
-                },
+                undefined,
               ],
             ],
             "results": Array [
@@ -152,10 +143,7 @@ exports[`The ProgramTags component renders on the page with no errors 1`] = `
             "dispatch": [MockFunction] {
               "calls": Array [
                 Array [
-                  Object {
-                    "payload": Promise {},
-                    "type": "FETCH_TAGS",
-                  },
+                  undefined,
                 ],
               ],
               "results": Array [
@@ -233,10 +221,7 @@ exports[`The ProgramTags component renders on the page with no errors 1`] = `
               "dispatch": [MockFunction] {
                 "calls": Array [
                   Array [
-                    Object {
-                      "payload": Promise {},
-                      "type": "FETCH_TAGS",
-                    },
+                    undefined,
                   ],
                 ],
                 "results": Array [

--- a/src/components/__tests__/__snapshots__/Workspace.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Workspace.test.js.snap
@@ -19,10 +19,7 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
             },
           ],
           Array [
-            Object {
-              "payload": Promise {},
-              "type": "CREATE_PROGRAM",
-            },
+            undefined,
           ],
         ],
         "results": Array [
@@ -75,10 +72,7 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
               },
             ],
             Array [
-              Object {
-                "payload": Promise {},
-                "type": "CREATE_PROGRAM",
-              },
+              undefined,
             ],
           ],
           "results": Array [
@@ -131,10 +125,7 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
                 },
               ],
               Array [
-                Object {
-                  "payload": Promise {},
-                  "type": "CREATE_PROGRAM",
-                },
+                undefined,
               ],
             ],
             "results": Array [
@@ -220,10 +211,7 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
                   },
                 ],
                 Array [
-                  Object {
-                    "payload": Promise {},
-                    "type": "CREATE_PROGRAM",
-                  },
+                  undefined,
                 ],
               ],
               "results": Array [
@@ -341,10 +329,7 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
                     },
                   ],
                   Array [
-                    Object {
-                      "payload": Promise {},
-                      "type": "CREATE_PROGRAM",
-                    },
+                    undefined,
                   ],
                 ],
                 "results": Array [
@@ -781,6 +766,7 @@ exports[`The Workspace component renders on the page with no errors 1`] = `
                                     >
                                       <div
                                         isConnected={true}
+                                        key=".0"
                                       />
                                     </div>
                                   </Styled(MuiBox)>

--- a/src/containers/Accounts/LoginCallback.js
+++ b/src/containers/Accounts/LoginCallback.js
@@ -49,7 +49,7 @@ class LoginCallback extends Component {
       })
       .catch((error) => {
         let errorMessage = null;
-        if (error.response) {
+        if (error.response && error.response.data) {
           errorMessage = error.response.data.non_field_errors;
         }
         this.setState({

--- a/src/containers/Accounts/__tests__/Login.test.js
+++ b/src/containers/Accounts/__tests__/Login.test.js
@@ -10,10 +10,13 @@ import MockAdapter from 'axios-mock-adapter';
 import configureStore from 'redux-mock-store';
 import jwtDecode from 'jwt-decode';
 
-import { updateValidAuth } from '@/actions/auth';
-import { updateUser } from '@/actions/user';
+import Login from '../Login'; // eslint-disable-line import/order
 
-import Login from '../Login';
+jest.mock('@/actions/auth');
+jest.mock('@/actions/user');
+
+import { updateValidAuth } from '@/actions/auth'; // eslint-disable-line import/first, import/order
+import { updateUser } from '@/actions/user'; // eslint-disable-line import/first, import/order
 
 const mockStore = configureStore();
 const store = mockStore();
@@ -49,7 +52,7 @@ test('Login mounts on the page with no errors', () => {
   expect(wrapper.find(Alert).exists()).toBe(false);
 });
 
-test('Login redirects to social api on button click', async () => {
+test('Login redirects to social api on button click', (done) => {
   const url = 'https://accounts.google.com/o/oauth2/auth?redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fauth%2Fsocial%2Fgoogle%2Fcallback';
   mock.reset();
   mock.onPost('/jwt/auth/social/google/auth-server/').reply(200, { url });
@@ -77,14 +80,15 @@ test('Login redirects to social api on button click', async () => {
     .dive()
     .dive();
 
-  await wrapper.instance().redirectToSocial(element);
-
-  expect(window.location.assign).toBeCalledWith(
-    'https://accounts.google.com/o/oauth2/auth?redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Faccounts%2Flogin%2Fcallback%2Fgoogle',
-  );
+  wrapper.instance().redirectToSocial(element).then(() => {
+    expect(window.location.assign).toBeCalledWith(
+      'https://accounts.google.com/o/oauth2/auth?redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Faccounts%2Flogin%2Fcallback%2Fgoogle',
+    );
+    done();
+  });
 });
 
-test('Login shows error message on api error', async () => {
+test('Login shows error message on api error', (done) => {
   mock.reset();
   mock.onPost('/jwt/auth/social/google/auth-server/').timeout();
   Object.defineProperty(window, 'location', {
@@ -110,14 +114,16 @@ test('Login shows error message on api error', async () => {
     .dive()
     .dive();
 
-  await wrapper.instance().redirectToSocial(element);
-  wrapper.update();
+  wrapper.instance().redirectToSocial(element).then(() => {
+    wrapper.update();
 
-  expect(wrapper.find(Alert).exists()).toBe(true);
-  expect(wrapper.find(AlertTitle).children().find(FormattedMessage).prop('defaultMessage')).toBe(
-    'There was an error initiating social login.',
-  );
-  expect(window.location.assign).not.toBeCalled();
+    expect(wrapper.find(Alert).exists()).toBe(true);
+    expect(wrapper.find(AlertTitle).children().find(FormattedMessage).prop('defaultMessage')).toBe(
+      'There was an error initiating social login.',
+    );
+    expect(window.location.assign).not.toBeCalled();
+    done();
+  });
 });
 
 test('Login shows error message on callback error', () => {
@@ -143,7 +149,7 @@ test('Login shows error message on callback error', () => {
   expect(wrapper.find(Alert).find('WithStyles(ForwardRef(Typography))').text()).toBe(localLocation.state.callbackError[0]);
 });
 
-test('Login redirects to root after basic login success', async () => {
+test('Login redirects to root after basic login success', (done) => {
   const token = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VybmFtZSI6ImFkbWluIiwiZXhwIjoxNTQwMzQzMjIxLCJlbWFpbCI6ImFkbWluQGV4YW1wbGUuY29tIiwib3JpZ19pYXQiOjE1NDAzMzk2MjF9.tumcSSAbKeWXc2QDd7KFR9IGh3PCsyHnCe6JLSszWpc';
   const username = 'admin';
   const password = 'password';
@@ -175,18 +181,22 @@ test('Login redirects to root after basic login success', async () => {
     },
   });
 
-  await wrapper.instance().basicLogin({ preventDefault: jest.fn() });
-  wrapper.update();
+  wrapper.instance().basicLogin({ preventDefault: jest.fn() }).then(() => {
+    wrapper.update();
 
-  expect(cookies.get('auth_jwt')).toBe(token);
-  expect(wrapper.find(Redirect).exists()).toBe(true);
-  expect(store.dispatch).toHaveBeenCalledWith(updateUser({ ...jwtDecode(token), isSocial: false }));
-  expect(store.dispatch).toHaveBeenCalledWith(updateValidAuth(true));
+    expect(cookies.get('auth_jwt')).toBe(token);
+    expect(wrapper.find(Redirect).exists()).toBe(true);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      updateUser({ ...jwtDecode(token), isSocial: false }),
+    );
+    expect(store.dispatch).toHaveBeenCalledWith(updateValidAuth(true));
 
-  cookies.remove('auth_jwt');
+    cookies.remove('auth_jwt');
+    done();
+  });
 });
 
-test('Login shows error message after basic login failure', async () => {
+test('Login shows error message after basic login failure', (done) => {
   const username = 'admin';
   const password = 'password';
 
@@ -215,12 +225,14 @@ test('Login shows error message after basic login failure', async () => {
     },
   });
 
-  await wrapper.instance().basicLogin({ preventDefault: jest.fn() });
-  wrapper.update();
+  wrapper.instance().basicLogin({ preventDefault: jest.fn() }).then(() => {
+    wrapper.update();
 
-  expect(wrapper.find(Alert).exists()).toBe(true);
-  expect(wrapper.find(AlertTitle).children().find(FormattedMessage).prop('defaultMessage')).toBe(
-    'Invalid username or password.',
-  );
-  expect(cookies.get('auth_jwt')).toBeUndefined();
+    expect(wrapper.find(Alert).exists()).toBe(true);
+    expect(wrapper.find(AlertTitle).children().find(FormattedMessage).prop('defaultMessage')).toBe(
+      'Invalid username or password.',
+    );
+    expect(cookies.get('auth_jwt')).toBeUndefined();
+    done();
+  });
 });

--- a/src/containers/Accounts/__tests__/PasswordReset.test.js
+++ b/src/containers/Accounts/__tests__/PasswordReset.test.js
@@ -15,7 +15,7 @@ test('PasswordReset renders on the page with no errors', () => {
   expect(wrapper.find(Alert).exists()).toBe(false);
 });
 
-test('PasswordReset displays form errors', async () => {
+test('PasswordReset displays form errors', (done) => {
   mock.reset();
   mock.onPost('/jwt/auth/password/reset/').reply(400, {
     email: [
@@ -24,16 +24,18 @@ test('PasswordReset displays form errors', async () => {
   });
   const wrapper = shallowWithIntl(<PasswordReset />).dive().dive();
 
-  await wrapper.instance().reset({ preventDefault: jest.fn() });
-  wrapper.update();
+  wrapper.instance().reset({ preventDefault: jest.fn() }).then(() => {
+    wrapper.update();
 
-  expect(wrapper.find(Alert).exists()).toBe(true);
-  expect(wrapper.find(ListItemText).length).toBe(1);
-  expect(wrapper.find(ListItemText).at(0).prop('children')).toBe('- This field may not be blank.');
-  expect(wrapper.find(TextField).at(0).prop('error')).toBeTruthy();
+    expect(wrapper.find(Alert).exists()).toBe(true);
+    expect(wrapper.find(ListItemText).length).toBe(1);
+    expect(wrapper.find(ListItemText).at(0).prop('children')).toBe('- This field may not be blank.');
+    expect(wrapper.find(TextField).at(0).prop('error')).toBeTruthy();
+    done();
+  });
 });
 
-test('PasswordReset displays success', async () => {
+test('PasswordReset displays success', (done) => {
   const email = 'admin@example.com';
 
   mock.reset();
@@ -50,10 +52,12 @@ test('PasswordReset displays success', async () => {
     },
   });
 
-  await wrapper.instance().reset({ preventDefault: jest.fn() });
-  wrapper.update();
+  wrapper.instance().reset({ preventDefault: jest.fn() }).then(() => {
+    wrapper.update();
 
-  expect(wrapper.find(Alert).exists()).toBe(true);
-  expect(wrapper.find(Alert).prop('children')).toBe('Password reset e-mail has been sent.');
-  expect(wrapper.find(TextField).at(0).prop('error')).toBeFalsy();
+    expect(wrapper.find(Alert).exists()).toBe(true);
+    expect(wrapper.find(Alert).prop('children')).toBe('Password reset e-mail has been sent.');
+    expect(wrapper.find(TextField).at(0).prop('error')).toBeFalsy();
+    done();
+  });
 });

--- a/src/containers/Accounts/__tests__/PasswordResetCallback.test.js
+++ b/src/containers/Accounts/__tests__/PasswordResetCallback.test.js
@@ -23,7 +23,7 @@ test('PasswordResetCallback renders on the page with no errors', () => {
   expect(wrapper.find(Alert).exists()).toBe(false);
 });
 
-test('PasswordResetCallback displays form errors', async () => {
+test('PasswordResetCallback displays form errors', (done) => {
   mock.reset();
   mock.onPost('/jwt/auth/password/reset/confirm/').reply(400, {
     new_password2: [
@@ -33,18 +33,20 @@ test('PasswordResetCallback displays form errors', async () => {
   });
   const wrapper = shallowWithIntl(<PasswordResetCallback match={match} />).dive().dive();
 
-  await wrapper.instance().confirm({ preventDefault: jest.fn() });
-  wrapper.update();
+  wrapper.instance().confirm({ preventDefault: jest.fn() }).then(() => {
+    wrapper.update();
 
-  expect(wrapper.find(Alert).exists()).toBe(true);
-  expect(wrapper.find(ListItemText).length).toBe(2);
-  expect(wrapper.find(ListItemText).at(0).prop('children')).toBe('- This password is too short. It must contain at least 8 characters.');
-  expect(wrapper.find(ListItemText).at(1).prop('children')).toBe('- This password is too common.');
-  expect(wrapper.find(TextField).at(0).prop('error')).toBeFalsy();
-  expect(wrapper.find(TextField).at(1).prop('error')).toBeTruthy();
+    expect(wrapper.find(Alert).exists()).toBe(true);
+    expect(wrapper.find(ListItemText).length).toBe(2);
+    expect(wrapper.find(ListItemText).at(0).prop('children')).toBe('- This password is too short. It must contain at least 8 characters.');
+    expect(wrapper.find(ListItemText).at(1).prop('children')).toBe('- This password is too common.');
+    expect(wrapper.find(TextField).at(0).prop('error')).toBeFalsy();
+    expect(wrapper.find(TextField).at(1).prop('error')).toBeTruthy();
+    done();
+  });
 });
 
-test('SignUp redirects to login after success', async () => {
+test('SignUp redirects to login after success', (done) => {
   const password1 = 'password123';
   const password2 = 'password123';
 
@@ -70,9 +72,11 @@ test('SignUp redirects to login after success', async () => {
     },
   });
 
-  await wrapper.instance().confirm({ preventDefault: jest.fn() });
-  wrapper.update();
+  wrapper.instance().confirm({ preventDefault: jest.fn() }).then(() => {
+    wrapper.update();
 
-  expect(wrapper.find(Redirect).exists()).toBe(true);
-  expect(wrapper.find(Redirect).prop('to')).toBe('/accounts/login');
+    expect(wrapper.find(Redirect).exists()).toBe(true);
+    expect(wrapper.find(Redirect).prop('to')).toBe('/accounts/login');
+    done();
+  });
 });

--- a/src/containers/Accounts/__tests__/SignUp.test.js
+++ b/src/containers/Accounts/__tests__/SignUp.test.js
@@ -8,9 +8,11 @@ import MockAdapter from 'axios-mock-adapter';
 import configureStore from 'redux-mock-store';
 import jwtDecode from 'jwt-decode';
 
-import { updateUser } from '@/actions/user';
-
 import SignUp from '../SignUp';
+
+jest.mock('@/actions/user');
+
+import { updateUser } from '@/actions/user'; // eslint-disable-line import/first, import/order
 
 const mockStore = configureStore();
 const store = mockStore();
@@ -34,7 +36,7 @@ test('SignUp renders on the page with no errors', () => {
   expect(wrapper.find(Alert).exists()).toBe(false);
 });
 
-test('SignUp displays form errors', async () => {
+test('SignUp displays form errors', (done) => {
   mock.reset();
   mock.onPost('/jwt/auth/registration/').reply(400, {
     username: ['A user with that username already exists.'],
@@ -52,23 +54,25 @@ test('SignUp displays form errors', async () => {
   const wrapper = cookiesWrapper.dive().dive().dive().dive()
     .dive()
     .dive();
-  await wrapper.instance().signUp({ preventDefault: jest.fn() });
-  wrapper.update();
+  wrapper.instance().signUp({ preventDefault: jest.fn() }).then(() => {
+    wrapper.update();
 
-  expect(wrapper.find(Alert).exists()).toBe(true);
-  expect(wrapper.find(ListItemText).length).toBe(5);
-  expect(wrapper.find(ListItemText).at(0).prop('children')).toBe('- A user with that username already exists.');
-  expect(wrapper.find(ListItemText).at(1).prop('children')).toBe('- Enter a valid email address.');
-  expect(wrapper.find(ListItemText).at(2).prop('children')).toBe('- This password is too short. It must contain at least 8 characters.');
-  expect(wrapper.find(ListItemText).at(3).prop('children')).toBe('- This password is too common.');
-  expect(wrapper.find(ListItemText).at(4).prop('children')).toBe('- This password is entirely numeric.');
-  expect(wrapper.find(TextField).at(0).prop('error')).toBeTruthy();
-  expect(wrapper.find(TextField).at(1).prop('error')).toBeTruthy();
-  expect(wrapper.find(TextField).at(2).prop('error')).toBeTruthy();
-  expect(wrapper.find(TextField).at(3).prop('error')).toBeFalsy();
+    expect(wrapper.find(Alert).exists()).toBe(true);
+    expect(wrapper.find(ListItemText).length).toBe(5);
+    expect(wrapper.find(ListItemText).at(0).prop('children')).toBe('- A user with that username already exists.');
+    expect(wrapper.find(ListItemText).at(1).prop('children')).toBe('- Enter a valid email address.');
+    expect(wrapper.find(ListItemText).at(2).prop('children')).toBe('- This password is too short. It must contain at least 8 characters.');
+    expect(wrapper.find(ListItemText).at(3).prop('children')).toBe('- This password is too common.');
+    expect(wrapper.find(ListItemText).at(4).prop('children')).toBe('- This password is entirely numeric.');
+    expect(wrapper.find(TextField).at(0).prop('error')).toBeTruthy();
+    expect(wrapper.find(TextField).at(1).prop('error')).toBeTruthy();
+    expect(wrapper.find(TextField).at(2).prop('error')).toBeTruthy();
+    expect(wrapper.find(TextField).at(3).prop('error')).toBeFalsy();
+    done();
+  });
 });
 
-test('SignUp redirects to root after success', async () => {
+test('SignUp redirects to root after success', (done) => {
   const token = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VybmFtZSI6ImFkbWluIiwiZXhwIjoxNTQwMzQzMjIxLCJlbWFpbCI6ImFkbWluQGV4YW1wbGUuY29tIiwib3JpZ19pYXQiOjE1NDAzMzk2MjF9.tumcSSAbKeWXc2QDd7KFR9IGh3PCsyHnCe6JLSszWpc';
   const username = 'admin';
   const email = 'admin@example.com';
@@ -113,13 +117,17 @@ test('SignUp redirects to root after success', async () => {
     },
   });
 
-  await wrapper.instance().signUp({ preventDefault: jest.fn() });
-  wrapper.update();
+  wrapper.instance().signUp({ preventDefault: jest.fn() }).then(() => {
+    wrapper.update();
 
-  expect(cookies.get('auth_jwt')).toBe(token);
-  expect(wrapper.find(Redirect).exists()).toBe(true);
-  expect(wrapper.find(Redirect).prop('to')).toBe('/');
-  expect(store.dispatch).toHaveBeenCalledWith(updateUser({ ...jwtDecode(token), isSocial: false }));
+    expect(cookies.get('auth_jwt')).toBe(token);
+    expect(wrapper.find(Redirect).exists()).toBe(true);
+    expect(wrapper.find(Redirect).prop('to')).toBe('/');
+    expect(store.dispatch).toHaveBeenCalledWith(
+      updateUser({ ...jwtDecode(token), isSocial: false }),
+    );
 
-  cookies.remove('auth_jwt');
+    cookies.remove('auth_jwt');
+    done();
+  });
 });

--- a/src/containers/__tests__/MissionControl.test.js
+++ b/src/containers/__tests__/MissionControl.test.js
@@ -37,7 +37,7 @@ describe('The MissionControl container', () => {
         commands: [],
       },
     });
-    store.dispatch = jest.fn(() => Promise.resolve({}));
+    store.dispatch = jest.fn().mockResolvedValue();
   });
 
   test('renders on the page with no errors', () => {

--- a/src/containers/__tests__/ProgramList.test.js
+++ b/src/containers/__tests__/ProgramList.test.js
@@ -1,14 +1,17 @@
 import React from 'react';
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
 import { shallow } from 'enzyme';
 import { Cookies } from 'react-cookie';
 import configureStore from 'redux-mock-store';
-import ProgramList from '../ProgramList';
-import { changeReadOnly, clearProgram, fetchProgram } from '../../actions/code';
-import { clearPrograms, fetchPrograms, removeProgram } from '../../actions/program';
-import { fetchTags } from '../../actions/tag';
-import { updateValidAuth } from '../../actions/auth';
+import { updateValidAuth } from '@/actions/auth';
+import ProgramList from '../ProgramList'; // eslint-disable-line import/order
+
+jest.mock('@/actions/code');
+jest.mock('@/actions/program');
+jest.mock('@/actions/tag');
+
+import { changeReadOnly, clearProgram, fetchProgram } from '@/actions/code'; // eslint-disable-line import/first, import/order
+import { clearPrograms, fetchPrograms, removeProgram } from '@/actions/program'; // eslint-disable-line import/first, import/order
+import { fetchTags } from '@/actions/tag'; // eslint-disable-line import/first, import/order
 
 const cookiesValues = { auth_jwt: '1234' };
 const cookies = new Cookies(cookiesValues);
@@ -39,7 +42,7 @@ describe('The ProgramListContainer', () => {
 
     const mockStore = configureStore();
     store = mockStore(defaultState);
-    store.dispatch = jest.fn(() => Promise.resolve());
+    store.dispatch = jest.fn().mockResolvedValue();
 
     const mockAuthFailStore = configureStore();
     const authError = new Error();
@@ -48,8 +51,8 @@ describe('The ProgramListContainer', () => {
     };
     authFailStore = mockAuthFailStore(defaultState);
     authFailStore.dispatch = jest.fn();
-    authFailStore.dispatch.mockReturnValueOnce(Promise.reject(authError));
-    authFailStore.dispatch.mockReturnValue(Promise.resolve());
+    authFailStore.dispatch.mockRejectedValueOnce(authError);
+    authFailStore.dispatch.mockResolvedValue();
 
     const mockOtherFailStore = configureStore();
     const error = new Error();
@@ -57,23 +60,11 @@ describe('The ProgramListContainer', () => {
       status: 500,
     };
     otherFailStore = mockOtherFailStore(defaultState);
-    otherFailStore.dispatch = jest.fn(() => Promise.reject(error));
+    otherFailStore.dispatch = jest.fn().mockRejectedValue(error);
 
     wrapper = shallow(<ProgramList store={store} />, { context }).dive().dive().dive();
   });
   test('dispatches an action to fetch programs', () => {
-    const programs = {
-      total_pages: 1,
-      results: [{
-        id: 33,
-        name: 'Unnamed_Design_3',
-        content: '<xml><variables></variables></xml>',
-        user: 10,
-      }],
-    };
-    const mockAxios = new MockAdapter(axios);
-
-    mockAxios.onGet('/api/v1/block-diagrams/').reply(200, programs);
     wrapper.dive().props().fetchPrograms({
       user__not: 10,
     }, 2);
@@ -85,27 +76,9 @@ describe('The ProgramListContainer', () => {
         },
       }),
     );
-
-    mockAxios.restore();
   });
 
   test('dispatches an action to fetch programs for a user', () => {
-    const programs = {
-      total_pages: 1,
-      results: [{
-        id: 33,
-        name: 'Unnamed_Design_3',
-        content: '<xml><variables></variables></xml>',
-        user: 10,
-      }],
-    };
-    const mockAxios = new MockAdapter(axios);
-
-    mockAxios.onGet('/api/v1/block-diagrams/', {
-      params: {
-        user: 10,
-      },
-    }).reply(200, programs);
     wrapper.dive().props().fetchPrograms({
       user: 10,
     });
@@ -120,20 +93,9 @@ describe('The ProgramListContainer', () => {
         },
       }),
     );
-
-    mockAxios.restore();
   });
 
   test('dispatches an action to fetch specific program', () => {
-    const program = {
-      id: 33,
-      name: 'Unnamed_Design_3',
-      content: '<xml><variables></variables></xml>',
-      user: 10,
-    };
-    const mockAxios = new MockAdapter(axios);
-
-    mockAxios.onGet('/api/v1/block-diagrams/1/').reply(200, program);
     wrapper.dive().props().fetchProgram(1);
 
     expect(store.dispatch).toHaveBeenCalledWith(
@@ -143,14 +105,9 @@ describe('The ProgramListContainer', () => {
         },
       }),
     );
-
-    mockAxios.restore();
   });
 
   test('dispatches an action to remove a program', () => {
-    const mockAxios = new MockAdapter(axios);
-
-    mockAxios.onDelete('/api/v1/block-diagrams/1/').reply(204);
     wrapper.dive().props().removeProgram(1);
 
     expect(store.dispatch).toHaveBeenCalledWith(
@@ -160,14 +117,9 @@ describe('The ProgramListContainer', () => {
         },
       }),
     );
-
-    mockAxios.restore();
   });
 
   test('dispatches an action to fetch tags', () => {
-    const mockAxios = new MockAdapter(axios);
-
-    mockAxios.onGet('/api/v1/tags/').reply(200);
     wrapper.dive().props().fetchTags();
 
     expect(store.dispatch).toHaveBeenCalledWith(
@@ -177,8 +129,6 @@ describe('The ProgramListContainer', () => {
         },
       }),
     );
-
-    mockAxios.restore();
   });
 
   test('handles authentication error fetching programs', (done) => {

--- a/src/containers/__tests__/RoverConnection.test.js
+++ b/src/containers/__tests__/RoverConnection.test.js
@@ -20,7 +20,7 @@ describe('The RoverConnectionContainer', () => {
         name: 'Sparky',
       },
     });
-    store.dispatch = jest.fn(() => Promise.resolve());
+    store.dispatch = jest.fn().mockResolvedValue();
     wrapper = shallow(<RoverConnection store={store} />).dive();
   });
 


### PR DESCRIPTION
Removes all warnings in the tests except for one (`Warning: React does not recognize the `isConnected` prop on a DOM element.`). I have not been able to find any way to remove it. Even when passing a React component, the warning still persists. It only happens in the `mount` case which leads me to believe the component is being broken down into DOM elements.
Also, converts all tests from using `async...await` to calling `done()` in the handler which exposed some tests that weren't even asynchronous using that syntax. Finally, converted to using `mockResolvedValue` and `mockRejectedValue` which cleared up some warnings and is simpler syntax.