### PR TITLE
Refresh session after upgrade

### DIFF
--- a/src/actions/__test__/user.test.js
+++ b/src/actions/__test__/user.test.js
@@ -5,6 +5,7 @@ import {
   editUserPassword,
   editUserShowGuide,
   fetchUserStats,
+  refreshSession,
   updateUser,
 } from '../user';
 
@@ -93,6 +94,29 @@ describe('User actions', () => {
     expect(type).toEqual('FETCH_USER_STATS');
     action.payload.then((result) => {
       expect(result).toEqual(data);
+      done();
+    });
+  });
+  test('refreshSession', (done) => {
+    const mock = new MockAdapter(axios);
+    const mockCookies = {
+      get: jest.fn(() => 'eyey0'),
+    };
+    const user = {
+      username: 'testuser',
+      email: 'testuser@example.com',
+      exp: 1629483380,
+    };
+    const token = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1OTc5NDczODAsImV4cCI6MTYyOTQ4MzM4MCwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsInVzZXJfaWQiOiIxIiwidXNlcm5hbWUiOiJ0ZXN0dXNlciIsImVtYWlsIjoidGVzdHVzZXJAZXhhbXBsZS5jb20iLCJ0aWVyIjoiMiJ9.w2oj_k6rD0VnsKgzOEHxKEPOkA137xkA4mRBaIjesCs';
+    mock.onPost('/api/api-token-refresh/', { token: 'eyey0' }).reply(200, { token });
+    const action = refreshSession(mockCookies);
+    const { type } = action;
+
+    expect(type).toEqual('REFRESH_SESSION');
+    action.payload.then((result) => {
+      expect(result.username).toEqual(user.username);
+      expect(result.email).toEqual(user.email);
+      expect(result.exp).toEqual(user.exp);
       done();
     });
   });

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -1,6 +1,7 @@
 // actions https://redux.js.org/basics/actions
 // async actions https://redux.js.org/advanced/asyncactions
 import axios from 'axios';
+import jwtDecode from 'jwt-decode';
 
 export const UPDATE_USER = 'UPDATE_USER';
 export const EDIT_USER_USERNAME = 'EDIT_USER_USERNAME';
@@ -19,11 +20,25 @@ export const FETCH_USER_STATS = 'FETCH_USER_STATS';
 export const FETCH_USER_STATS_PENDING = `${FETCH_USER_STATS}_PENDING`;
 export const FETCH_USER_STATS_FULFILLED = `${FETCH_USER_STATS}_FULFILLED`;
 export const FETCH_USER_STATS_REJECTED = `${FETCH_USER_STATS}_REJECTED`;
+export const REFRESH_SESSION = 'REFRESH_SESSION';
+export const REFRESH_SESSION_PENDING = `${REFRESH_SESSION}_PENDING`;
+export const REFRESH_SESSION_FULFILLED = `${REFRESH_SESSION}_FULFILLED`;
+export const REFRESH_SESSION_REJECTED = `${REFRESH_SESSION}_REJECTED`;
 
 // action creators
 export const updateUser = (data) => ({
   type: UPDATE_USER,
   payload: data,
+});
+
+export const refreshSession = (cookies) => ({
+  type: REFRESH_SESSION,
+  payload: axios.post('/api/api-token-refresh/', {
+    token: cookies.get('auth_jwt'),
+  })
+    .then(({ data }) => (
+      jwtDecode(data.token)
+    )),
 });
 
 export const editUserUsername = (username, xhrOptions) => ({

--- a/src/components/PlanClass.js
+++ b/src/components/PlanClass.js
@@ -37,6 +37,7 @@ const PlanClass = ({
   error,
   expires,
   maxLength,
+  refreshSession,
   upgradeSubscription,
   userId,
 }) => {
@@ -45,7 +46,7 @@ const PlanClass = ({
   const handleCodeChange = (event) => {
     setLength(event.target.value.length);
     if (event.target.value.length === maxLength) {
-      upgradeSubscription(userId, event.target.value);
+      upgradeSubscription(userId, event.target.value).then(refreshSession);
     }
   };
 
@@ -178,6 +179,7 @@ PlanClass.propTypes = {
   error: PropTypes.string,
   expires: PropTypes.number,
   maxLength: PropTypes.number,
+  refreshSession: PropTypes.func.isRequired,
   upgradeSubscription: PropTypes.func.isRequired,
   userId: PropTypes.number.isRequired,
 };

--- a/src/components/UserSetting.js
+++ b/src/components/UserSetting.js
@@ -141,6 +141,7 @@ class UserSetting extends Component {
     const {
       isFetching,
       intl,
+      refreshSession,
       subscription,
       upgradeError,
       upgradeSubscription,
@@ -346,6 +347,7 @@ class UserSetting extends Component {
                     error={upgradeError ? upgradeError.response.data.accessCode[0] : null}
                     expires={moment.unix(subscription.start).add(1, 'year').unix()}
                     maxLength={8}
+                    refreshSession={refreshSession}
                     upgradeSubscription={upgradeSubscription}
                     userId={user.user_id}
                   />
@@ -374,6 +376,7 @@ UserSetting.propTypes = {
   editUserUsername: PropTypes.func.isRequired,
   editUserPassword: PropTypes.func.isRequired,
   fetchSubscription: PropTypes.func.isRequired,
+  refreshSession: PropTypes.func.isRequired,
   upgradeSubscription: PropTypes.func.isRequired,
   user: PropTypes.shape({
     user_id: PropTypes.number.isRequired,

--- a/src/components/__tests__/PlanClass.test.js
+++ b/src/components/__tests__/PlanClass.test.js
@@ -3,13 +3,15 @@ import { shallow } from 'enzyme';
 
 import PlanClass from '../PlanClass';
 
+let refreshSession;
 let upgradeSubscription;
 
 describe('The PlanClass component', () => {
   const setState = jest.fn();
 
   beforeEach(() => {
-    upgradeSubscription = jest.fn();
+    refreshSession = jest.fn().mockResolvedValue();
+    upgradeSubscription = jest.fn().mockResolvedValue();
   });
 
   afterEach(() => {
@@ -18,14 +20,22 @@ describe('The PlanClass component', () => {
 
   test('renders on the page with no errors', () => {
     const wrapper = mountWithIntl(
-      <PlanClass upgradeSubscription={upgradeSubscription} userId={1} />,
+      <PlanClass
+        refreshSession={refreshSession}
+        upgradeSubscription={upgradeSubscription}
+        userId={1}
+      />,
     );
     expect(wrapper).toMatchSnapshot();
   });
 
   test('renders typing status on the page with no errors', () => {
     const wrapper = mountWithIntl(
-      <PlanClass upgradeSubscription={upgradeSubscription} userId={1} />,
+      <PlanClass
+        refreshSession={refreshSession}
+        upgradeSubscription={upgradeSubscription}
+        userId={1}
+      />,
     );
     wrapper.find('input').simulate('change', {
       target: {
@@ -39,6 +49,7 @@ describe('The PlanClass component', () => {
   test('renders success status on the page with no errors', () => {
     const wrapper = mountWithIntl(
       <PlanClass
+        refreshSession={refreshSession}
         upgradeSubscription={upgradeSubscription}
         userId={1}
         active
@@ -51,7 +62,13 @@ describe('The PlanClass component', () => {
   test('sets length on text change', () => {
     const useStateSpy = jest.spyOn(React, 'useState');
     useStateSpy.mockImplementation((init) => [init, setState]);
-    const wrapper = shallow(<PlanClass upgradeSubscription={upgradeSubscription} userId={1} />);
+    const wrapper = shallow(
+      <PlanClass
+        refreshSession={refreshSession}
+        upgradeSubscription={upgradeSubscription}
+        userId={1}
+      />,
+    );
 
     wrapper.find('WithStyles(WithStyles(ForwardRef(TextField)))').simulate('change', {
       target: {
@@ -69,7 +86,12 @@ describe('The PlanClass component', () => {
     const useStateSpy = jest.spyOn(React, 'useState');
     useStateSpy.mockImplementation((init) => [init, setState]);
     const wrapper = shallow(
-      <PlanClass upgradeSubscription={upgradeSubscription} userId={1} maxLength={5} />,
+      <PlanClass
+        refreshSession={refreshSession}
+        upgradeSubscription={upgradeSubscription}
+        userId={1}
+        maxLength={5}
+      />,
     );
 
     wrapper.find('WithStyles(WithStyles(ForwardRef(TextField)))').simulate('change', {

--- a/src/components/__tests__/UserSetting.test.js
+++ b/src/components/__tests__/UserSetting.test.js
@@ -9,6 +9,7 @@ import UserSetting from '../UserSetting';
 let editUserPassword;
 let editUserUsername;
 let fetchSubscription;
+let refreshSession;
 let upgradeSubscription;
 
 describe('The UserSetting component', () => {
@@ -16,6 +17,7 @@ describe('The UserSetting component', () => {
     editUserPassword = jest.fn().mockResolvedValue();
     editUserUsername = jest.fn().mockResolvedValue();
     fetchSubscription = jest.fn().mockResolvedValue();
+    refreshSession = jest.fn().mockResolvedValue();
     upgradeSubscription = jest.fn().mockResolvedValue();
   });
 
@@ -32,6 +34,7 @@ describe('The UserSetting component', () => {
         editUserPassword={editUserPassword}
         editUserUsername={editUserUsername}
         fetchSubscription={fetchSubscription}
+        refreshSession={refreshSession}
         upgradeSubscription={upgradeSubscription}
         isFetching
       />,
@@ -53,6 +56,7 @@ describe('The UserSetting component', () => {
         editUserPassword={editUserPassword}
         editUserUsername={editUserUsername}
         fetchSubscription={fetchSubscription}
+        refreshSession={refreshSession}
         upgradeSubscription={upgradeSubscription}
         isFetching
       />,
@@ -73,6 +77,7 @@ describe('The UserSetting component', () => {
         editUserPassword={editUserPassword}
         editUserUsername={editUserUsername}
         fetchSubscription={fetchSubscription}
+        refreshSession={refreshSession}
         upgradeSubscription={upgradeSubscription}
         isFetching
       />,
@@ -109,6 +114,7 @@ describe('The UserSetting component', () => {
         editUserPassword={editUserPassword}
         editUserUsername={editUserUsername}
         fetchSubscription={fetchSubscription}
+        refreshSession={refreshSession}
         upgradeSubscription={upgradeSubscription}
         isFetching
       />,
@@ -152,6 +158,7 @@ describe('The UserSetting component', () => {
         editUserPassword={editUserPassword}
         editUserUsername={editUserUsername}
         fetchSubscription={fetchSubscription}
+        refreshSession={refreshSession}
         upgradeSubscription={upgradeSubscription}
         isFetching
       />,
@@ -202,6 +209,7 @@ describe('The UserSetting component', () => {
         editUserPassword={editUserPassword}
         editUserUsername={editUserUsername}
         fetchSubscription={fetchSubscription}
+        refreshSession={refreshSession}
         upgradeSubscription={upgradeSubscription}
         isFetching
       />,
@@ -241,6 +249,7 @@ describe('The UserSetting component', () => {
         editUserPassword={editUserPassword}
         editUserUsername={editUserUsername}
         fetchSubscription={fetchSubscription}
+        refreshSession={refreshSession}
         upgradeSubscription={upgradeSubscription}
         isFetching
       />,
@@ -279,6 +288,7 @@ describe('The UserSetting component', () => {
         editUserPassword={editUserPassword}
         editUserUsername={editUserUsername}
         fetchSubscription={fetchSubscription}
+        refreshSession={refreshSession}
         upgradeSubscription={upgradeSubscription}
         isFetching={false}
       />,
@@ -309,6 +319,7 @@ describe('The UserSetting component', () => {
         editUserPassword={editUserPassword}
         editUserUsername={editUserUsername}
         fetchSubscription={fetchSubscription}
+        refreshSession={refreshSession}
         upgradeSubscription={upgradeSubscription}
         isFetching={false}
         upgradeError={{

--- a/src/components/__tests__/__snapshots__/PlanClass.test.js.snap
+++ b/src/components/__tests__/__snapshots__/PlanClass.test.js.snap
@@ -6,6 +6,7 @@ exports[`The PlanClass component renders on the page with no errors 1`] = `
   error={null}
   expires={0}
   maxLength={8}
+  refreshSession={[MockFunction]}
   upgradeSubscription={[MockFunction]}
   userId={1}
 >
@@ -1796,6 +1797,7 @@ exports[`The PlanClass component renders success status on the page with no erro
   error={null}
   expires={1596831913}
   maxLength={8}
+  refreshSession={[MockFunction]}
   upgradeSubscription={[MockFunction]}
   userId={1}
 >
@@ -2722,6 +2724,7 @@ exports[`The PlanClass component renders typing status on the page with no error
   error={null}
   expires={0}
   maxLength={8}
+  refreshSession={[MockFunction]}
   upgradeSubscription={[MockFunction]}
   userId={1}
 >

--- a/src/containers/UserSetting.js
+++ b/src/containers/UserSetting.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { hot } from 'react-hot-loader';
 import { withCookies, Cookies } from 'react-cookie';
-import { editUserPassword, editUserUsername } from '@/actions/user';
+import { editUserPassword, editUserUsername, refreshSession } from '@/actions/user';
 import { checkAuthError, authHeader } from '@/actions/auth';
 import { fetchSubscription, upgradeSubscription } from '@/actions/subscription';
 import UserSetting from '@/components/UserSetting';
@@ -14,6 +14,7 @@ const mapDispatchToProps = (dispatch, { cookies }) => ({
   editUserPassword: (password) => dispatch(editUserPassword(password, authHeader(cookies)))
     .catch(checkAuthError(dispatch)),
   fetchSubscription: (id) => dispatch(fetchSubscription(id, authHeader(cookies))),
+  refreshSession: () => dispatch(refreshSession(cookies)).catch(checkAuthError(dispatch)),
   upgradeSubscription: (id, accessCode) => dispatch(
     upgradeSubscription(id, accessCode, authHeader(cookies)),
   ),

--- a/src/containers/__tests__/UserSetting.test.js
+++ b/src/containers/__tests__/UserSetting.test.js
@@ -7,7 +7,7 @@ import UserSetting from '../UserSetting'; // eslint-disable-line import/order
 
 jest.mock('@/actions/user');
 
-import { editUserUsername, editUserPassword } from '@/actions/user'; // eslint-disable-line import/first, import/order
+import { editUserUsername, editUserPassword, refreshSession } from '@/actions/user'; // eslint-disable-line import/first, import/order
 import { fetchSubscription, upgradeSubscription } from '@/actions/subscription'; // eslint-disable-line import/first, import/order
 
 const cookiesValues = { auth_jwt: '1234' };
@@ -184,6 +184,14 @@ describe('The UserSettingContainer', () => {
     );
   });
 
+  test('dispatches an action to upgrade subscription', () => {
+    wrapper.dive().props().refreshSession(cookiesValues);
+
+    expect(store.dispatch).toHaveBeenCalledWith(
+      refreshSession(cookiesValues.auth_jwt),
+    );
+  });
+
   test('handles error fetching subscription', (done) => {
     const userId = 1;
     const localWrapper = shallow(
@@ -218,6 +226,20 @@ describe('The UserSettingContainer', () => {
             Authorization: `JWT ${cookiesValues.auth_jwt}`,
           },
         }),
+      );
+      done();
+    });
+  });
+
+  test('handles error refreshing session', (done) => {
+    const localWrapper = shallow(
+      <UserSetting store={otherFailStore} />, { context },
+    ).dive().dive().dive();
+
+    localWrapper.dive().props().refreshSession(cookiesValues).catch(() => {
+      expect(otherFailStore.dispatch.mock.calls.length).toBe(1);
+      expect(otherFailStore.dispatch).toHaveBeenCalledWith(
+        refreshSession(cookiesValues.auth_jwt),
       );
       done();
     });

--- a/src/reducers/__tests__/user.test.js
+++ b/src/reducers/__tests__/user.test.js
@@ -13,6 +13,9 @@ import {
   FETCH_USER_STATS_PENDING,
   FETCH_USER_STATS_FULFILLED,
   FETCH_USER_STATS_REJECTED,
+  REFRESH_SESSION_PENDING,
+  REFRESH_SESSION_FULFILLED,
+  REFRESH_SESSION_REJECTED,
 } from '../../actions/user';
 
 describe('The user reducer', () => {
@@ -58,10 +61,12 @@ describe('The user reducer', () => {
       isEditingPassword: false,
       isEditingShowGuide: false,
       isFetchingStats: false,
+      isRefreshingSession: false,
       editUsernameError: null,
       editPasswordError: null,
       editShowGuideError: null,
       fetchStatsError: null,
+      refreshSessionError: null,
     });
   });
 
@@ -114,10 +119,12 @@ describe('The user reducer', () => {
       isEditingPassword: true,
       isEditingShowGuide: false,
       isFetchingStats: false,
+      isRefreshingSession: false,
       editUsernameError: null,
       editPasswordError: null,
       editShowGuideError: null,
       fetchStatsError: null,
+      refreshSessionError: null,
     });
   });
 
@@ -168,10 +175,12 @@ describe('The user reducer', () => {
       isEditingPassword: false,
       isEditingShowGuide: true,
       isFetchingStats: false,
+      isRefreshingSession: false,
       editUsernameError: null,
       editPasswordError: null,
       editShowGuideError: null,
       fetchStatsError: null,
+      refreshSessionError: null,
     });
   });
 
@@ -221,10 +230,12 @@ describe('The user reducer', () => {
       isEditingPassword: false,
       isEditingShowGuide: false,
       isFetchingStats: true,
+      isRefreshingSession: false,
       editUsernameError: null,
       editPasswordError: null,
       editShowGuideError: null,
       fetchStatsError: null,
+      refreshSessionError: null,
     });
   });
 
@@ -256,6 +267,71 @@ describe('The user reducer', () => {
     ).toEqual({
       isFetchingStats: false,
       fetchStatsError: error,
+    });
+  });
+
+  test('should handle REFRESH_SESSION_PENDING', () => {
+    expect(
+      reducer(undefined, {
+        type: REFRESH_SESSION_PENDING,
+      }),
+    ).toEqual({
+      user_id: null,
+      username: null,
+      email: null,
+      exp: null,
+      showGuide: true,
+      isSocial: false,
+      tier: 1,
+      stats: null,
+      isEditingUsername: false,
+      isEditingPassword: false,
+      isEditingShowGuide: false,
+      isFetchingStats: false,
+      isRefreshingSession: true,
+      editUsernameError: null,
+      editPasswordError: null,
+      editShowGuideError: null,
+      fetchStatsError: null,
+      refreshSessionError: null,
+    });
+  });
+
+  test('should handle REFRESH_SESSION_FULFILLED', () => {
+    const user = {
+      user_id: 1,
+      username: 'testuser',
+      email: 'testuser@example.com',
+      exp: 1540178211,
+      isSocial: false,
+      tier: 2,
+    };
+    expect(
+      reducer({}, {
+        type: REFRESH_SESSION_FULFILLED,
+        payload: user,
+      }),
+    ).toEqual({
+      user_id: user.user_id,
+      username: user.username,
+      email: user.email,
+      exp: user.exp,
+      isSocial: user.isSocial,
+      tier: user.tier,
+      isRefreshingSession: false,
+    });
+  });
+
+  test('should handle REFRESH_SESSION_REJECTED', () => {
+    const error = 'woops';
+    expect(
+      reducer({}, {
+        type: REFRESH_SESSION_REJECTED,
+        payload: error,
+      }),
+    ).toEqual({
+      isRefreshingSession: false,
+      refreshSessionError: error,
     });
   });
 

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -12,6 +12,9 @@ import {
   FETCH_USER_STATS_PENDING,
   FETCH_USER_STATS_FULFILLED,
   FETCH_USER_STATS_REJECTED,
+  REFRESH_SESSION_PENDING,
+  REFRESH_SESSION_FULFILLED,
+  REFRESH_SESSION_REJECTED,
 } from '../actions/user';
 
 export default function user(
@@ -28,10 +31,12 @@ export default function user(
     isEditingPassword: false,
     isEditingShowGuide: false,
     isFetchingStats: false,
+    isRefreshingSession: false,
     editUsernameError: null,
     editPasswordError: null,
     editShowGuideError: null,
     fetchStatsError: null,
+    refreshSessionError: null,
   },
   action,
 ) {
@@ -114,6 +119,28 @@ export default function user(
         ...state,
         isFetchingStats: false,
         fetchStatsError: action.payload,
+      };
+    case REFRESH_SESSION_FULFILLED:
+      return {
+        ...state,
+        isRefreshingSession: false,
+        user_id: action.payload.user_id,
+        username: action.payload.username,
+        email: action.payload.email,
+        exp: action.payload.exp,
+        isSocial: action.payload.isSocial,
+        tier: action.payload.tier,
+      };
+    case REFRESH_SESSION_PENDING:
+      return {
+        ...state,
+        isRefreshingSession: true,
+      };
+    case REFRESH_SESSION_REJECTED:
+      return {
+        ...state,
+        isRefreshingSession: false,
+        refreshSessionError: action.payload,
       };
     default:
       return state;


### PR DESCRIPTION
After upgrading, the JWT needs to be refreshed to contain the updated `tier` level for the user. This will allow the user to access all content without having to logout and login again