### PR TITLE
Refresh blog questions on remix and save

### DIFF
--- a/src/reducers/__tests__/code.test.js
+++ b/src/reducers/__tests__/code.test.js
@@ -258,6 +258,13 @@ describe('The code reducer', () => {
     const id = 1;
     const xmlCode = '<xml></xml>';
     const lessonId = 2;
+    const questions = [{
+      id: 1,
+      question: 'Question1',
+      answer: null,
+      sequence_number: 2,
+      required: true,
+    }];
 
     expect(
       reducer({ id: 1 }, {
@@ -267,6 +274,7 @@ describe('The code reducer', () => {
           id,
           content: xmlCode,
           lesson: lessonId,
+          blog_questions: questions,
         },
       }),
     ).toEqual({
@@ -275,6 +283,7 @@ describe('The code reducer', () => {
       id,
       xmlCode,
       lessonId,
+      blog_questions: questions,
     });
   });
 
@@ -496,6 +505,13 @@ describe('The code reducer', () => {
     const id = 1;
     const xmlCode = '<xml></xml>';
     const lessonId = 2;
+    const questions = [{
+      id: 1,
+      question: 'Question1',
+      answer: null,
+      sequence_number: 2,
+      required: true,
+    }];
 
     expect(
       reducer({}, {
@@ -505,6 +521,7 @@ describe('The code reducer', () => {
           id,
           content: xmlCode,
           lesson: lessonId,
+          blog_questions: questions,
         },
       }),
     ).toEqual({
@@ -513,6 +530,7 @@ describe('The code reducer', () => {
       id,
       xmlCode,
       lessonId,
+      blog_questions: questions,
     });
   });
 

--- a/src/reducers/code.js
+++ b/src/reducers/code.js
@@ -156,6 +156,7 @@ export default function code(
           id: action.payload.id,
           name: action.payload.name,
           lessonId: action.payload.lesson,
+          blog_questions: action.payload.blog_questions,
         } : {
           ...state,
           isSaving: false,
@@ -240,6 +241,7 @@ export default function code(
         id: action.payload.id,
         name: action.payload.name,
         lessonId: action.payload.lesson,
+        blog_questions: action.payload.blog_questions,
       };
     case REMIX_PROGRAM_REJECTED:
       return {


### PR DESCRIPTION
We had a bug in which the blog question ids were not getting updated after a remix. This led to the answers gettings saved to the wrong bd.

This refreshes the blog questions in the state after a remix and after a save. I think it makes sense for both places; either one alone would have fixed the bug.