### PR TITLE
Clear lesson

### DIFF
--- a/src/actions/__test__/code.test.js
+++ b/src/actions/__test__/code.test.js
@@ -14,6 +14,7 @@ import {
   clearProgram,
   remixProgram,
   fetchLesson,
+  clearLesson,
   EXECUTION_RUN,
 } from '../code';
 
@@ -161,6 +162,14 @@ describe('Code actions', () => {
       mock.restore();
       done();
     });
+  });
+
+  test('clearLesson', () => {
+    const action = clearLesson();
+    const { type, payload } = action;
+
+    expect(type).toEqual('CLEAR_LESSON');
+    expect(payload).toBeUndefined();
   });
 
   test('change program tags', (done) => {

--- a/src/actions/code.js
+++ b/src/actions/code.js
@@ -23,6 +23,7 @@ export const FETCH_LESSON = 'FETCH_LESSON';
 export const FETCH_LESSON_PENDING = `${FETCH_LESSON}_PENDING`;
 export const FETCH_LESSON_FULFILLED = `${FETCH_LESSON}_FULFILLED`;
 export const FETCH_LESSON_REJECTED = `${FETCH_LESSON}_REJECTED`;
+export const CLEAR_LESSON = 'CLEAR_LESSON';
 
 export const UPDATE_JSCODE = 'UPDATE_JSCODE';
 export const UPDATE_XMLCODE = 'UPDATE_XMLCODE';
@@ -115,6 +116,9 @@ export const fetchLesson = (id, xhroptions) => ({
     )),
 });
 
+export const clearLesson = () => ({
+  type: CLEAR_LESSON,
+});
 
 export const changeProgramTags = (id, tags, xhroptions) => ({
   type: CHANGE_PROGRAM_TAGS,

--- a/src/containers/MissionControl.js
+++ b/src/containers/MissionControl.js
@@ -483,6 +483,7 @@ MissionControl.propTypes = {
   }).isRequired,
   changeReadOnly: PropTypes.func.isRequired,
   fetchLesson: PropTypes.func.isRequired,
+  clearLesson: PropTypes.func.isRequired,
   createProgram: PropTypes.func.isRequired,
   fetchProgram: PropTypes.func.isRequired,
   remixProgram: PropTypes.func.isRequired,

--- a/src/containers/MissionControl.js
+++ b/src/containers/MissionControl.js
@@ -37,6 +37,7 @@ import { checkAuthError, authHeader } from '@/actions/auth';
 import {
   changeReadOnly as actionChangeReadOnly,
   fetchLesson as actionFetchLesson,
+  clearLesson as actionClearLesson,
   createProgram as actionCreateProgram,
   fetchProgram as actionFetchProgram,
   remixProgram as actionRemixProgram,
@@ -49,6 +50,7 @@ const mapDispatchToProps = (dispatch, { cookies }) => ({
     .catch(checkAuthError(dispatch)),
   fetchLesson: (id) => dispatch(actionFetchLesson(id, authHeader(cookies)))
     .catch(checkAuthError(dispatch)),
+  clearLesson: () => dispatch(actionClearLesson()),
   fetchProgram: (id) => dispatch(actionFetchProgram(id, authHeader(cookies)))
     .catch(checkAuthError(dispatch)),
   createProgram: (name) => dispatch(actionCreateProgram(name, authHeader(cookies)))
@@ -72,6 +74,7 @@ class MissionControl extends Component {
       createProgram,
       fetchProgram,
       fetchLesson,
+      clearLesson,
       match,
       user,
     } = this.props;
@@ -84,10 +87,13 @@ class MissionControl extends Component {
         });
         if (result.value.lesson) {
           fetchLesson(result.value.lesson);
+        } else {
+          clearLesson();
         }
       });
     } else {
       // No program already loaded, create a new one
+      clearLesson();
       const number = (Math.floor(Math.random() * 1000));
       createProgram(`Unnamed_Design_${number}`).then((result) => {
         changeReadOnly(false);

--- a/src/containers/__tests__/MissionControl.test.js
+++ b/src/containers/__tests__/MissionControl.test.js
@@ -24,6 +24,7 @@ import { // eslint-disable-line import/first, import/order
   changeReadOnly,
   createProgram,
   fetchLesson,
+  clearLesson,
   fetchProgram,
   remixProgram,
 } from '@/actions/code';
@@ -171,6 +172,7 @@ describe('The MissionControl container', () => {
       .dive();
 
     expect(store.dispatch).toHaveBeenCalledWith(createProgram('Unnamed_Design_5'));
+    expect(store.dispatch).toHaveBeenCalledWith(clearLesson());
   });
 
   test('redirects after creating program', () => {
@@ -202,7 +204,7 @@ describe('The MissionControl container', () => {
     expect(wrapper.find(Redirect).exists()).toBe(true);
   });
 
-  test('fetches lesson when present', () => {
+  test('clears lesson when not present on fetched program', () => {
     const localStore = mockStore({
       code: {
         jsCode: '',
@@ -210,7 +212,7 @@ describe('The MissionControl container', () => {
         name: 'test program',
         ownerName: 'phil',
         isReadOnly: false,
-        lessonId: 1,
+        lessonId: null,
       },
       sensor: {
         leftLightSensorReading: -1,
@@ -241,10 +243,11 @@ describe('The MissionControl container', () => {
       .dive()
       .dive();
 
-    expect(localStore.dispatch).toHaveBeenCalledWith(fetchLesson(1));
+    expect(localStore.dispatch).toHaveBeenCalledWith(clearLesson());
   });
 
-  test('fetches lesson when present', () => {
+
+  test('fetches lesson when present on fetched program', () => {
     const localStore = mockStore({
       code: {
         jsCode: '',

--- a/src/containers/__tests__/__snapshots__/MissionControl.test.js.snap
+++ b/src/containers/__tests__/__snapshots__/MissionControl.test.js.snap
@@ -187,6 +187,7 @@ exports[`The MissionControl container renders on the page with no errors 1`] = `
         <MissionControl
           allCookies={Object {}}
           changeReadOnly={[Function]}
+          clearLesson={[Function]}
           code={
             Object {
               "id": 123,

--- a/src/reducers/__tests__/code.test.js
+++ b/src/reducers/__tests__/code.test.js
@@ -361,9 +361,6 @@ describe('The code reducer', () => {
   });
 
   test('should handle CLEAR_LESSON', () => {
-    const lessonTutorialLink = 'youtu.be/asdf';
-    const lessonGoals = 'to do a thing';
-
     expect(
       reducer({}, {
         type: CLEAR_LESSON,

--- a/src/reducers/__tests__/code.test.js
+++ b/src/reducers/__tests__/code.test.js
@@ -24,6 +24,7 @@ import {
   FETCH_LESSON_PENDING,
   FETCH_LESSON_FULFILLED,
   FETCH_LESSON_REJECTED,
+  CLEAR_LESSON,
   REMIX_PROGRAM_PENDING,
   REMIX_PROGRAM_FULFILLED,
   REMIX_PROGRAM_REJECTED,
@@ -356,6 +357,21 @@ describe('The code reducer', () => {
     ).toEqual({
       isFetchingLesson: false,
       error: { detail },
+    });
+  });
+
+  test('should handle CLEAR_LESSON', () => {
+    const lessonTutorialLink = 'youtu.be/asdf';
+    const lessonGoals = 'to do a thing';
+
+    expect(
+      reducer({}, {
+        type: CLEAR_LESSON,
+      }),
+    ).toEqual({
+      lessonId: null,
+      lessonTutorialLink: null,
+      lessonGoals: null,
     });
   });
 

--- a/src/reducers/code.js
+++ b/src/reducers/code.js
@@ -22,6 +22,7 @@ import {
   FETCH_LESSON_PENDING,
   FETCH_LESSON_FULFILLED,
   FETCH_LESSON_REJECTED,
+  CLEAR_LESSON,
   REMIX_PROGRAM_PENDING,
   REMIX_PROGRAM_FULFILLED,
   REMIX_PROGRAM_REJECTED,
@@ -188,6 +189,13 @@ export default function code(
         ...state,
         isFetchingLesson: false,
         error: action.payload,
+      };
+    case CLEAR_LESSON:
+      return {
+        ...state,
+        lessonId: null,
+        lessonTutorialLink: null,
+        lessonGoals: null,
       };
     case REMIX_PROGRAM_PENDING:
       return {


### PR DESCRIPTION
Before, if you went from a program that did have a lesson to a program that didn't, the previous program's lesson goals and tutorial link persisted. This clears them out.