### PR TITLE
Make courses expanded by default

### DIFF
--- a/src/components/Course.js
+++ b/src/components/Course.js
@@ -13,7 +13,7 @@ import PropTypes from 'prop-types';
 import LessonCard from './LessonCard';
 
 const Course = ({ course, onLessonClick }) => (
-  <ExpansionPanel>
+  <ExpansionPanel expanded>
     <ExpansionPanelSummary expandIcon={<ExpandMore />}>
       <Typography>
         { course.name }

--- a/src/components/CourseList.js
+++ b/src/components/CourseList.js
@@ -43,6 +43,9 @@ const styles = (theme) => ({
       minWidth: theme.breakpoints.values.lg,
     },
   },
+  listContainer: {
+    marginTop: theme.spacing(2),
+  },
   paginationPaddedBox: {
     display: 'flex',
     justifyContent: 'center',
@@ -266,7 +269,9 @@ class CourseList extends Component {
               </Grid>
             ) : (
               <Grid item>
-                <Box m={2}>
+                <Box
+                  className={classes.listContainer}
+                >
                   {
                     courses.results.map((course) => (
                       <Course key={course.id} course={course} onLessonClick={this.loadProgram} />
@@ -321,6 +326,7 @@ CourseList.defaultProps = {
 CourseList.propTypes = {
   classes: PropTypes.shape({
     mainContainer: PropTypes.string.isRequired,
+    listContainer: PropTypes.string.isRequired,
     paginationPaddedBox: PropTypes.string.isRequired,
   }).isRequired,
   fetchCourses: PropTypes.func.isRequired,

--- a/src/components/__tests__/__snapshots__/Course.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Course.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`The Course component renders on the page with no errors 1`] = `
-<WithStyles(ForwardRef(ExpansionPanel))>
+<WithStyles(ForwardRef(ExpansionPanel))
+  expanded={true}
+>
   <WithStyles(ForwardRef(ExpansionPanelSummary))
     expandIcon={<Memo(ExpandMoreIcon) />}
   >

--- a/src/components/__tests__/__snapshots__/CourseList.test.js.snap
+++ b/src/components/__tests__/__snapshots__/CourseList.test.js.snap
@@ -116,7 +116,7 @@ exports[`The CourseList component renders on the page with no errors 1`] = `
         item={true}
       >
         <Styled(MuiBox)
-          m={2}
+          className="CourseList-listContainer-2"
         >
           <Course
             course={
@@ -157,7 +157,7 @@ exports[`The CourseList component renders on the page with no errors 1`] = `
       </WithStyles(ForwardRef(Grid))>
     </WithStyles(ForwardRef(Grid))>
     <Styled(MuiBox)
-      className="CourseList-paginationPaddedBox-2"
+      className="CourseList-paginationPaddedBox-3"
     >
       <WithStyles(ForwardRef(Pagination))
         color="secondary"


### PR DESCRIPTION
Since we'll only have a few courses for a while, I thought they ExpansionPanel in the course list could default to being open.

In the future, we could be smarter by opening up only the first course with incomplete lessons (or something like that).

Thoughts?

I also adjusted some padding so that the ExpansionPanel lines up with the search box but still has some vertical padding.