### PR TITLE
Use the 'next' parameter in social login

### DIFF
--- a/src/containers/Accounts/Login.js
+++ b/src/containers/Accounts/Login.js
@@ -84,8 +84,11 @@ class Login extends Component {
   }
 
   redirectToSocial = (element) => {
+    const { location } = this.props;
+
+    const next = location && location.state && location.state.next ? location.state.next : null;
     const service = element.target.parentNode.id || element.target.id;
-    return axios.post(`/jwt/auth/social/${service}/auth-server/`)
+    return axios.post(`/jwt/auth/social/${service}/auth-server/`, null, { params: { ...(next && { next }) } })
       .then((response) => {
         const url = URL(response.data.url);
         const parsed = queryString.parse(url.query);

--- a/src/containers/Accounts/LoginCallback.js
+++ b/src/containers/Accounts/LoginCallback.js
@@ -44,7 +44,7 @@ class LoginCallback extends Component {
         updateValidAuth(true);
         this.setState({
           loading: false,
-          loginSuccess: true,
+          loginSuccess: response.data.next_url ? response.data.next_url : '/',
         });
       })
       .catch((error) => {
@@ -81,7 +81,7 @@ class LoginCallback extends Component {
     }
 
     if (loginSuccess) {
-      return <Redirect to="/" />;
+      return <Redirect to={loginSuccess} />;
     }
 
     return (

--- a/src/containers/Accounts/__tests__/Login.test.js
+++ b/src/containers/Accounts/__tests__/Login.test.js
@@ -54,6 +54,12 @@ test('Login mounts on the page with no errors', () => {
 
 test('Login redirects to social api on button click', (done) => {
   const url = 'https://accounts.google.com/o/oauth2/auth?redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fauth%2Fsocial%2Fgoogle%2Fcallback';
+  const localLocation = {
+    pathname: location.pathname,
+    state: {
+      next: '/courses',
+    },
+  };
   mock.reset();
   mock.onPost('/jwt/auth/social/google/auth-server/').reply(200, { url });
   Object.defineProperty(window, 'location', {
@@ -72,7 +78,7 @@ test('Login redirects to social api on button click', (done) => {
     },
   };
 
-  const cookiesWrapper = shallowWithIntl(<Login location={location} store={store} />, {
+  const cookiesWrapper = shallowWithIntl(<Login location={localLocation} store={store} />, {
     context: { cookies },
   });
 

--- a/src/containers/Accounts/__tests__/LoginCallback.test.js
+++ b/src/containers/Accounts/__tests__/LoginCallback.test.js
@@ -120,3 +120,36 @@ test('LoginCallback redirects to root after success', (done) => {
     done();
   });
 });
+
+test('LoginCallback redirects to next URL after success', (done) => {
+  const token = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VybmFtZSI6ImFkbWluIiwiZXhwIjoxNTQwMzQzMjIxLCJlbWFpbCI6ImFkbWluQGV4YW1wbGUuY29tIiwib3JpZ19pYXQiOjE1NDAzMzk2MjF9.tumcSSAbKeWXc2QDd7KFR9IGh3PCsyHnCe6JLSszWpc';
+  mock.reset();
+  mock.onPost('/jwt/auth/social/google/login/').reply(200, {
+    access_token: token,
+    next_url: '/test/url',
+  });
+  const cookiesValues = { };
+  const cookies = new Cookies(cookiesValues);
+  const cookiesWrapper = shallowWithIntl(
+    <LoginCallback location={location} match={match} store={store} />, {
+      context: { cookies },
+    },
+  );
+
+  const wrapper = cookiesWrapper.dive().dive().dive().dive();
+
+  wrapper.instance().componentDidMount().then(() => {
+    wrapper.update();
+
+    const redirect = wrapper.find(Redirect);
+    expect(redirect.exists()).toBe(true);
+    expect(redirect.prop('to')).toBe('/test/url');
+    expect(wrapper.find(CircularProgress).exists()).toBe(false);
+    expect(cookies.get('auth_jwt')).toBe(token);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      updateUser({ ...jwtDecode(token), isSocial: true }),
+    );
+    expect(store.dispatch).toHaveBeenCalledWith(updateValidAuth(true));
+    done();
+  });
+});


### PR DESCRIPTION
Sends the `next` parameter to the backend when initiating social login. Upon success, reads the parameter back from the backend and redirects the user to that location
Depends on: https://github.com/rovercode/rovercode-web/pull/329