### PR TITLE
Change interpreter to class variable

### DIFF
--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -185,13 +185,13 @@ class Workspace extends Component {
     this.sleeping = false;
     this.runningEnabled = false;
     this.highlightPause = false;
+    this.interpreter = null;
 
     this.api = new BlocklyApi(this.highlightBlock, this.beginSleep,
       this.sensorStateCache, writeToConsole, this.sendToRover);
 
     this.state = {
       workspace: null,
-      interpreter: null,
     };
   }
 
@@ -361,9 +361,7 @@ class Workspace extends Component {
 
     updateJsCode(code);
 
-    this.setState({
-      interpreter: new Interpreter(code, this.api.initApi),
-    });
+    this.interpreter = new Interpreter(code, this.api.initApi);
 
     return code;
   }
@@ -402,14 +400,14 @@ class Workspace extends Component {
   }
 
   stepCode = () => {
-    const { interpreter, workspace } = this.state;
+    const { workspace } = this.state;
     const { rover } = this.props;
 
     if (this.sleeping || rover.isSending) {
       return true;
     }
 
-    const ok = interpreter.step();
+    const ok = this.interpreter.step();
     if (!ok) {
       // Program complete, no more code to execute.
       workspace.highlightBlock(null);

--- a/src/components/__tests__/Workspace.test.js
+++ b/src/components/__tests__/Workspace.test.js
@@ -494,11 +494,9 @@ describe('The Workspace component', () => {
       .dive()
       .dive();
 
-    workspace.setState({
-      interpreter: {
-        step: jest.fn(() => false),
-      },
-    });
+    workspace.instance().interpreter = {
+      step: jest.fn(() => false),
+    };
     const result = workspace.instance().stepCode();
 
     expect(result).toBe(false);
@@ -516,11 +514,9 @@ describe('The Workspace component', () => {
       .dive()
       .dive();
 
-    workspace.setState({
-      interpreter: {
-        step: jest.fn(() => true),
-      },
-    });
+    workspace.instance().interpreter = {
+      step: jest.fn(() => true),
+    };
     workspace.instance().goToStopState = jest.fn();
     workspace.instance().highlightPause = true;
     workspace.update();
@@ -544,9 +540,7 @@ describe('The Workspace component', () => {
     const mockInterpreter = {
       step: jest.fn(() => true),
     };
-    workspace.setState({
-      interpreter: mockInterpreter,
-    });
+    workspace.instance().interpreter = mockInterpreter;
     workspace.update();
     workspace.instance().sleeping = true;
     const result = workspace.instance().stepCode();
@@ -568,11 +562,9 @@ describe('The Workspace component', () => {
       .dive()
       .dive();
 
-    workspace.setState({
-      interpreter: {
-        step: mockStep,
-      },
-    });
+    workspace.instance().interpreter = {
+      step: mockStep,
+    };
     workspace.instance().goToStopState = jest.fn();
     workspace.update();
     const result = workspace.instance().stepCode();


### PR DESCRIPTION
Closes #234 

`interpreter` does not need to be in the state. By being in the state, it causes a render to happen when the new interpreter is created. Somehow, this must be causing the interpreter to not be recreated correctly and commands to be duplicated