### PR TITLE
Adding missing distance sensor to cache update

### DIFF
--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -292,10 +292,7 @@ class Workspace extends Component {
     const { code: currentCode, rover: currentRover } = prevProps;
     const { code: nextCode, sensor, rover: nextRover } = this.props;
 
-    this.updateSensorStateCache(sensor.left, sensor.right,
-      sensor.leftLightSensorReading, sensor.rightLightSensorReading,
-      sensor.leftLineSensorReading, sensor.rightLineSensorReading,
-      sensor.distanceSensorReading);
+    this.updateSensorStateCache(sensor);
 
     if (currentCode && currentCode.isReadOnly && nextCode && !nextCode.isReadOnly) {
       this.createWorkspace();
@@ -337,15 +334,16 @@ class Workspace extends Component {
     }
   }
 
-  updateSensorStateCache = (
-    leftState,
-    rightState,
-    leftLightSensorReading,
-    rightLightSensorReading,
-    leftLineSensorReading,
-    rightLineSensorReading,
-    distanceSensorReading,
-  ) => {
+  updateSensorStateCache = (sensor) => {
+    const {
+      left: leftState,
+      right: rightState,
+      leftLightSensorReading,
+      rightLightSensorReading,
+      leftLineSensorReading,
+      rightLineSensorReading,
+      distanceSensorReading,
+    } = sensor;
     this.sensorStateCache.A_BUTTON = leftState === COVERED;
     this.sensorStateCache.B_BUTTON = rightState === COVERED;
     this.sensorStateCache.LEFT_LIGHT = leftLightSensorReading;

--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -294,7 +294,8 @@ class Workspace extends Component {
 
     this.updateSensorStateCache(sensor.left, sensor.right,
       sensor.leftLightSensorReading, sensor.rightLightSensorReading,
-      sensor.leftLineSensorReading, sensor.rightLineSensorReading);
+      sensor.leftLineSensorReading, sensor.rightLineSensorReading,
+      sensor.distanceSensorReading);
 
     if (currentCode && currentCode.isReadOnly && nextCode && !nextCode.isReadOnly) {
       this.createWorkspace();

--- a/src/components/__tests__/Workspace.test.js
+++ b/src/components/__tests__/Workspace.test.js
@@ -834,31 +834,36 @@ describe('The Workspace component', () => {
 
     expect(workspace.instance().sensorStateCache.A_BUTTON).toBe(false);
     expect(workspace.instance().sensorStateCache.B_BUTTON).toBe(false);
+    expect(workspace.instance().sensorStateCache.LEFT_LIGHT).toBe(-1);
+    expect(workspace.instance().sensorStateCache.RIGHT_LIGHT).toBe(-1);
+    expect(workspace.instance().sensorStateCache.LEFT_LINE).toBe(-1);
+    expect(workspace.instance().sensorStateCache.RIGHT_LINE).toBe(-1);
+    expect(workspace.instance().sensorStateCache.DISTANCE).toBe(-1);
 
     workspace.setProps({
       sensor: {
         left: COVERED,
         right: NOT_COVERED,
-        leftLightSensorReading: -1,
-        rightLightSensorReading: -1,
-        leftLineSensorReading: -1,
-        rightLineSensorReading: -1,
-        distanceSensorReading: -1,
+        leftLightSensorReading: 1,
+        rightLightSensorReading: 2,
+        leftLineSensorReading: 3,
+        rightLineSensorReading: 4,
+        distanceSensorReading: 5,
       },
     });
 
     expect(workspace.instance().sensorStateCache.A_BUTTON).toBe(true);
     expect(workspace.instance().sensorStateCache.B_BUTTON).toBe(false);
+    expect(workspace.instance().sensorStateCache.LEFT_LIGHT).toBe(1);
+    expect(workspace.instance().sensorStateCache.RIGHT_LIGHT).toBe(2);
+    expect(workspace.instance().sensorStateCache.LEFT_LINE).toBe(3);
+    expect(workspace.instance().sensorStateCache.RIGHT_LINE).toBe(4);
+    expect(workspace.instance().sensorStateCache.DISTANCE).toBe(5);
 
     workspace.setProps({
       sensor: {
         left: COVERED,
         right: COVERED,
-        leftLightSensorReading: -1,
-        rightLightSensorReading: -1,
-        leftLineSensorReading: -1,
-        rightLineSensorReading: -1,
-        distanceSensorReading: -1,
       },
     });
 
@@ -869,11 +874,6 @@ describe('The Workspace component', () => {
       sensor: {
         left: NOT_COVERED,
         right: COVERED,
-        leftLightSensorReading: -1,
-        rightLightSensorReading: -1,
-        leftLineSensorReading: -1,
-        rightLineSensorReading: -1,
-        distanceSensorReading: -1,
       },
     });
 


### PR DESCRIPTION
I started to record a lesson using the distance sensor and realize the block was always returning `undefined`. This fixes the error and improves the test that should have caught it.