### PR TITLE
Don't overwrite on save fulfill if ID doesn't match

### DIFF
--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -322,7 +322,6 @@ class Workspace extends Component {
     });
 
     workspace.addChangeListener(
-      // this.updateCode
       debounce(
         parseInt(SAVE_DEBOUNCE_TIME, 10) || 5000, this.updateCode, // eslint-disable-line no-undef
       ),

--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -322,6 +322,7 @@ class Workspace extends Component {
     });
 
     workspace.addChangeListener(
+      // this.updateCode
       debounce(
         parseInt(SAVE_DEBOUNCE_TIME, 10) || 5000, this.updateCode, // eslint-disable-line no-undef
       ),

--- a/src/reducers/__tests__/code.test.js
+++ b/src/reducers/__tests__/code.test.js
@@ -233,7 +233,7 @@ describe('The code reducer', () => {
     const lessonId = 2;
 
     expect(
-      reducer({id: 1}, {
+      reducer({ id: 1 }, {
         type: SAVE_PROGRAM_FULFILLED,
         payload: {
           name,
@@ -258,7 +258,7 @@ describe('The code reducer', () => {
     const lessonId = 2;
 
     expect(
-      reducer({id: 7}, {
+      reducer({ id: 7 }, {
         type: SAVE_PROGRAM_FULFILLED,
         payload: {
           name,

--- a/src/reducers/__tests__/code.test.js
+++ b/src/reducers/__tests__/code.test.js
@@ -244,10 +244,6 @@ describe('The code reducer', () => {
       }),
     ).toEqual({
       isSaving: false,
-      name,
-      id,
-      xmlCode,
-      lessonId,
     });
   });
 

--- a/src/reducers/__tests__/code.test.js
+++ b/src/reducers/__tests__/code.test.js
@@ -226,14 +226,14 @@ describe('The code reducer', () => {
     });
   });
 
-  test('should handle SAVE_PROGRAM_FULFILLED', () => {
+  test('should handle SAVE_PROGRAM_FULFILLED where program ID matches state', () => {
     const name = 'mybd';
     const id = 1;
     const xmlCode = '<xml></xml>';
     const lessonId = 2;
 
     expect(
-      reducer({}, {
+      reducer({id: 1}, {
         type: SAVE_PROGRAM_FULFILLED,
         payload: {
           name,
@@ -243,6 +243,32 @@ describe('The code reducer', () => {
         },
       }),
     ).toEqual({
+      isSaving: false,
+      name,
+      id,
+      xmlCode,
+      lessonId,
+    });
+  });
+
+  test('should handle SAVE_PROGRAM_FULFILLED where program ID doesn\'t matchstate', () => {
+    const name = 'mybd';
+    const id = 1;
+    const xmlCode = '<xml></xml>';
+    const lessonId = 2;
+
+    expect(
+      reducer({id: 7}, {
+        type: SAVE_PROGRAM_FULFILLED,
+        payload: {
+          name,
+          id,
+          content: xmlCode,
+          lesson: lessonId,
+        },
+      }),
+    ).toEqual({
+      id: 7,
       isSaving: false,
     });
   });

--- a/src/reducers/code.js
+++ b/src/reducers/code.js
@@ -139,10 +139,18 @@ export default function code(
         isSaving: true,
       };
     case SAVE_PROGRAM_FULFILLED:
-      return {
-        ...state,
-        isSaving: false,
-      };
+      return state.id === action.payload.id ?
+        {
+          ...state,
+          isSaving: false,
+          xmlCode: action.payload.content,
+          id: action.payload.id,
+          name: action.payload.name,
+          lessonId: action.payload.lesson,
+        } : {
+          ...state,
+          isSaving: false,
+        };
     case SAVE_PROGRAM_REJECTED:
       return {
         ...state,

--- a/src/reducers/code.js
+++ b/src/reducers/code.js
@@ -142,10 +142,6 @@ export default function code(
       return {
         ...state,
         isSaving: false,
-        xmlCode: action.payload.content,
-        id: action.payload.id,
-        name: action.payload.name,
-        lessonId: action.payload.lesson,
       };
     case SAVE_PROGRAM_REJECTED:
       return {

--- a/src/reducers/code.js
+++ b/src/reducers/code.js
@@ -139,8 +139,8 @@ export default function code(
         isSaving: true,
       };
     case SAVE_PROGRAM_FULFILLED:
-      return state.id === action.payload.id ?
-        {
+      return state.id === action.payload.id
+        ? {
           ...state,
           isSaving: false,
           xmlCode: action.payload.content,


### PR DESCRIPTION
I think that we shouldn't overwrite the code state on `SAVE_PROGRAM_FULFILLED` if the program ID doesn't match. This should make the responses out-of-order tolerant.