### PR TITLE
Add comment block

### DIFF
--- a/src/blocks/Comment.js
+++ b/src/blocks/Comment.js
@@ -1,0 +1,26 @@
+import Blockly from 'blockly';
+import { display } from './Color';
+
+const Comment = {
+  definition: {
+    init() {
+      this.appendDummyInput()
+        .appendField('/* ')
+        .appendField(new Blockly.FieldTextInput('Write a comment here!'), 'COMMENT')
+        .appendField('*/');
+      this.setInputsInline(true);
+      this.setPreviousStatement(true, null);
+      this.setNextStatement(true, null);
+      this.setColour(display.HUE);
+      this.setTooltip('Write a comment to explain your code. It will not affect how your program runs.');
+      this.setHelpUrl('https://docs.rovercode.com/blocks/comment');
+    },
+  },
+  generator: (block) => {
+    const valueComment = block.getFieldValue('COMMENT');
+    const code = `/* ${valueComment} */\n`; // Injection risk, but more power to them
+    return code;
+  },
+};
+
+export default Comment;

--- a/src/blocks/Comment.js
+++ b/src/blocks/Comment.js
@@ -18,8 +18,7 @@ const Comment = {
   },
   generator: (block) => {
     const valueComment = block.getFieldValue('COMMENT');
-    const code = `/* ${valueComment} */\n`; // Injection risk, but more power to them
-    return code;
+    return `/* ${valueComment} */\n`; // Injection risk, but more power to them
   },
 };
 

--- a/src/blocks/__tests__/Comment.test.js
+++ b/src/blocks/__tests__/Comment.test.js
@@ -1,0 +1,43 @@
+import Comment from '../Comment';
+import { display } from '../Color';
+
+class TestBlock {
+  appendField = jest.fn(() => new TestBlock())
+
+  appendDummyInput = jest.fn(() => new TestBlock())
+
+  setColour = jest.fn()
+
+  setInputsInline = jest.fn()
+
+  setNextStatement = jest.fn()
+
+  setPreviousStatement = jest.fn()
+
+  setTooltip = jest.fn()
+
+  setHelpUrl = jest.fn()
+}
+
+describe('Comment block', () => {
+  test('initializes successfully', () => {
+    const testBlock = new TestBlock();
+    const { init } = Comment.definition;
+    const boundInit = init.bind(testBlock);
+    boundInit();
+
+    expect(testBlock.setColour).toHaveBeenCalledWith(display.HUE);
+    expect(testBlock.setInputsInline).toHaveBeenCalledWith(true);
+    expect(testBlock.setNextStatement).toHaveBeenCalledWith(true, null);
+    expect(testBlock.setPreviousStatement).toHaveBeenCalledWith(true, null);
+  });
+
+  test('generates code correctly', () => {
+    const block = {
+      getFieldValue: jest.fn(() => 'test message'),
+    };
+    const result = Comment.generator(block);
+
+    expect(result).toBe('/* test message */\n');
+  });
+});

--- a/src/blocks/index.js
+++ b/src/blocks/index.js
@@ -1,6 +1,7 @@
 import ButtonPress from './ButtonPress';
 import Continue from './Continue';
 import DisplayMessage from './DisplayMessage';
+import Comment from './Comment';
 import Headlight from './Headlight';
 import LightSensorValue from './LightSensorValue';
 import LineSensorValue from './LineSensorValue';
@@ -13,6 +14,7 @@ export {
   ButtonPress,
   Continue,
   DisplayMessage,
+  Comment,
   Headlight,
   LightSensorValue,
   LineSensorValue,

--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -29,6 +29,7 @@ import {
   ButtonPress,
   Continue,
   DisplayMessage,
+  Comment,
   Headlight,
   LightSensorValue,
   LineSensorValue,
@@ -67,6 +68,8 @@ Blockly.Blocks.continue = Continue.definition;
 Blockly.JavaScript.continue = Continue.generator;
 Blockly.Blocks.display_message = DisplayMessage.definition;
 Blockly.JavaScript.display_message = DisplayMessage.generator;
+Blockly.Blocks.comment = Comment.definition;
+Blockly.JavaScript.comment = Comment.generator;
 Blockly.Blocks.headlight = Headlight.definition;
 Blockly.JavaScript.headlight = Headlight.generator;
 Blockly.Blocks.light_sensor_value = LightSensorValue.definition;
@@ -107,6 +110,8 @@ const toolbox = `
               <field name="TEXT">Hi!</field>
             </block>
           </value>
+        </block>
+        <block type="comment">
         </block>
         <block type="headlight"></block>
         <block type="colour_rgb">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/976857/126885922-a65708c9-f308-46fd-8ccf-2a4ec1108b75.png)

![image](https://user-images.githubusercontent.com/976857/126885950-373f8d5b-1427-44c2-9608-38d85222584d.png)


Adds a comment block.

Blockly already has the right-click comment feature, but those aren't as good because they are not visiable until you click on them. This new block is visible as you read the code.