### PR TITLE
Debounce search queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "jest": {
     "globals": {
       "LOGGER_ENDPOINT": "",
-      "SAVE_DEBOUNCE_TIME": "1000"
+      "SAVE_DEBOUNCE_TIME": "1000",
+      "SEARCH_DEBOUNCE_TIME": "500"
     },
     "snapshotSerializers": [
       "enzyme-to-json/serializer"

--- a/src/components/ProgramCollection.js
+++ b/src/components/ProgramCollection.js
@@ -29,6 +29,7 @@ import {
   Delete,
 } from '@material-ui/icons';
 import { Pagination, Autocomplete } from '@material-ui/lab';
+import { debounce } from 'throttle-debounce';
 
 import flavourImage from '@/assets/images/flavour.png';
 
@@ -59,6 +60,10 @@ const styles = (theme) => ({
 class ProgramCollection extends Component {
   constructor(props) {
     super(props);
+
+    this.searchDebounce = debounce(
+      parseInt(SEARCH_DEBOUNCE_TIME, 10) || 1000, this.update, // eslint-disable-line no-undef
+    );
 
     this.state = {
       page: 1,
@@ -115,20 +120,20 @@ class ProgramCollection extends Component {
 
   handlePageChange = (e, page) => this.setState({
     page,
-  }, () => this.update())
+  }, this.update)
 
   handleSearchChange = (event) => this.setState({
     searchQuery: event.target.value,
     page: 1,
-  }, () => this.update())
+  }, this.searchDebounce)
 
   handleOrderingChange = (e) => this.setState({
     ordering: this.toggleOrdering(e.target.id),
-  }, () => this.update())
+  }, this.update)
 
   handleTagFilterChange = (event, value) => this.setState({
     tagFilters: value,
-  }, () => this.update())
+  }, this.update)
 
   render() {
     const {

--- a/src/components/__tests__/ProgramCollection.test.js
+++ b/src/components/__tests__/ProgramCollection.test.js
@@ -335,6 +335,8 @@ describe('The ProgramCollection component', () => {
   });
 
   test('callback when search changes', () => {
+    jest.useFakeTimers();
+
     const programs = {
       count: 2,
       next: null,
@@ -373,12 +375,82 @@ describe('The ProgramCollection component', () => {
       },
     });
 
+    expect(onUpdate).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(250);
+
+    expect(onUpdate).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(500);
+
     expect(onUpdate).toHaveBeenCalledWith({
       search: 'abc',
       page: 1,
       ordering: 'name',
       tag: '',
     });
+  });
+
+  test('callback when search changes unset debounce time', () => {
+    jest.useFakeTimers();
+
+    const builtInParseInt = global.parseInt;
+    global.parseInt = () => NaN;
+
+    const programs = {
+      count: 2,
+      next: null,
+      previous: null,
+      total_pages: 2,
+      results: [{
+        id: 33,
+        name: 'Unnamed_Design_3',
+        content: '<xml><variables></variables></xml>',
+        user: {
+          username: 'testuser',
+        },
+      }, {
+        id: 5,
+        name: 'Unnamed_Design_2',
+        content: '<xml><variables></variables></xml>',
+        user: {
+          username: 'testuser',
+        },
+      }],
+    };
+    const wrapper = shallowWithIntl(
+      <ProgramCollection
+        programs={programs}
+        label="My Programs"
+        user={adminUser}
+        onProgramClick={onProgramClick}
+        onRemoveClick={onRemoveClick}
+        onUpdate={onUpdate}
+      />,
+    ).dive().dive().dive();
+
+    wrapper.find('WithStyles(ForwardRef(TextField))').simulate('change', {
+      target: {
+        value: 'abc',
+      },
+    });
+
+    expect(onUpdate).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(500);
+
+    expect(onUpdate).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(500);
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      search: 'abc',
+      page: 1,
+      ordering: 'name',
+      tag: '',
+    });
+
+    global.parseInt = builtInParseInt;
   });
 
   test('callback when order changes', () => {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -62,6 +62,7 @@ module.exports = {
       PXT_HEX_URL: JSON.stringify(process.env.PXT_HEX_URL
         || 'https://rovercode-pxt.s3.us-east-2.amazonaws.com/alpha/rovercode.hex'),
       SAVE_DEBOUNCE_TIME: JSON.stringify(process.env.SAVE_DEBOUNCE_TIME),
+      SEARCH_DEBOUNCE_TIME: JSON.stringify(process.env.SEARCH_DEBOUNCE_TIME),
     }),
     new HtmlWebPackPlugin({
       template: './src/index.html',


### PR DESCRIPTION
This fixes the issue of responses being returned out of order. This will wait `SEARCH_DEBOUNCE_TIME` before making a request to the API for search queries. This will also reduce the total amount of search API calls which will be a more intensive database operation.