### PR TITLE
Make logger noop when no endpoint

### DIFF
--- a/jestsetup.js
+++ b/jestsetup.js
@@ -8,6 +8,8 @@ global.TextEncoder = TextEncoder;
 
 global.PXT_HEX_URL = 'https://some-url';
 
+global.LOGGER_ENDPOINT = 'https://some-sumo-url/rovercode';
+
 const mockDevice = { name: 'Sparky' };
 const mockBluetooth = {
   requestDevice: jest.fn(() => mockDevice),

--- a/src/utils/__tests__/logger.test.js
+++ b/src/utils/__tests__/logger.test.js
@@ -1,12 +1,22 @@
 import SumoLogger from 'sumo-logger';
-import logger from '../logger';
+import logger, { Logger } from '../logger';
 
 jest.mock('sumo-logger');
 
 describe('Logger', () => {
+  afterEach(() => {
+    SumoLogger.mockClear();
+  });
+
   test('sends message to logger', () => {
     logger.log('test message');
     expect(SumoLogger).toHaveBeenCalled();
     expect(SumoLogger.mock.instances[0].log).toHaveBeenCalledWith('test message');
+  });
+
+  test('does nothing when no endpoint is provided', () => {
+    const localLogger = new Logger('');
+    localLogger.log('test message');
+    expect(SumoLogger).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,16 +1,20 @@
 import SumoLogger from 'sumo-logger';
 
-const opts = {
-  endpoint: LOGGER_ENDPOINT, // eslint-disable-line no-undef
-  returnPromise: true,
-};
 
-class Logger {
-  constructor() {
+export class Logger {
+  constructor(endpoint) {
+    if (!endpoint) {
+      this.logger = null;
+      return;
+    }
+    const opts = {
+      endpoint,
+      returnPromise: true,
+    };
     this.logger = new SumoLogger(opts);
   }
 
-  log = (message) => this.logger.log(message)
+  log = (message) => (this.logger ? this.logger.log(message) : null);
 }
 
-export default new Logger();
+export default new Logger(LOGGER_ENDPOINT); // eslint-disable-line no-undef


### PR DESCRIPTION
This makes the logger util do nothing when no endpoint is provided.
This fixes the error where we couldn't remix when running locally.