### PR TITLE
Fix sign-up for new auth lib

### DIFF
--- a/src/containers/Accounts/SignUp.js
+++ b/src/containers/Accounts/SignUp.js
@@ -138,8 +138,8 @@ class SignUp extends Component {
       password2,
     })
       .then((response) => {
-        updateUser(jwtDecode(response.data.token));
-        cookies.set('auth_jwt', response.data.token, { path: '/' });
+        updateUser(jwtDecode(response.data.access_token));
+        cookies.set('auth_jwt', response.data.access_token, { path: '/' });
         this.setState({
           success: true,
         });

--- a/src/containers/Accounts/__tests__/SignUp.test.js
+++ b/src/containers/Accounts/__tests__/SignUp.test.js
@@ -86,7 +86,7 @@ test('SignUp redirects to root after success', (done) => {
     password1,
     password2,
   }).reply(200, {
-    token,
+    access_token: token,
   });
   const cookiesWrapper = shallowWithIntl(<SignUp store={store} />, {
     context: { cookies },


### PR DESCRIPTION
This should fix the regular account sign-up issue.

I think the call to `password/reset/confirm` is good as-is. https://dj-rest-auth.readthedocs.io/en/latest/api_endpoints.html