### PR TITLE
Handle single char messages by padding

### DIFF
--- a/src/utils/__tests__/blockly-api.test.js
+++ b/src/utils/__tests__/blockly-api.test.js
@@ -181,4 +181,17 @@ describe('Blockly API', () => {
     // 11 characters in 'hello world' times 1500 ms each
     expect(beginSleep).toHaveBeenCalledWith(16500);
   });
+
+  test('handles displayMessage with single charatcter message by padding', () => {
+    const displayMessageHandler = interpreter.createNativeFunction.mock.calls[8][0];
+
+    const result = displayMessageHandler({ data: 'h' });
+
+    expect(result).toBe(false);
+    expect(sendToRover).toHaveBeenCalledTimes(1);
+    expect(sendToRover).toHaveBeenCalledWith('disp: h \n');
+    expect(beginSleep).toHaveBeenCalled();
+    // 3 characters in ' h ' times 1500 ms each
+    expect(beginSleep).toHaveBeenCalledWith(4500);
+  });
 });

--- a/src/utils/blockly-api.js
+++ b/src/utils/blockly-api.js
@@ -26,6 +26,10 @@ class BlocklyApi {
   }
 
   sendDisplayCommand = (message) => {
+    if (message.length < 2) {
+      // pad with spaces to ensure scrolling
+      message = ` ${message} `;
+    }
     this.sendToRover(`disp:${message}\n`);
     // Give 1.5 seconds per letter to display
     this.beginSleep(message.length * 1500);


### PR DESCRIPTION
The micro:bit display library handles single-char strings differently than multi-char strings. It always scrolls multi-char strings (which takes some time), but single-char strings it just displays then moves onto the next line of code.

We display the smiley again after displaying the user's message. That means that if the message was only a single character long, it barely flashed on the display before the display was reset to the smiley.

To make the experience consistent, this PR pads single-character messages with spaces so that they scroll. 

In the future maybe this could be handled on the micro:bit side so that the UI can be agnostic. But while we're learning more about the micro:bit's code size limitations, I'd like to avoid adding more logic there.