### PR TITLE
Remove help icon on lesson cards

### DIFF
--- a/src/components/LessonCard.js
+++ b/src/components/LessonCard.js
@@ -6,7 +6,7 @@ import {
   CardActionArea,
   SvgIcon,
 } from '@material-ui/core';
-import { CheckCircle, Help, Lens } from '@material-ui/icons';
+import { CheckCircle, Lens } from '@material-ui/icons';
 import { makeStyles } from '@material-ui/core/styles';
 import { grey } from '@material-ui/core/colors';
 import PropTypes from 'prop-types';
@@ -31,10 +31,6 @@ const LessonCard = ({ lesson, onClick }) => {
 
   const progressIcon = () => {
     switch (progress) {
-      case 'AVAILABLE':
-      case 'UNAVAILABLE':
-        return (null);
-
       case 'IN_PROGRESS':
         return (<Lens className={classes.inProgress} />);
 
@@ -42,7 +38,7 @@ const LessonCard = ({ lesson, onClick }) => {
         return (<CheckCircle className={classes.complete} />);
 
       default:
-        return (<Help />);
+        return (null);
     }
   };
 

--- a/src/components/__tests__/LessonCard.test.js
+++ b/src/components/__tests__/LessonCard.test.js
@@ -53,6 +53,6 @@ describe('The LessonCard component', () => {
     const wrapper = shallow(<LessonCard lesson={lesson} onClick={onClick} />);
 
     expect(wrapper.find(CardActionArea).prop('disabled')).toBe(false);
-    expect(wrapper.find(CardHeader).prop('action').props.children.type.displayName).toBe('HelpIcon');
+    expect(wrapper.find(CardHeader).prop('action').props.children).toBeNull();
   });
 });


### PR DESCRIPTION
Removes the AVAILABLE and UNAVAILABLE states for now, since we don't have logic to set them. Makes the default icon null on lesson cards.