### PR TITLE
Add VS Code run configs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,45 @@ To run unit tests, run:
 yarn test
 ```
 
+To debug the tests in [VS Code](https://code.visualstudio.com), use these run configurations in your [launch.json](https://code.visualstudio.com/docs/editor/debugging):
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest All",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": [
+        "--runInBand"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest Current File",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": [
+        "${fileBasenameNoExtension}"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      }
+    }
+  ]
+}
+```
+
 Linting
 =======
 


### PR DESCRIPTION
This add to the README the run configs for debugging the unit tests in VS Code. I think it's a common enough tool to be worthy of including in the README, but I'm flexible if you'd rather not.