### PR TITLE
Stop program on failure to send to rover

### DIFF
--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -263,7 +263,7 @@ class Workspace extends Component {
 
     if (rover.rover) {
       const encoder = new TextEncoder();
-      sendToRover(rover.transmitChannel, encoder.encode(command));
+      sendToRover(rover.transmitChannel, encoder.encode(command)).catch(this.goToStopState);
     }
   }
 

--- a/src/components/__tests__/Workspace.test.js
+++ b/src/components/__tests__/Workspace.test.js
@@ -837,6 +837,24 @@ describe('The Workspace component', () => {
     expect(store.dispatch).toHaveBeenCalledWith(send(store.getState().rover.transmitChannel, 'command'));
   });
 
+  test('stops program when failure sending to rover', (done) => {
+    const error = new Error();
+    store.dispatch = jest.fn().mockRejectedValue(error);
+    const wrapper = shallowWithIntl(
+      <Workspace store={store}>
+        <div />
+      </Workspace>, { context },
+    ).dive().dive().dive()
+      .dive()
+      .dive()
+      .dive()
+      .dive();
+
+    wrapper.instance().goToStopState = jest.fn(() => done());
+
+    wrapper.instance().sendToRover('command');
+  });
+
   test('dispatches an action when sending to rover with no connected rover', () => {
     const localStore = mockStore({
       code: {


### PR DESCRIPTION
When the application fails to send a command to the rover, stop the currently running program. Otherwise, the program will continue encountering errors indefinitely while continuing to run