### PR TITLE
Add circular progress when creating checkout session

### DIFF
--- a/src/components/Purchase.js
+++ b/src/components/Purchase.js
@@ -97,6 +97,7 @@ class Purchase extends Component {
     const {
       classes,
       isFetching,
+      isCreating,
       subscription,
       creationError,
       intl,
@@ -220,11 +221,17 @@ class Purchase extends Component {
                   color="primary"
                   onClick={this.handleCheckoutClick}
                 >
-                  <FormattedMessage
-                    id="app.purchase.checkout"
-                    description="Button label to checkout purchase"
-                    defaultMessage="Check Out"
-                  />
+                  {
+                    isCreating ? (
+                      <CircularProgress />
+                    ) : (
+                      <FormattedMessage
+                        id="app.purchase.checkout"
+                        description="Button label to checkout purchase"
+                        defaultMessage="Check Out"
+                      />
+                    )
+                  }
                 </Button>
                 <Chip label={costText} />
               </CardActions>

--- a/src/components/__tests__/Purchase.test.js
+++ b/src/components/__tests__/Purchase.test.js
@@ -64,6 +64,23 @@ describe('The Purchase component', () => {
     expect(wrapper.find('WithStyles(ForwardRef(CircularProgress))').exists()).toBe(true);
   });
 
+  test('shows circular progress while creating session', () => {
+    const user = {
+      user_id: 1,
+    };
+    const wrapper = shallowWithIntl(
+      <Purchase
+        user={user}
+        fetchSubscription={fetchSubscription}
+        createCheckoutSession={createCheckoutSession}
+        isFetching={false}
+        isCreating
+      />,
+    ).dive().dive().dive();
+    const button = wrapper.find(Button);
+    expect(button.find('WithStyles(ForwardRef(CircularProgress))').exists()).toBe(true);
+  });
+
   test('shows already purchased message when already purchased', () => {
     const user = {
       user_id: 1,


### PR DESCRIPTION
It takes a few seconds after clicking "Check out" for the checkout session to be created and the redirect to Stripe to happen. It makes me unsure that I actually clicked the button. This makes a circular progress appear in the button immediately after clicking it.