### PR TITLE
Make connection help redirect to courses

### DIFF
--- a/src/components/ConnectionHelp.js
+++ b/src/components/ConnectionHelp.js
@@ -284,7 +284,7 @@ class ConnectionHelp extends Component {
             {
               done ? (
                 <Redirect to={{
-                  pathname: '/programs/mine',
+                  pathname: '/courses',
                 }}
                 />
               ) : (null)

--- a/src/components/__tests__/ConnectionHelp.test.js
+++ b/src/components/__tests__/ConnectionHelp.test.js
@@ -65,7 +65,7 @@ describe('The ConnectionHelp component', () => {
     wrapper.find('WithStyles(ForwardRef(Button))').at(2).simulate('click');
     expect(wrapper.find(Redirect).exists()).toBe(true);
     expect(wrapper.find(Redirect).at(0).prop('to')).toEqual({
-      pathname: '/programs/mine',
+      pathname: '/courses',
     });
     expect(wrapper.state('open')).toBe(false);
   });


### PR DESCRIPTION
Now that we have the Courses page, let's make the ConnectionHelp modal dump users there.