### PR TITLE
Suppress connection help on purchase page

### DIFF
--- a/src/components/ConnectionHelp.js
+++ b/src/components/ConnectionHelp.js
@@ -46,8 +46,10 @@ class ConnectionHelp extends Component {
   constructor(props) {
     super(props);
 
+    const userShowGuide = props.user.showGuide === undefined ? false : props.user.showGuide;
+
     this.state = {
-      open: props.user.showGuide === undefined ? false : props.user.showGuide,
+      open: userShowGuide && !props.suppressGuide,
       done: false,
     };
   }
@@ -339,6 +341,7 @@ ConnectionHelp.defaultProps = {
     user_id: undefined,
     showGuide: true,
   },
+  suppressGuide: false,
 };
 
 ConnectionHelp.propTypes = {
@@ -350,6 +353,7 @@ ConnectionHelp.propTypes = {
     name: PropTypes.string.isRequired,
   }),
   editUserShowGuide: PropTypes.func.isRequired,
+  suppressGuide: PropTypes.bool,
 };
 
 export default hot(module)(withCookies(

--- a/src/components/TopNav.js
+++ b/src/components/TopNav.js
@@ -92,7 +92,7 @@ class TopNav extends Component {
                     justifyContent="left"
                   >
                     <RoverConnection />
-                    <ConnectionHelp />
+                    <ConnectionHelp suppressGuide={window.location.pathname === '/purchase'} />
                   </Box>
                 </Grid>
                 <Grid item xs={2} xl={2}>

--- a/src/components/__tests__/__snapshots__/ConnectionHelp.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ConnectionHelp.test.js.snap
@@ -51,6 +51,7 @@ exports[`The ConnectionHelp component renders on the page with no errors 1`] = `
           }
           editUserShowGuide={[Function]}
           rover={null}
+          suppressGuide={false}
           user={
             Object {
               "showGuide": true,

--- a/src/components/__tests__/__snapshots__/TopNav.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TopNav.test.js.snap
@@ -24,7 +24,9 @@ exports[`The TopNav component should render on the page with no errors 1`] = `
               justifyContent="left"
             >
               <Connect(RoverConnection) />
-              <withCookies(Connect(ConnectionHelp)) />
+              <withCookies(Connect(ConnectionHelp))
+                suppressGuide={false}
+              />
             </Styled(MuiBox)>
           </WithStyles(ForwardRef(Grid))>
           <WithStyles(ForwardRef(Grid))


### PR DESCRIPTION
If we link someone straight to the /purchase page, I don't think we want the connection help dialog popping up to confuse them.